### PR TITLE
DCOS_OSS-4222: Show cosmos errors

### DIFF
--- a/plugins/services/src/js/pages/EditFrameworkConfiguration.js
+++ b/plugins/services/src/js/pages/EditFrameworkConfiguration.js
@@ -5,6 +5,7 @@ import { StoreMixin } from "mesosphere-shared-reactjs";
 import { routerShape } from "react-router";
 import isEqual from "lodash.isequal";
 import CosmosPackagesStore from "#SRC/js/stores/CosmosPackagesStore";
+import Page from "#SRC/js/components/Page";
 import UniversePackage from "#SRC/js/structs/UniversePackage";
 import FrameworkConfiguration from "#SRC/js/components/FrameworkConfiguration";
 import Loader from "#SRC/js/components/Loader";
@@ -20,7 +21,7 @@ class EditFrameworkConfiguration extends mixin(StoreMixin) {
       deployErrors: null,
       formData: null,
       formErrors: {},
-      hasError: false,
+      cosmosErrors: null,
       defaultConfigWarning: null
     };
 
@@ -54,11 +55,16 @@ class EditFrameworkConfiguration extends mixin(StoreMixin) {
       ? null
       : "This service was initially deployed to a previous version of DC/OS that did not store service configuration settings. The default package values were used to populate the configuration in this form. Carefully verify the default settings are correct, prior to deploying the new configuration.";
 
-    this.setState({ packageDetails, formData, defaultConfigWarning });
+    this.setState({
+      cosmosErrors: null,
+      packageDetails,
+      formData,
+      defaultConfigWarning
+    });
   }
 
-  onCosmosPackagesStoreServiceDescriptionError() {
-    this.setState({ hasError: true });
+  onCosmosPackagesStoreServiceDescriptionError(cosmosErrors) {
+    this.setState({ cosmosErrors });
   }
 
   onCosmosPackagesStoreServiceUpdateSuccess() {
@@ -104,16 +110,24 @@ class EditFrameworkConfiguration extends mixin(StoreMixin) {
       deployErrors,
       formData,
       formErrors,
-      hasError,
+      cosmosErrors,
       defaultConfigWarning
     } = this.state;
 
-    if (packageDetails == null) {
-      return <Loader className="vertical-center" />;
+    if (cosmosErrors) {
+      return (
+        <Page>
+          <RequestErrorMsg
+            message={
+              <p className="text-align-center flush-bottom">{cosmosErrors}</p>
+            }
+          />
+        </Page>
+      );
     }
 
-    if (hasError) {
-      return <RequestErrorMsg />;
+    if (packageDetails == null) {
+      return <Loader className="vertical-center" />;
     }
 
     return (

--- a/tests/pages/services/EditFrameworkConfiguration-cy.js
+++ b/tests/pages/services/EditFrameworkConfiguration-cy.js
@@ -1,0 +1,27 @@
+describe("Edit Framework Configuration", function() {
+  context("Missing package", function() {
+    beforeEach(function() {
+      cy.configureCluster({
+        mesos: "1-for-each-health"
+      });
+
+      cy.route({
+        method: "POST",
+        url: /service\/describe/,
+        status: 400,
+        response: JSON.stringify({
+          type: "VersionNotFound",
+          message: "Version [0.2.0-1] of package [cassandra] not found",
+          data: { packageName: "cassandra", packageVersion: "0.2.0-1" }
+        })
+      }).as("describeService");
+    });
+
+    it("contains correct error message", function() {
+      cy.visitUrl({ url: "/services/detail/%2Fcassandra-healthy/edit" });
+
+      cy.wait("@describeService");
+      cy.contains("Version [0.2.0-1] of package [cassandra] not found");
+    });
+  });
+});


### PR DESCRIPTION
Properly handle Cosmos errors.

Closes: DCOS_OSS-4222

## Testing

1. Install something from the Catalog i.e. Kafka
2. Try editing the service
3. It should open the Editing form
4. Block `/cosmos/service/describe` URL in Chrome inspector
5. Refresh the Form
6. It now should show an error

Without the fix error would not appear. UI would keep showing loading bubble.

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs

I added some markup to fix the styling of the message. Otherwise it would be black on black and left-aligned.
## Screenshots
<img width="886" alt="screenshot 2018-10-05 at 15 59 49" src="https://user-images.githubusercontent.com/186223/46539763-b66d8000-c8b7-11e8-8b94-aabdd6f6f05d.png">
