### PR TITLE
DCOS-43055: Wrap text resources in app (src/js/pages)

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1,10 +1,73 @@
 {
+  "CLI Only Package": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackageDetailTab.js",
+        269
+      ]
+    ]
+  },
+  "Catalog": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackageDetailTab.js",
+        35
+      ]
+    ]
+  },
+  "Open Service": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackageDetailTab.js",
+        416
+      ]
+    ]
+  },
+  "Review & Run": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackageDetailTab.js",
+        322
+      ]
+    ]
+  },
+  "Success!": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackageDetailTab.js",
+        397
+      ]
+    ]
+  },
+  "This package can only be installed using the CLI. See the <0>documentation</0>.": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackageDetailTab.js",
+        270
+      ]
+    ]
+  },
   "Total Tasks": {
     "translation": "",
     "origin": [
       [
         "src/js/components/charts/TasksChart.js",
-        120
+        119
+      ]
+    ]
+  },
+  "{0} is being installed.": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackageDetailTab.js",
+        400
       ]
     ]
   }

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -66,6 +66,24 @@
       ]
     ]
   },
+  "IP Subnet": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/network/virtual-network-detail/VirtualNetworkDetailsTab.js",
+        28
+      ]
+    ]
+  },
+  "Name": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/network/virtual-network-detail/VirtualNetworkDetailsTab.js",
+        22
+      ]
+    ]
+  },
   "Networks": {
     "translation": "",
     "origin": [

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -132,6 +132,10 @@
     "translation": "",
     "origin": [
       [
+        "src/js/pages/NetworkPage.js",
+        22
+      ],
+      [
         "src/js/pages/network/VirtualNetworksTab.js",
         27
       ],

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -75,6 +75,15 @@
       ]
     ]
   },
+  "Cryptographic Cluster ID": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/system/OverviewDetailTab.js",
+        172
+      ]
+    ]
+  },
   "IP Subnet": {
     "translation": "",
     "origin": [
@@ -143,6 +152,24 @@
       [
         "src/js/pages/system/units-health-node-detail/NodeInfoPanel.js",
         36
+      ]
+    ]
+  },
+  "Overview": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/system/OverviewDetailTab.js",
+        43
+      ]
+    ]
+  },
+  "Public IP": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/system/OverviewDetailTab.js",
+        178
       ]
     ]
   },
@@ -224,6 +251,15 @@
       [
         "src/js/pages/catalog/PackagesTab.js",
         50
+      ]
+    ]
+  },
+  "{0} Version": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/system/OverviewDetailTab.js",
+        166
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -250,6 +250,10 @@
       [
         "src/js/pages/system/OrganizationTab.js",
         54
+      ],
+      [
+        "src/js/pages/system/UsersPage.js",
+        26
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -66,12 +66,30 @@
       ]
     ]
   },
+  "Networks": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/network/VirtualNetworksTab.js",
+        27
+      ]
+    ]
+  },
   "No package repositories": {
     "translation": "",
     "origin": [
       [
         "src/js/pages/catalog/PackagesTab.js",
         48
+      ]
+    ]
+  },
+  "No virtual networks detected": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/network/VirtualNetworksTab.js",
+        91
       ]
     ]
   },
@@ -99,6 +117,15 @@
       [
         "src/js/pages/catalog/PackageDetailTab.js",
         397
+      ]
+    ]
+  },
+  "There a currently no other virtual networks found on your datacenter. Virtual networks are configured during setup of your DC/OS cluster.": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/network/VirtualNetworksTab.js",
+        93
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -92,6 +92,15 @@
       ]
     ]
   },
+  "Dashboard": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/DashboardPage.js",
+        47
+      ]
+    ]
+  },
   "Download Snapshot": {
     "translation": "",
     "origin": [

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -128,6 +128,15 @@
       ]
     ]
   },
