### PR TITLE
DCOS-43050: add POC for wrapping const text resources

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -26,6 +26,15 @@
       ]
     ]
   },
+  "Cancel": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/FrameworkConfiguration.js",
+        345
+      ]
+    ]
+  },
   "Catalog": {
     "translation": "",
     "origin": [
@@ -101,6 +110,15 @@
       ]
     ]
   },
+  "Discard": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/FrameworkConfiguration.js",
+        347
+      ]
+    ]
+  },
   "Download Snapshot": {
     "translation": "",
     "origin": [
@@ -122,6 +140,10 @@
   "Name": {
     "translation": "",
     "origin": [
+      [
+        "src/js/constants/RepositoriesTableHeaderLabels.js",
+        4
+      ],
       [
         "src/js/pages/network/virtual-network-detail/VirtualNetworkDetailsTab.js",
         22
@@ -203,6 +225,15 @@
       ]
     ]
   },
+  "Priority": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/constants/RepositoriesTableHeaderLabels.js",
+        5
+      ]
+    ]
+  },
   "Public IP": {
     "translation": "",
     "origin": [
@@ -272,6 +303,15 @@
       [
         "src/js/components/charts/TasksChart.js",
         119
+      ]
+    ]
+  },
+  "URL": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/constants/RepositoriesTableHeaderLabels.js",
+        6
       ]
     ]
   },

--- a/src/js/components/FrameworkConfiguration.js
+++ b/src/js/components/FrameworkConfiguration.js
@@ -1,6 +1,8 @@
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { Confirm } from "reactjs-components";
+import { withI18n } from "@lingui/react";
+import { t } from "@lingui/macro";
 
 import FullScreenModal from "#SRC/js/components/modals/FullScreenModal";
 import FullScreenModalHeader from "#SRC/js/components/modals/FullScreenModalHeader";
@@ -29,7 +31,7 @@ const METHODS_TO_BIND = [
   "handleFormSubmit"
 ];
 
-export default class FrameworkConfiguration extends Component {
+class FrameworkConfiguration extends Component {
   constructor(props) {
     super(props);
 
@@ -299,7 +301,8 @@ export default class FrameworkConfiguration extends Component {
       formData,
       onFormDataChange,
       onFormErrorChange,
-      defaultConfigWarning
+      defaultConfigWarning,
+      i18n
     } = this.props;
 
     let pageContents;
@@ -339,9 +342,9 @@ export default class FrameworkConfiguration extends Component {
           header={<ModalHeading>Discard Changes?</ModalHeading>}
           open={isConfirmOpen}
           onClose={this.handleCloseConfirmModal}
-          leftButtonText="Cancel"
+          leftButtonText={i18n._(t`Cancel`)}
           leftButtonCallback={this.handleCloseConfirmModal}
-          rightButtonText="Discard"
+          rightButtonText={i18n._(t`Discard`)}
           rightButtonClassName="button button-danger"
           rightButtonCallback={this.handleConfirmGoBack}
           showHeader={true}
@@ -368,3 +371,5 @@ FrameworkConfiguration.propTypes = {
   deployErrors: PropTypes.object,
   defaultConfigWarning: PropTypes.string
 };
+
+export default withI18n()(FrameworkConfiguration);

--- a/src/js/constants/RepositoriesTableHeaderLabels.js
+++ b/src/js/constants/RepositoriesTableHeaderLabels.js
@@ -1,7 +1,9 @@
+import { i18nMark } from "@lingui/react";
+
 const RepositoriesTableHeaderLabels = {
-  name: "Name",
-  priority: "Priority",
-  uri: "URL"
+  name: i18nMark("Name"),
+  priority: i18nMark("Priority"),
+  uri: i18nMark("URL")
 };
 
 module.exports = RepositoriesTableHeaderLabels;

--- a/src/js/utils/ResourceTableUtil.js
+++ b/src/js/utils/ResourceTableUtil.js
@@ -3,6 +3,7 @@ import classNames from "classnames";
 import React from "react";
 /* eslint-enable no-unused-vars */
 import { Tooltip } from "reactjs-components";
+import { Trans } from "@lingui/macro";
 
 import Icon from "../components/Icon";
 import TimeAgo from "../components/TimeAgo";
@@ -75,7 +76,7 @@ const ResourceTableUtil = {
       return (
         <span>
           {caret.before}
-          <span className="table-header-title">{title}</span>
+          <Trans render="span" id={title} className="table-header-title" />
           {helpIcon}
           {caret.after}
         </span>


### PR DESCRIPTION
Add POC for wrapping const text resources outside of React components. Covers 2 cases:
- Constants marked for translation but not immediately translated. These are used in conjunction with `<Trans>` component.
- Strings that need to be pre-translated (not just marked for translation)

Closes DCOS-43050.

## Testing

- Run `npx lingui extract` and ensure that both text wrapped in `i18nMark()` from `RepositoriesTableHeaderLabels.js` and text wrapped in `i18n._(t``)` from `FrameworkConfiguration.js` has been added to `locale/en/messages.json`
- Run app 
- Ensure table in Settings > Package Repositories displays as expected
- Go to Catalog > cassandra > Review & Run > Cancel > ensure that `Cancel` and `Discard` button text on confirmation popup is visible as expected

## Trade-offs

Constants must be marked for translation (`i18nMark`) and then wrapped where they are used. It can be cumbersome to track down where constants have been passed through to be used. Pre-translated strings rely on `i18n` prop, which comes from using HOC `withI18n`.