+  "Output": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/system/units-health-node-detail/NodeInfoPanel.js",
+        36
+      ]
+    ]
+  },
   "Review & Run": {
     "translation": "",
     "origin": [
@@ -143,6 +152,15 @@
       [
         "src/js/pages/catalog/PackageDetailTab.js",
         397
+      ]
+    ]
+  },
+  "Summary": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/system/units-health-node-detail/NodeInfoPanel.js",
+        25
       ]
     ]
   },
@@ -170,6 +188,15 @@
       [
         "src/js/components/charts/TasksChart.js",
         119
+      ]
+    ]
+  },
+  "View Documentation": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/system/units-health-node-detail/NodeInfoPanel.js",
+        30
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -200,6 +200,15 @@
       ]
     ]
   },
+  "Users": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/system/OrganizationTab.js",
+        54
+      ]
+    ]
+  },
   "View Documentation": {
     "translation": "",
     "origin": [

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -76,6 +76,10 @@
       [
         "src/js/pages/system/UnitsHealthDetail.js",
         26
+      ],
+      [
+        "src/js/pages/system/UnitsHealthTab.js",
+        30
       ]
     ]
   },
@@ -85,6 +89,15 @@
       [
         "src/js/pages/system/OverviewDetailTab.js",
         172
+      ]
+    ]
+  },
+  "Download Snapshot": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/system/UnitsHealthTab.js",
+        214
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -172,7 +172,7 @@
     "origin": [
       [
         "src/js/pages/catalog/PackageDetailTab.js",
-        416
+        414
       ]
     ]
   },
@@ -226,7 +226,7 @@
     "origin": [
       [
         "src/js/pages/catalog/PackageDetailTab.js",
-        397
+        398
       ]
     ]
   },
@@ -312,15 +312,6 @@
       [
         "src/js/pages/system/OverviewDetailTab.js",
         166
-      ]
-    ]
-  },
-  "{0} is being installed.": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/pages/catalog/PackageDetailTab.js",
-        400
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -72,6 +72,10 @@
       [
         "src/js/pages/system/ComponentsUnitsHealthNodeDetailPage.js",
         23
+      ],
+      [
+        "src/js/pages/system/UnitsHealthDetail.js",
+        26
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -66,6 +66,15 @@
       ]
     ]
   },
+  "Components": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/system/ComponentsUnitsHealthNodeDetailPage.js",
+        23
+      ]
+    ]
+  },
   "IP Subnet": {
     "translation": "",
     "origin": [

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1,4 +1,22 @@
 {
+  "Add Package Repository": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackagesTab.js",
+        63
+      ]
+    ]
+  },
+  "An Error Occurred": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackagesTab.js",
+        147
+      ]
+    ]
+  },
   "CLI Only Package": {
     "translation": "",
     "origin": [
@@ -14,6 +32,46 @@
       [
         "src/js/pages/catalog/PackageDetailTab.js",
         35
+      ],
+      [
+        "src/js/pages/catalog/PackagesTab.js",
+        35
+      ]
+    ]
+  },
+  "Certified": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackagesTab.js",
+        200
+      ]
+    ]
+  },
+  "Certified packages are verified by Mesosphere for interoperability with DC/OS.": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackagesTab.js",
+        203
+      ]
+    ]
+  },
+  "Community packages are unverified and unreviewed content from the community.": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackagesTab.js",
+        219
+      ]
+    ]
+  },
+  "No package repositories": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackagesTab.js",
+        48
       ]
     ]
   },
@@ -62,12 +120,30 @@
       ]
     ]
   },
+  "You need at least one package repository with some packages to be able to install packages. For more <0>information on repositories</0>.": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackagesTab.js",
+        50
+      ]
+    ]
+  },
   "{0} is being installed.": {
     "translation": "",
     "origin": [
       [
         "src/js/pages/catalog/PackageDetailTab.js",
         400
+      ]
+    ]
+  },
+  "{noResults} (<0>view all</0>)": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackagesTab.js",
+        238
       ]
     ]
   }

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -72,6 +72,10 @@
       [
         "src/js/pages/network/VirtualNetworksTab.js",
         27
+      ],
+      [
+        "src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.js",
+        23
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -94,6 +94,10 @@
       [
         "src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.js",
         23
+      ],
+      [
+        "src/js/pages/network/virtual-network-detail/VirtualNetworkTaskPage.js",
+        25
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -194,6 +194,15 @@
       ]
     ]
   },
+  "Page not found": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/NotFoundPage.js",
+        28
+      ]
+    ]
+  },
   "Public IP": {
     "translation": "",
     "origin": [
@@ -227,6 +236,15 @@
       [
         "src/js/pages/system/units-health-node-detail/NodeInfoPanel.js",
         25
+      ]
+    ]
+  },
+  "The page you requested cannot be found. Check the address you provided, or head back to the <0>Dashboard</0>.": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/NotFoundPage.js",
+        30
       ]
     ]
   },

--- a/src/js/pages/DashboardPage.js
+++ b/src/js/pages/DashboardPage.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import { routerShape, Link } from "react-router";
 import React from "react";
 import { StoreMixin } from "mesosphere-shared-reactjs";
@@ -42,7 +43,9 @@ const DashboardBreadcrumbs = () => {
   const crumbs = [
     <Breadcrumb key={0} title="Dashboard">
       <BreadcrumbTextContent>
-        <Link to="/dashboard">Dashboard</Link>
+        <Link to="/dashboard">
+          <Trans render="span">Dashboard</Trans>
+        </Link>
       </BreadcrumbTextContent>
     </Breadcrumb>
   ];

--- a/src/js/pages/NetworkPage.js
+++ b/src/js/pages/NetworkPage.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import { routerShape, Link } from "react-router";
 import mixin from "reactjs-mixin";
 /* eslint-disable no-unused-vars */
@@ -17,7 +18,9 @@ const NetworkingBreadcrumbs = () => {
   const crumbs = [
     <Breadcrumb key={0} title="Networks">
       <BreadcrumbTextContent>
-        <Link to="/networking">Networks</Link>
+        <Link to="/networking">
+          <Trans render="span">Networks</Trans>
+        </Link>
       </BreadcrumbTextContent>
     </Breadcrumb>
   ];

--- a/src/js/pages/NotFoundPage.js
+++ b/src/js/pages/NotFoundPage.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import { Link } from "react-router";
 import React from "react";
 
@@ -23,12 +24,14 @@ var NotFoundPage = React.createClass({
     return (
       <Page title="Page Not Found">
         <AlertPanel>
-          <AlertPanelHeader>Page not found</AlertPanelHeader>
-          <p>
+          <AlertPanelHeader>
+            <Trans render="span">Page not found</Trans>
+          </AlertPanelHeader>
+          <Trans render="p">
             The page you requested cannot be found. Check the address you
             provided, or head back to the <Link to="/dashboard">Dashboard</Link>
             .
-          </p>
+          </Trans>
         </AlertPanel>
       </Page>
     );

--- a/src/js/pages/catalog/PackageDetailTab.js
+++ b/src/js/pages/catalog/PackageDetailTab.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import qs from "query-string";
 import mixin from "reactjs-mixin";
 import { Link, routerShape } from "react-router";
@@ -30,7 +31,9 @@ const PackageDetailBreadcrumbs = ({ cosmosPackage, isLoading }) => {
   const crumbs = [
     <Breadcrumb key={0} title="Catalog">
       <BreadcrumbTextContent>
-        <Link to="/catalog/packages">Catalog</Link>
+        <Link to="/catalog/packages">
+          <Trans render="span">Catalog</Trans>
+        </Link>
       </BreadcrumbTextContent>
     </Breadcrumb>,
     <Breadcrumb key={1} title={!isLoading && name}>
@@ -263,8 +266,8 @@ class PackageDetailTab extends mixin(StoreMixin) {
     if (cosmosPackage.isCLIOnly()) {
       return (
         <div>
-          <p>CLI Only Package</p>
-          <p>
+          <Trans render="p">CLI Only Package</Trans>
+          <Trans render="p">
             {"This package can only be installed using the CLI. See the "}
             <a
               href={MetadataStore.buildDocsURI(
@@ -274,7 +277,7 @@ class PackageDetailTab extends mixin(StoreMixin) {
             >
               documentation
             </a>.
-          </p>
+          </Trans>
         </div>
       );
     }
@@ -316,7 +319,7 @@ class PackageDetailTab extends mixin(StoreMixin) {
             className="button button-primary"
             onClick={this.handleReviewAndRunClick}
           >
-            Review & Run
+            <Trans render="span">Review & Run</Trans>
           </button>
         </Tooltip>
       </div>
@@ -391,10 +394,15 @@ class PackageDetailTab extends mixin(StoreMixin) {
               <span className="text-success">
                 <Icon id="circle-check" size="large" color="green" />
               </span>
-              <h2 className="short-top short-bottom">Success!</h2>
-              <div className="install-package-modal-package-notes text-overflow-break-word">
+              <Trans render="h2" className="short-top short-bottom">
+                Success!
+              </Trans>
+              <Trans
+                render="div"
+                className="install-package-modal-package-notes text-overflow-break-word"
+              >
                 {`${StringUtil.capitalize(name)} is being installed.`}
-              </div>
+              </Trans>
             </div>
           </div>
           <div className="modal-footer">
@@ -405,7 +413,7 @@ class PackageDetailTab extends mixin(StoreMixin) {
                   location.query.appId
                 )}`}
               >
-                Open Service
+                <Trans render="span">Open Service</Trans>
               </a>
             </div>
           </div>

--- a/src/js/pages/catalog/PackageDetailTab.js
+++ b/src/js/pages/catalog/PackageDetailTab.js
@@ -381,6 +381,7 @@ class PackageDetailTab extends mixin(StoreMixin) {
 
   getInstalledSuccessModal(name) {
     const { location } = this.props;
+    const installMessage = `${StringUtil.capitalize(name)} is being installed.`;
 
     return (
       <Modal
@@ -397,12 +398,9 @@ class PackageDetailTab extends mixin(StoreMixin) {
               <Trans render="h2" className="short-top short-bottom">
                 Success!
               </Trans>
-              <Trans
-                render="div"
-                className="install-package-modal-package-notes text-overflow-break-word"
-              >
-                {`${StringUtil.capitalize(name)} is being installed.`}
-              </Trans>
+              <div className="install-package-modal-package-notes text-overflow-break-word">
+                {installMessage}
+              </div>
             </div>
           </div>
           <div className="modal-footer">

--- a/src/js/pages/catalog/PackagesTab.js
+++ b/src/js/pages/catalog/PackagesTab.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import classNames from "classnames";
 import mixin from "reactjs-mixin";
 import { Hooks } from "PluginSDK";
@@ -30,7 +31,9 @@ const PackagesBreadcrumbs = () => {
   const crumbs = [
     <Breadcrumb key={0} title="Catalog">
       <BreadcrumbTextContent>
-        <Link to="/catalog/packages">Catalog</Link>
+        <Link to="/catalog/packages">
+          <Trans render="span">Catalog</Trans>
+        </Link>
       </BreadcrumbTextContent>
     </Breadcrumb>
   ];
@@ -41,8 +44,10 @@ const PackagesBreadcrumbs = () => {
 const PackagesEmptyState = () => {
   return (
     <AlertPanel>
-      <AlertPanelHeader>No package repositories</AlertPanelHeader>
-      <p className="tall">
+      <AlertPanelHeader>
+        <Trans render="span">No package repositories</Trans>
+      </AlertPanelHeader>
+      <Trans render="p" className="tall">
         You need at least one package repository with some packages to be able
         to install packages. For more{" "}
         <a
@@ -52,10 +57,10 @@ const PackagesEmptyState = () => {
           information on repositories
         </a>
         .
-      </p>
+      </Trans>
       <div className="button-collection flush-bottom">
         <Link to="/settings/repositories" className="button button-primary">
-          Add Package Repository
+          <Trans render="span">Add Package Repository</Trans>
         </Link>
       </div>
     </AlertPanel>
@@ -138,7 +143,9 @@ class PackagesTab extends mixin(StoreMixin) {
 
     return (
       <AlertPanel>
-        <AlertPanelHeader>An Error Occurred</AlertPanelHeader>
+        <AlertPanelHeader>
+          <Trans render="span">An Error Occurred</Trans>
+        </AlertPanelHeader>
         <CosmosErrorMessage error={errorMessage} flushBottom={true} />
       </AlertPanel>
     );
@@ -190,11 +197,13 @@ class PackagesTab extends mixin(StoreMixin) {
 
     return (
       <div className="pod flush-top flush-horizontal clearfix">
-        <h1 className="short flush-top">Certified</h1>
-        <p className="tall flush-top">
+        <Trans render="h1" className="short flush-top">
+          Certified
+        </Trans>
+        <Trans render="p" className="tall flush-top">
           Certified packages are verified by Mesosphere for interoperability
           with DC/OS.
-        </p>
+        </Trans>
         <div className="panel-grid row">{this.getPackageGrid(packages)}</div>
       </div>
     );
@@ -207,10 +216,10 @@ class PackagesTab extends mixin(StoreMixin) {
     }
 
     let subtitle = (
-      <p className="tall flush-top">
+      <Trans render="p" className="tall flush-top">
         Community packages are unverified and unreviewed content from the
         community.
-      </p>
+      </Trans>
     );
     let title = "Community";
     const titleClasses = classNames("flush-top", {
@@ -226,12 +235,12 @@ class PackagesTab extends mixin(StoreMixin) {
         }" `;
 
         return (
-          <div className="clearfix">
+          <Trans render="div" className="clearfix">
             {noResults}
             (<a className="clickable" onClick={this.clearInput}>
               view all
             </a>)
-          </div>
+          </Trans>
         );
       }
 

--- a/src/js/pages/catalog/__tests__/__snapshots__/PackageDetailTab-test.js.snap
+++ b/src/js/pages/catalog/__tests__/__snapshots__/PackageDetailTab-test.js.snap
@@ -654,16 +654,11 @@ Please follow the instructions at http://docs.mesosphere.com/services/marathon/#
             id="Success!"
             render="h2"
           />
-          <WithI18n
+          <div
             className="install-package-modal-package-notes text-overflow-break-word"
-            id="{0} is being installed."
-            render="div"
-            values={
-              Object {
-                "0": "Marathon",
-              }
-            }
-          />
+          >
+            Marathon is being installed.
+          </div>
         </div>
       </div>
       <div

--- a/src/js/pages/catalog/__tests__/__snapshots__/PackageDetailTab-test.js.snap
+++ b/src/js/pages/catalog/__tests__/__snapshots__/PackageDetailTab-test.js.snap
@@ -608,7 +608,10 @@ Please follow the instructions at http://docs.mesosphere.com/services/marathon/#
                 disabled={true}
                 onClick={[Function]}
               >
-                Review & Run
+                <WithI18n
+                  id="Review & Run"
+                  render="span"
+                />
               </button>
             </Tooltip>
           </div>
@@ -646,16 +649,21 @@ Please follow the instructions at http://docs.mesosphere.com/services/marathon/#
               size="large"
             />
           </span>
-          <h2
+          <WithI18n
             className="short-top short-bottom"
-          >
-            Success!
-          </h2>
-          <div
+            id="Success!"
+            render="h2"
+          />
+          <WithI18n
             className="install-package-modal-package-notes text-overflow-break-word"
-          >
-            Marathon is being installed.
-          </div>
+            id="{0} is being installed."
+            render="div"
+            values={
+              Object {
+                "0": "Marathon",
+              }
+            }
+          />
         </div>
       </div>
       <div
@@ -668,7 +676,10 @@ Please follow the instructions at http://docs.mesosphere.com/services/marathon/#
             className="button button-success button-block"
             href="#/services/detail/undefined"
           >
-            Open Service
+            <WithI18n
+              id="Open Service"
+              render="span"
+            />
           </a>
         </div>
       </div>

--- a/src/js/pages/catalog/__tests__/__snapshots__/PackagesTab-test.js.snap
+++ b/src/js/pages/catalog/__tests__/__snapshots__/PackagesTab-test.js.snap
@@ -13,13 +13,16 @@ exports[`PackagesTab with empty state displays AlertPanel with action to Package
       <h2
         className="flush-top"
       >
-        No package repositories
+        <span
+          className={undefined}
+        >
+          No package repositories
+        </span>
       </h2>
       <p
         className="tall"
       >
-        You need at least one package repository with some packages to be able to install packages. For more
-         
+        You need at least one package repository with some packages to be able to install packages. For more 
         <a
           href="https://docs.mesosphere.com/latest/administering-clusters/repo"
           target="_blank"
@@ -36,7 +39,11 @@ exports[`PackagesTab with empty state displays AlertPanel with action to Package
           onClick={[Function]}
           style={Object {}}
         >
-          Add Package Repository
+          <span
+            className={undefined}
+          >
+            Add Package Repository
+          </span>
         </a>
       </div>
     </div>

--- a/src/js/pages/network/VirtualNetworksTab.js
+++ b/src/js/pages/network/VirtualNetworksTab.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import mixin from "reactjs-mixin";
 import { Link } from "react-router";
 /* eslint-disable no-unused-vars */
@@ -22,7 +23,9 @@ const NetworksBreadcrumbs = () => {
   const crumbs = [
     <Breadcrumb key={0} title="Networks">
       <BreadcrumbTextContent>
-        <Link to="/networking/networks">Networks</Link>
+        <Link to="/networking/networks">
+          <Trans render="span">Networks</Trans>
+        </Link>
       </BreadcrumbTextContent>
     </Breadcrumb>
   ];
@@ -84,11 +87,13 @@ class VirtualNetworksTabContent extends mixin(StoreMixin) {
   getEmptyScreen() {
     return (
       <AlertPanel>
-        <AlertPanelHeader>No virtual networks detected</AlertPanelHeader>
-        <p className="flush">
+        <AlertPanelHeader>
+          <Trans render="span">No virtual networks detected</Trans>
+        </AlertPanelHeader>
+        <Trans render="p" className="flush">
           There a currently no other virtual networks found on your datacenter.
           Virtual networks are configured during setup of your DC/OS cluster.
-        </p>
+        </Trans>
       </AlertPanel>
     );
   }

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import mixin from "reactjs-mixin";
 import { Link, routerShape } from "react-router";
 /* eslint-disable no-unused-vars */
@@ -18,7 +19,9 @@ const NetworksDetailBreadcrumbs = ({ overlayID, overlay }) => {
   const crumbs = [
     <Breadcrumb key={0} title="Networks">
       <BreadcrumbTextContent>
-        <Link to="/networking/networks">Networks</Link>
+        <Link to="/networking/networks">
+          <Trans render="span">Networks</Trans>
+        </Link>
       </BreadcrumbTextContent>
     </Breadcrumb>
   ];

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkDetailsTab.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkDetailsTab.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import PropTypes from "prop-types";
 import React from "react";
 
@@ -17,11 +18,15 @@ class VirtualNetworkDetailsTab extends React.Component {
         <ConfigurationMap>
           <ConfigurationMapSection>
             <ConfigurationMapRow>
-              <ConfigurationMapLabel>Name</ConfigurationMapLabel>
+              <ConfigurationMapLabel>
+                <Trans render="span">Name</Trans>
+              </ConfigurationMapLabel>
               <ConfigurationMapValue>{overlay.getName()}</ConfigurationMapValue>
             </ConfigurationMapRow>
             <ConfigurationMapRow>
-              <ConfigurationMapLabel>IP Subnet</ConfigurationMapLabel>
+              <ConfigurationMapLabel>
+                <Trans render="span">IP Subnet</Trans>
+              </ConfigurationMapLabel>
               <ConfigurationMapValue>
                 {overlay.getSubnet()}
               </ConfigurationMapValue>

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskPage.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskPage.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import PropTypes from "prop-types";
 import React from "react";
 import { Link } from "react-router";
@@ -20,7 +21,9 @@ const NetworksDetailTaskBreadcrumbs = ({
   const crumbs = [
     <Breadcrumb key={0} title="Networks">
       <BreadcrumbTextContent>
-        <Link to="/networking/networks">Networks</Link>
+        <Link to="/networking/networks">
+          <Trans render="span">Networks</Trans>
+        </Link>
       </BreadcrumbTextContent>
     </Breadcrumb>
   ];

--- a/src/js/pages/system/ComponentsUnitsHealthNodeDetailPage.js
+++ b/src/js/pages/system/ComponentsUnitsHealthNodeDetailPage.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import mixin from "reactjs-mixin";
 import { Link } from "react-router";
 /* eslint-disable no-unused-vars */
@@ -18,7 +19,9 @@ const UnitHealthNodeDetailBreadcrumbs = ({ node, unit }) => {
   const crumbs = [
     <Breadcrumb key={0} title="Components">
       <BreadcrumbTextContent>
-        <Link to="/components">Components</Link>
+        <Link to="/components">
+          <Trans render="span">Components</Trans>
+        </Link>
       </BreadcrumbTextContent>
     </Breadcrumb>
   ];

--- a/src/js/pages/system/OrganizationTab.js
+++ b/src/js/pages/system/OrganizationTab.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import classNames from "classnames";
 import { Dropdown, Form, Table } from "reactjs-components";
 import { Hooks } from "PluginSDK";
@@ -49,7 +50,9 @@ const UsersBreadcrumbs = () => {
   const crumbs = [
     <Breadcrumb key={0} title="Users">
       <BreadcrumbTextContent>
-        <Link to="/organization/users">Users</Link>
+        <Link to="/organization/users">
+          <Trans render="span">Users</Trans>
+        </Link>
       </BreadcrumbTextContent>
     </Breadcrumb>
   ];

--- a/src/js/pages/system/OverviewDetailTab.js
+++ b/src/js/pages/system/OverviewDetailTab.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import mixin from "reactjs-mixin";
 import { Link } from "react-router";
 import { MountService } from "foundation-ui";
@@ -38,7 +39,9 @@ const SystemOverviewBreadcrumbs = () => {
   const crumbs = [
     <Breadcrumb key={0} title="Cluster">
       <BreadcrumbTextContent>
-        <Link to="/cluster/overview">Overview</Link>
+        <Link to="/cluster/overview">
+          <Trans render="span">Overview</Trans>
+        </Link>
       </BreadcrumbTextContent>
     </Breadcrumb>
   ];
@@ -160,18 +163,20 @@ class OverviewDetailTab extends mixin(StoreMixin) {
       <ConfigurationMapSection>
         <ConfigurationMapRow key="version">
           <ConfigurationMapLabel>
-            {Config.productName} Version
+            <Trans render="span">{Config.productName} Version</Trans>
           </ConfigurationMapLabel>
           <ConfigurationMapValue>{productVersion}</ConfigurationMapValue>
         </ConfigurationMapRow>
         <ConfigurationMapRow key="ccid">
           <ConfigurationMapLabel>
-            Cryptographic Cluster ID
+            <Trans render="span">Cryptographic Cluster ID</Trans>
           </ConfigurationMapLabel>
           <ConfigurationMapValue>{ccid}</ConfigurationMapValue>
         </ConfigurationMapRow>
         <ConfigurationMapRow key="publicIP">
-          <ConfigurationMapLabel>Public IP</ConfigurationMapLabel>
+          <ConfigurationMapLabel>
+            <Trans render="span">Public IP</Trans>
+          </ConfigurationMapLabel>
           <ConfigurationMapValue>{publicIP}</ConfigurationMapValue>
         </ConfigurationMapRow>
         <MountService.Mount

--- a/src/js/pages/system/UnitsHealthDetail.js
+++ b/src/js/pages/system/UnitsHealthDetail.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import mixin from "reactjs-mixin";
 import { Link } from "react-router";
 /* eslint-disable no-unused-vars */
@@ -21,7 +22,9 @@ const UnitHealthDetailBreadcrumbs = ({ unit }) => {
   const crumbs = [
     <Breadcrumb key={0} title="Components">
       <BreadcrumbTextContent>
-        <Link to="/components">Components</Link>
+        <Link to="/components">
+          <Trans render="span">Components</Trans>
+        </Link>
       </BreadcrumbTextContent>
     </Breadcrumb>
   ];

--- a/src/js/pages/system/UnitsHealthTab.js
+++ b/src/js/pages/system/UnitsHealthTab.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import classNames from "classnames";
 import { Link } from "react-router";
 import mixin from "reactjs-mixin";
@@ -25,7 +26,9 @@ const UnitHealthBreadcrumbs = () => {
   const crumbs = [
     <Breadcrumb key={0} title="Components">
       <BreadcrumbTextContent>
-        <Link to="/components">Components</Link>
+        <Link to="/components">
+          <Trans render="span">Components</Trans>
+        </Link>
       </BreadcrumbTextContent>
     </Breadcrumb>
   ];
@@ -208,7 +211,7 @@ class UnitsHealthTab extends mixin(StoreMixin) {
                 className="button button-primary"
                 target="_blank"
               >
-                Download Snapshot
+                <Trans render="span">Download Snapshot</Trans>
               </a>
             </FilterBar>
           </div>

--- a/src/js/pages/system/UsersPage.js
+++ b/src/js/pages/system/UsersPage.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import { Hooks } from "PluginSDK";
 import mixin from "reactjs-mixin";
 import { Link } from "react-router";
@@ -21,7 +22,9 @@ const UsersBreadcrumbs = () => {
   const crumbs = [
     <Breadcrumb key={0} title="Users">
       <BreadcrumbTextContent>
-        <Link to="/organization/users">Users</Link>
+        <Link to="/organization/users">
+          <Trans render="span">Users</Trans>
+        </Link>
       </BreadcrumbTextContent>
     </Breadcrumb>
   ];

--- a/src/js/pages/system/units-health-node-detail/NodeInfoPanel.js
+++ b/src/js/pages/system/units-health-node-detail/NodeInfoPanel.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import PureRender from "react-addons-pure-render-mixin";
 import PropTypes from "prop-types";
 import React from "react";
@@ -20,16 +21,20 @@ class NodeInfoPanel extends React.Component {
       <div className="container">
         <ConfigurationMap>
           <ConfigurationMapSection>
-            <ConfigurationMapHeading>Summary</ConfigurationMapHeading>
+            <ConfigurationMapHeading>
+              <Trans render="span">Summary</Trans>
+            </ConfigurationMapHeading>
             <p>{summary}</p>
             {docsURL && (
               <a href={docsURL} target="_blank">
-                View Documentation
+                <Trans render="span">View Documentation</Trans>
               </a>
             )}
           </ConfigurationMapSection>
           <ConfigurationMapSection>
-            <ConfigurationMapHeading>Output</ConfigurationMapHeading>
+            <ConfigurationMapHeading>
+              <Trans render="span">Output</Trans>
+            </ConfigurationMapHeading>
             <ConfigurationMapRow>
               <pre className="flex-item-grow-1 flush-bottom">{output}</pre>
             </ConfigurationMapRow>

--- a/tests/pages/catalog/packages/PackagesTab-cy.js
+++ b/tests/pages/catalog/packages/PackagesTab-cy.js
@@ -175,6 +175,7 @@ describe("Packages Tab", function() {
         .click();
       cy.get(".button.button-primary")
         .contains("Review & Run")
+        .parent()
         .should("be.disabled");
     });
   });


### PR DESCRIPTION
## Testing

These changes should result in no visible changes to the UI. There may be some additional `<span>` tags rendered from using the `<Trans>` macro. But we would also be able to remove that once we upgrade to React 16 as string's will become valid return results from a component.

## Trade-offs

There was at least one place where the current code could be simpler and allow easier translation (see comment), but I left the current code in place to not increase the scope of these changes.
