### PR TITLE
DCOS-43087: Wrap text content from /plugins folder using Trans macro

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -42,7 +42,10 @@ packages.forEach(function(packageDir) {
 module.exports = {
   roots,
   globals: {
-    __DEV__: true
+    __DEV__: true,
+    "ts-jest": {
+      useBabelrc: true
+    }
   },
   // TODO: split up transforms
   transform: {

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1513,6 +1513,15 @@
       ]
     ]
   },
+  "Other": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/NodesGridView.js",
+        94
+      ]
+    ]
+  },
   "Package Repositories": {
     "translation": "",
     "origin": [

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1374,6 +1374,24 @@
       ]
     ]
   },
+  "Last Failure:": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobsOverviewTable.js",
+        260
+      ]
+    ]
+  },
+  "Last Success:": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobsOverviewTable.js",
+        249
+      ]
+    ]
+  },
   "Package Repositories": {
     "translation": "",
     "origin": [

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1513,6 +1513,15 @@
       ]
     ]
   },
+  "Non-Leaders": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/NonLeadersGrid.js",
+        70
+      ]
+    ]
+  },
   "Other": {
     "translation": "",
     "origin": [
@@ -2057,6 +2066,15 @@
       [
         "plugins/jobs/src/js/pages/JobConfiguration.js",
         96
+      ]
+    ]
+  },
+  "There are no more known masters in this cluster.": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/NonLeadersGrid.js",
+        40
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1365,6 +1365,100 @@
       ]
     ]
   },
+  "CPUs": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        32
+      ]
+    ]
+  },
+  "CRON Schedule": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        84
+      ]
+    ]
+  },
+  "Command": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        50
+      ]
+    ]
+  },
+  "Description": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        26
+      ]
+    ]
+  },
+  "Disk Space (Mib)": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        44
+      ]
+    ]
+  },
+  "Docker Container": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        106
+      ]
+    ]
+  },
+  "Enabled": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        78
+      ]
+    ]
+  },
+  "General": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        16
+      ]
+    ]
+  },
+  "ID": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        20
+      ],
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        72
+      ]
+    ]
+  },
+  "Image": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        110
+      ]
+    ]
+  },
   "Jobs": {
     "translation": "",
     "origin": [
@@ -1389,6 +1483,15 @@
       [
         "plugins/jobs/src/js/components/JobsOverviewTable.js",
         249
+      ]
+    ]
+  },
+  "Memory (MiB)": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        38
       ]
     ]
   },
@@ -1909,6 +2012,33 @@
       [
         ".dcos-ui-plugins-private/secrets/components/ServiceCreate.js",
         181
+      ]
+    ]
+  },
+  "Schedule": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        68
+      ]
+    ]
+  },
+  "Starting Deadline": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        96
+      ]
+    ]
+  },
+  "Time Zone": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        90
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -896,6 +896,15 @@
       ]
     ]
   },
+  "Grid": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/nodes/src/js/pages/NodesAgents.js",
+        234
+      ]
+    ]
+  },
   "ID": {
     "translation": "",
     "origin": [
@@ -1495,12 +1504,30 @@
       ]
     ]
   },
+  "List": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/nodes/src/js/pages/NodesAgents.js",
+        224
+      ]
+    ]
+  },
   "Memory (MiB)": {
     "translation": "",
     "origin": [
       [
         "plugins/jobs/src/js/pages/JobConfiguration.js",
         38
+      ]
+    ]
+  },
+  "No nodes detected": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/nodes/src/js/pages/NodesAgents.js",
+        301
       ]
     ]
   },
@@ -2066,6 +2093,15 @@
       [
         "plugins/jobs/src/js/pages/JobConfiguration.js",
         96
+      ]
+    ]
+  },
+  "There a currently no other nodes in your datacenter other than your DC/OS master node.": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/nodes/src/js/pages/NodesAgents.js",
+        303
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -759,6 +759,15 @@
       ]
     ]
   },
+  "Delete Job": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobDeleteModal.js",
+        30
+      ]
+    ]
+  },
   "Delete Repository": {
     "translation": "",
     "origin": [
@@ -1275,7 +1284,7 @@
     "origin": [
       [
         "plugins/jobs/src/js/components/Breadcrumbs.js",
-        15
+        14
       ]
     ]
   },
@@ -1598,7 +1607,7 @@
     "origin": [
       [
         "plugins/nodes/src/js/components/NodeBreadcrumbs.js",
-        18
+        17
       ]
     ]
   },
@@ -1717,7 +1726,7 @@
     "origin": [
       [
         "plugins/catalog/src/js/repositories/components/RepositoriesPage.js",
-        14
+        13
       ]
     ]
   },
@@ -1862,7 +1871,7 @@
       ]
     ]
   },
-  "Repository ({label}) will be {0} from {1}. You will not be able to install any packages belonging to that repository anymore.": {
+  "Repository ({label}) will be deleted from {0}. You will not be able to install any packages belonging to that repository anymore.": {
     "translation": "",
     "origin": [
       [
@@ -2720,15 +2729,6 @@
       [
         "src/js/components/modals/VersionsModal.js",
         31
-      ]
-    ]
-  },
-  "{0} Job": {
-    "translation": "",
-    "origin": [
-      [
-        "plugins/jobs/src/js/components/JobDeleteModal.js",
-        30
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -298,6 +298,15 @@
       ]
     ]
   },
+  "Are you sure you want to stop {headerContent}?": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobStopRunModal.js",
+        16
+      ]
+    ]
+  },
   "Are you sure?": {
     "translation": "",
     "origin": [
@@ -362,15 +371,6 @@
       ]
     ]
   },
-  "Are you sure you want to stop {headerContent}?": {
-    "translation": "",
-    "origin": [
-      [
-        "plugins/jobs/src/js/components/JobStopRunModal.js",
-        16
-      ]
-    ]
-  },
   "CLI Only Package": {
     "translation": "",
     "origin": [
@@ -425,6 +425,10 @@
       [
         ".dcos-ui-plugins-private/secrets/components/SecretFormModal.js",
         167
+      ],
+      [
+        "plugins/jobs/src/js/components/JobFormModal.tsx",
+        44
       ],
       [
         "src/js/components/FrameworkConfiguration.js",
@@ -1212,6 +1216,15 @@
       ]
     ]
   },
+  "JSON mode": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobFormModal.tsx",
+        61
+      ]
+    ]
+  },
   "Jobs": {
     "translation": "",
     "origin": [
@@ -1364,17 +1377,12 @@
     "translation": "",
     "origin": [
       [
-        "src/js/constants/UnitHealthStatus.js",
-        39
-      ]
-    ]
-  },
-  "N/A": {
-    "translation": "",
-    "origin": [
-      [
         "plugins/jobs/src/js/pages/JobRunHistoryTable.js",
         323
+      ],
+      [
+        "src/js/constants/UnitHealthStatus.js",
+        39
       ]
     ]
   },
@@ -1769,21 +1777,21 @@
       ]
     ]
   },
-  "Resource": {
-    "translation": "",
-    "origin": [
-      [
-        ".dcos-ui-plugins-private/organization/components/PermissionBuilderModal.js",
-        481
-      ]
-    ]
-  },
   "Repository ({label}) will be {0} from {1}. You will not be able to install any packages belonging to that repository anymore.": {
     "translation": "",
     "origin": [
       [
         "plugins/catalog/src/js/repositories/components/RepositoriesDeleteConfirm.js",
         15
+      ]
+    ]
+  },
+  "Resource": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/PermissionBuilderModal.js",
+        481
       ]
     ]
   },
@@ -2013,21 +2021,21 @@
       ]
     ]
   },
-  "Store": {
-    "translation": "",
-    "origin": [
-      [
-        ".dcos-ui-plugins-private/secrets/pages/SecretDetail.js",
-        218
-      ]
-    ]
-  },
   "Stop": {
     "translation": "",
     "origin": [
       [
         "plugins/jobs/src/js/pages/JobRunHistoryTable.js",
         219
+      ]
+    ]
+  },
+  "Store": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/pages/SecretDetail.js",
+        218
       ]
     ]
   },
@@ -2437,6 +2445,15 @@
       ]
     ]
   },
+  "You are about to stop {bodyText}.": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobStopRunModal.js",
+        34
+      ]
+    ]
+  },
   "You can also join us on our <0>Slack channel</0> or send us an email at <1>{0}</1>.": {
     "translation": "",
     "origin": [
@@ -2488,15 +2505,6 @@
       [
         ".dcos-ui-plugins-private/secrets/pages/SecretDetail.js",
         64
-      ]
-    ]
-  },
-  "You are about to stop {bodyText}.": {
-    "translation": "",
-    "origin": [
-      [
-        "plugins/jobs/src/js/components/JobStopRunModal.js",
-        34
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1365,6 +1365,15 @@
       ]
     ]
   },
+  "Jobs": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/Breadcrumbs.js",
+        15
+      ]
+    ]
+  },
   "Package Repositories": {
     "translation": "",
     "origin": [

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -362,6 +362,15 @@
       ]
     ]
   },
+  "Are you sure you want to stop {headerContent}?": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobStopRunModal.js",
+        16
+      ]
+    ]
+  },
   "CLI Only Package": {
     "translation": "",
     "origin": [
@@ -2461,6 +2470,15 @@
       [
         ".dcos-ui-plugins-private/secrets/pages/SecretDetail.js",
         64
+      ]
+    ]
+  },
+  "You are about to stop {bodyText}.": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobStopRunModal.js",
+        34
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1113,6 +1113,15 @@
       ]
     ]
   },
+  "IP Addresses": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/pages/task-details/TaskIpAddressesRow.js",
+        41
+      ]
+    ]
+  },
   "IP Subnet": {
     "translation": "",
     "origin": [

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -142,6 +142,15 @@
       ]
     ]
   },
+  "Add Repository": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/catalog/src/js/repositories/components/AddRepositoryFormModal.js",
+        114
+      ]
+    ]
+  },
   "Add Secret": {
     "translation": "",
     "origin": [
@@ -1353,6 +1362,15 @@
       [
         ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPsTable.js",
         54
+      ]
+    ]
+  },
+  "Package Repositories": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/catalog/src/js/repositories/components/RepositoriesPage.js",
+        14
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -652,6 +652,24 @@
       ]
     ]
   },
+  "Configuration": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/pages/task-details/TaskDetailsTab.js",
+        119
+      ]
+    ]
+  },
+  "Container Configuration": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/pages/task-details/TaskDetailsTab.js",
+        31
+      ]
+    ]
+  },
   "Create a Job": {
     "translation": "",
     "origin": [
@@ -1261,6 +1279,15 @@
       ]
     ]
   },
+  "Labels": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/pages/task-details/TaskDetailsTab.js",
+        173
+      ]
+    ]
+  },
   "Last Failure:": {
     "translation": "",
     "origin": [
@@ -1548,6 +1575,15 @@
       ]
     ]
   },
+  "Node": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/pages/task-details/TaskDetailsTab.js",
+        96
+      ]
+    ]
+  },
   "Nodes": {
     "translation": "",
     "origin": [
@@ -1788,6 +1824,10 @@
       [
         "plugins/nodes/src/js/pages/nodes/NodeDetailTab.js",
         100
+      ],
+      [
+        "plugins/services/src/js/pages/task-details/TaskDetailsTab.js",
+        142
       ]
     ]
   },
@@ -1873,6 +1913,15 @@
       [
         ".dcos-ui-plugins-private/organization/submodules/directories/components/DirectoryFormModal.js",
         105
+      ]
+    ]
+  },
+  "Sandbox Path": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/pages/task-details/TaskDetailsTab.js",
+        109
       ]
     ]
   },
@@ -2048,6 +2097,15 @@
       ]
     ]
   },
+  "Service": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/pages/task-details/TaskDetailsTab.js",
+        83
+      ]
+    ]
+  },
   "Starting Deadline": {
     "translation": "",
     "origin": [
@@ -2161,6 +2219,15 @@
       [
         ".dcos-ui-plugins-private/secrets/components/SealedStoreAlert.js",
         19
+      ]
+    ]
+  },
+  "Task ID": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/pages/task-details/TaskDetailsTab.js",
+        123
       ]
     ]
   },
@@ -2568,6 +2635,10 @@
       [
         "plugins/nodes/src/js/pages/nodes/NodeDetailTab.js",
         111
+      ],
+      [
+        "plugins/services/src/js/pages/task-details/TaskDetailsTab.js",
+        134
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1504,6 +1504,15 @@
       ]
     ]
   },
+  "Nodes": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/NodeBreadcrumbs.js",
+        18
+      ]
+    ]
+  },
   "Package Repositories": {
     "translation": "",
     "origin": [

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -367,6 +367,24 @@
       ]
     ]
   },
+  "CPUs": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        32
+      ]
+    ]
+  },
+  "CRON Schedule": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        84
+      ]
+    ]
+  },
   "Callback URL": {
     "translation": "",
     "origin": [
@@ -481,6 +499,15 @@
       [
         "src/js/components/ClusterHeader.js",
         59
+      ]
+    ]
+  },
+  "Command": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        50
       ]
     ]
   },
@@ -681,6 +708,19 @@
       [
         ".dcos-ui-plugins-private/secrets/pages/SecretDetail.js",
         207
+      ],
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        26
+      ]
+    ]
+  },
+  "Did not find a node by the id \"{nodeID}\"": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/nodes/src/js/pages/nodes/NodeDetailPage.js",
+        130
       ]
     ]
   },
@@ -699,6 +739,24 @@
       [
         "src/js/components/FrameworkConfiguration.js",
         344
+      ]
+    ]
+  },
+  "Disk Space (Mib)": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        44
+      ]
+    ]
+  },
+  "Docker Container": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        106
       ]
     ]
   },
@@ -781,6 +839,15 @@
       ]
     ]
   },
+  "Enabled": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        78
+      ]
+    ]
+  },
   "Enter": {
     "translation": "",
     "origin": [
@@ -796,6 +863,15 @@
       [
         ".dcos-ui-plugins-private/auth-providers/components/AuthProviderDetailTab.js",
         91
+      ]
+    ]
+  },
+  "Error finding node": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/nodes/src/js/pages/nodes/NodeDetailPage.js",
+        127
       ]
     ]
   },
@@ -856,6 +932,24 @@
       ]
     ]
   },
+  "General": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        16
+      ]
+    ]
+  },
+  "Grid": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/nodes/src/js/pages/NodesAgents.js",
+        234
+      ]
+    ]
+  },
   "Group Search": {
     "translation": "",
     "origin": [
@@ -896,21 +990,20 @@
       ]
     ]
   },
-  "Grid": {
-    "translation": "",
-    "origin": [
-      [
-        "plugins/nodes/src/js/pages/NodesAgents.js",
-        234
-      ]
-    ]
-  },
   "ID": {
     "translation": "",
     "origin": [
       [
         ".dcos-ui-plugins-private/secrets/components/SecretFormModal.js",
         197
+      ],
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        20
+      ],
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        72
       ]
     ]
   },
@@ -987,6 +1080,15 @@
       [
         ".dcos-ui-plugins-private/secrets/components/SecretActionsModal.js",
         83
+      ]
+    ]
+  },
+  "Image": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        110
       ]
     ]
   },
@@ -1071,12 +1173,48 @@
       ]
     ]
   },
+  "Jobs": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/Breadcrumbs.js",
+        15
+      ]
+    ]
+  },
   "LDAP Directory": {
     "translation": "",
     "origin": [
       [
         ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
         38
+      ]
+    ]
+  },
+  "Last Failure:": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobsOverviewTable.js",
+        260
+      ]
+    ]
+  },
+  "Last Success:": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobsOverviewTable.js",
+        249
+      ]
+    ]
+  },
+  "Leader": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/LeaderGrid.js",
+        33
       ]
     ]
   },
@@ -1108,6 +1246,15 @@
       [
         ".dcos-ui-plugins-private/cluster-linking/pages/LinkedClustersPage.js",
         25
+      ]
+    ]
+  },
+  "List": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/nodes/src/js/pages/NodesAgents.js",
+        224
       ]
     ]
   },
@@ -1144,6 +1291,15 @@
       [
         "src/js/components/ImageViewer.js",
         71
+      ]
+    ]
+  },
+  "Memory (MiB)": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        38
       ]
     ]
   },
@@ -1246,6 +1402,15 @@
       ]
     ]
   },
+  "No nodes detected": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/nodes/src/js/pages/NodesAgents.js",
+        301
+      ]
+    ]
+  },
   "No package repositories": {
     "translation": "",
     "origin": [
@@ -1279,6 +1444,24 @@
       [
         ".dcos-ui-plugins-private/licensing/components/LicensingNodeCapacityRow.js",
         93
+      ]
+    ]
+  },
+  "Nodes": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/NodeBreadcrumbs.js",
+        18
+      ]
+    ]
+  },
+  "Non-Leaders": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/NonLeadersGrid.js",
+        70
       ]
     ]
   },
@@ -1335,6 +1518,15 @@
       ]
     ]
   },
+  "Other": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/NodesGridView.js",
+        94
+      ]
+    ]
+  },
   "Output": {
     "translation": "",
     "origin": [
@@ -1371,190 +1563,6 @@
       [
         ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPsTable.js",
         54
-      ]
-    ]
-  },
-  "CPUs": {
-    "translation": "",
-    "origin": [
-      [
-        "plugins/jobs/src/js/pages/JobConfiguration.js",
-        32
-      ]
-    ]
-  },
-  "CRON Schedule": {
-    "translation": "",
-    "origin": [
-      [
-        "plugins/jobs/src/js/pages/JobConfiguration.js",
-        84
-      ]
-    ]
-  },
-  "Command": {
-    "translation": "",
-    "origin": [
-      [
-        "plugins/jobs/src/js/pages/JobConfiguration.js",
-        50
-      ]
-    ]
-  },
-  "Description": {
-    "translation": "",
-    "origin": [
-      [
-        "plugins/jobs/src/js/pages/JobConfiguration.js",
-        26
-      ]
-    ]
-  },
-  "Disk Space (Mib)": {
-    "translation": "",
-    "origin": [
-      [
-        "plugins/jobs/src/js/pages/JobConfiguration.js",
-        44
-      ]
-    ]
-  },
-  "Docker Container": {
-    "translation": "",
-    "origin": [
-      [
-        "plugins/jobs/src/js/pages/JobConfiguration.js",
-        106
-      ]
-    ]
-  },
-  "Enabled": {
-    "translation": "",
-    "origin": [
-      [
-        "plugins/jobs/src/js/pages/JobConfiguration.js",
-        78
-      ]
-    ]
-  },
-  "General": {
-    "translation": "",
-    "origin": [
-      [
-        "plugins/jobs/src/js/pages/JobConfiguration.js",
-        16
-      ]
-    ]
-  },
-  "ID": {
-    "translation": "",
-    "origin": [
-      [
-        "plugins/jobs/src/js/pages/JobConfiguration.js",
-        20
-      ],
-      [
-        "plugins/jobs/src/js/pages/JobConfiguration.js",
-        72
-      ]
-    ]
-  },
-  "Image": {
-    "translation": "",
-    "origin": [
-      [
-        "plugins/jobs/src/js/pages/JobConfiguration.js",
-        110
-      ]
-    ]
-  },
-  "Jobs": {
-    "translation": "",
-    "origin": [
-      [
-        "plugins/jobs/src/js/components/Breadcrumbs.js",
-        15
-      ]
-    ]
-  },
-  "Last Failure:": {
-    "translation": "",
-    "origin": [
-      [
-        "plugins/jobs/src/js/components/JobsOverviewTable.js",
-        260
-      ]
-    ]
-  },
-  "Last Success:": {
-    "translation": "",
-    "origin": [
-      [
-        "plugins/jobs/src/js/components/JobsOverviewTable.js",
-        249
-      ]
-    ]
-  },
-  "Leader": {
-    "translation": "",
-    "origin": [
-      [
-        "plugins/nodes/src/js/components/LeaderGrid.js",
-        33
-      ]
-    ]
-  },
-  "List": {
-    "translation": "",
-    "origin": [
-      [
-        "plugins/nodes/src/js/pages/NodesAgents.js",
-        224
-      ]
-    ]
-  },
-  "Memory (MiB)": {
-    "translation": "",
-    "origin": [
-      [
-        "plugins/jobs/src/js/pages/JobConfiguration.js",
-        38
-      ]
-    ]
-  },
-  "No nodes detected": {
-    "translation": "",
-    "origin": [
-      [
-        "plugins/nodes/src/js/pages/NodesAgents.js",
-        301
-      ]
-    ]
-  },
-  "Nodes": {
-    "translation": "",
-    "origin": [
-      [
-        "plugins/nodes/src/js/components/NodeBreadcrumbs.js",
-        18
-      ]
-    ]
-  },
-  "Non-Leaders": {
-    "translation": "",
-    "origin": [
-      [
-        "plugins/nodes/src/js/components/NonLeadersGrid.js",
-        70
-      ]
-    ]
-  },
-  "Other": {
-    "translation": "",
-    "origin": [
-      [
-        "plugins/nodes/src/js/components/NodesGridView.js",
-        94
       ]
     ]
   },
@@ -1727,6 +1735,15 @@
       ]
     ]
   },
+  "Schedule": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        68
+      ]
+    ]
+  },
   "Secret": {
     "translation": "",
     "origin": [
@@ -1890,6 +1907,15 @@
       ]
     ]
   },
+  "Starting Deadline": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        96
+      ]
+    ]
+  },
   "Store": {
     "translation": "",
     "origin": [
@@ -2006,12 +2032,30 @@
       ]
     ]
   },
+  "There a currently no other nodes in your datacenter other than your DC/OS master node.": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/nodes/src/js/pages/NodesAgents.js",
+        303
+      ]
+    ]
+  },
   "There a currently no other virtual networks found on your datacenter. Virtual networks are configured during setup of your DC/OS cluster.": {
     "translation": "",
     "origin": [
       [
         "src/js/pages/network/VirtualNetworksTab.js",
         93
+      ]
+    ]
+  },
+  "There are no more known masters in this cluster.": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/NonLeadersGrid.js",
+        40
       ]
     ]
   },
@@ -2060,6 +2104,15 @@
       ]
     ]
   },
+  "Time Zone": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        90
+      ]
+    ]
+  },
   "To enable this feature please contact support via {slackLink} or send us an email at {supportLink}.": {
     "translation": "",
     "origin": [
@@ -2075,51 +2128,6 @@
       [
         ".dcos-ui-plugins-private/secrets/components/ServiceCreate.js",
         181
-      ]
-    ]
-  },
-  "Schedule": {
-    "translation": "",
-    "origin": [
-      [
-        "plugins/jobs/src/js/pages/JobConfiguration.js",
-        68
-      ]
-    ]
-  },
-  "Starting Deadline": {
-    "translation": "",
-    "origin": [
-      [
-        "plugins/jobs/src/js/pages/JobConfiguration.js",
-        96
-      ]
-    ]
-  },
-  "There a currently no other nodes in your datacenter other than your DC/OS master node.": {
-    "translation": "",
-    "origin": [
-      [
-        "plugins/nodes/src/js/pages/NodesAgents.js",
-        303
-      ]
-    ]
-  },
-  "There are no more known masters in this cluster.": {
-    "translation": "",
-    "origin": [
-      [
-        "plugins/nodes/src/js/components/NonLeadersGrid.js",
-        40
-      ]
-    ]
-  },
-  "Time Zone": {
-    "translation": "",
-    "origin": [
-      [
-        "plugins/jobs/src/js/pages/JobConfiguration.js",
-        90
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1486,6 +1486,15 @@
       ]
     ]
   },
+  "Leader": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/LeaderGrid.js",
+        33
+      ]
+    ]
+  },
   "Memory (MiB)": {
     "translation": "",
     "origin": [

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1721,6 +1721,15 @@
       ]
     ]
   },
+  "Please contact your system administrator or see the <0>documentation</0>.": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/oauth/components/LoginPage.js",
+        118
+      ]
+    ]
+  },
   "Priority": {
     "translation": "",
     "origin": [
@@ -2372,6 +2381,15 @@
       [
         ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
         149
+      ]
+    ]
+  },
+  "Unable to login to your DC/OS cluster. Clusters must be connected to the internet.": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/oauth/components/LoginPage.js",
+        113
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -710,6 +710,15 @@
       ]
     ]
   },
+  "Delete Repository": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/catalog/src/js/repositories/components/RepositoriesDeleteConfirm.js",
+        35
+      ]
+    ]
+  },
   "Description": {
     "translation": "",
     "origin": [
@@ -1748,6 +1757,15 @@
       [
         ".dcos-ui-plugins-private/organization/components/PermissionBuilderModal.js",
         481
+      ]
+    ]
+  },
+  "Repository ({label}) will be {0} from {1}. You will not be able to install any packages belonging to that repository anymore.": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/catalog/src/js/repositories/components/RepositoriesDeleteConfirm.js",
+        15
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -2554,6 +2554,15 @@
       ]
     ]
   },
+  "{0} Job": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobDeleteModal.js",
+        30
+      ]
+    ]
+  },
   "{0} Version": {
     "translation": "",
     "origin": [

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -57,6 +57,10 @@
     "translation": "",
     "origin": [
       [
+        "plugins/nodes/src/js/pages/nodes/NodeDetailTab.js",
+        76
+      ],
+      [
         "src/js/components/FrameworkConfigurationReviewScreen.js",
         67
       ]
@@ -373,6 +377,10 @@
       [
         "plugins/jobs/src/js/pages/JobConfiguration.js",
         32
+      ],
+      [
+        "plugins/nodes/src/js/pages/nodes/NodeDetailTab.js",
+        141
       ]
     ]
   },
@@ -742,6 +750,15 @@
       ]
     ]
   },
+  "Disk": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/nodes/src/js/pages/nodes/NodeDetailTab.js",
+        125
+      ]
+    ]
+  },
   "Disk Space (Mib)": {
     "translation": "",
     "origin": [
@@ -1004,6 +1021,10 @@
       [
         "plugins/jobs/src/js/pages/JobConfiguration.js",
         72
+      ],
+      [
+        "plugins/nodes/src/js/pages/nodes/NodeDetailTab.js",
+        70
       ]
     ]
   },
@@ -1285,12 +1306,30 @@
       ]
     ]
   },
+  "Master Version": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/nodes/src/js/pages/nodes/NodeDetailTab.js",
+        92
+      ]
+    ]
+  },
   "Media": {
     "translation": "",
     "origin": [
       [
         "src/js/components/ImageViewer.js",
         71
+      ]
+    ]
+  },
+  "Mem": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/nodes/src/js/pages/nodes/NodeDetailTab.js",
+        133
       ]
     ]
   },
@@ -1674,6 +1713,19 @@
       [
         ".dcos-ui-plugins-private/placement/components/RegionSelection.js",
         84
+      ],
+      [
+        "plugins/nodes/src/js/pages/nodes/NodeDetailTab.js",
+        100
+      ]
+    ]
+  },
+  "Registered": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/nodes/src/js/pages/nodes/NodeDetailTab.js",
+        84
       ]
     ]
   },
@@ -1696,6 +1748,15 @@
       [
         ".dcos-ui-plugins-private/organization/components/PermissionBuilderModal.js",
         481
+      ]
+    ]
+  },
+  "Resources": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/nodes/src/js/pages/nodes/NodeDetailTab.js",
+        121
       ]
     ]
   },
@@ -2391,6 +2452,15 @@
       [
         "src/js/pages/catalog/PackagesTab.js",
         50
+      ]
+    ]
+  },
+  "Zone": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/nodes/src/js/pages/nodes/NodeDetailTab.js",
+        111
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -652,6 +652,24 @@
       ]
     ]
   },
+  "Create a Job": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobsOverviewEmpty.tsx",
+        35
+      ]
+    ]
+  },
+  "Create both one-off or scheduled jobs to perform tasks at a predefined interval.": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobsOverviewEmpty.tsx",
+        29
+      ]
+    ]
+  },
   "Cryptographic Cluster ID": {
     "translation": "",
     "origin": [
@@ -1473,6 +1491,15 @@
       [
         ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.js",
         87
+      ]
+    ]
+  },
+  "No active jobs": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobsOverviewEmpty.tsx",
+        27
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1369,6 +1369,15 @@
       ]
     ]
   },
+  "N/A": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobRunHistoryTable.js",
+        323
+      ]
+    ]
+  },
   "Name": {
     "translation": "",
     "origin": [
@@ -2010,6 +2019,15 @@
       [
         ".dcos-ui-plugins-private/secrets/pages/SecretDetail.js",
         218
+      ]
+    ]
+  },
+  "Stop": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobRunHistoryTable.js",
+        219
       ]
     ]
   },

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@sentry/cli": "1.35.6",
     "@types/events": "1.2.0",
     "@types/jest": "22.2.3",
+    "@types/lingui__react": "2.5.0",
     "@types/prop-types": "15.5.3",
     "@types/react": "15.0.39",
     "@types/react-router": "2.0.54",

--- a/plugins/catalog/src/js/repositories/components/AddRepositoryFormModal.js
+++ b/plugins/catalog/src/js/repositories/components/AddRepositoryFormModal.js
@@ -2,6 +2,7 @@ import PropTypes from "prop-types";
 /* eslint-disable no-unused-vars */
 import React from "react";
 /* eslint-enable no-unused-vars */
+import { Trans } from "@lingui/macro";
 
 import FormModal from "#SRC/js/components/FormModal";
 import ModalHeading from "#SRC/js/components/modals/ModalHeading";
@@ -108,7 +109,11 @@ class AddRepositoryFormModal extends React.Component {
         disabled={props.pendingRequest}
         buttonDefinition={this.getButtonDefinition()}
         modalProps={{
-          header: <ModalHeading>Add Repository</ModalHeading>,
+          header: (
+            <ModalHeading>
+              <Trans render="span">Add Repository</Trans>
+            </ModalHeading>
+          ),
           showHeader: true
         }}
         onSubmit={this.handleAddRepository}

--- a/plugins/catalog/src/js/repositories/components/RepositoriesDeleteConfirm.js
+++ b/plugins/catalog/src/js/repositories/components/RepositoriesDeleteConfirm.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import React from "react";
 import Config from "#SRC/js/config/Config";
 import ModalHeading from "#SRC/js/components/modals/ModalHeading";
@@ -11,11 +12,11 @@ const RepositoriesDeleteConfirmMessage = ({ repository, error }) => {
 
   return (
     <div>
-      <p>
-        {`Repository (${label}) will be ${UserActions.DELETED}
-          from ${Config.productName}. You will not be able to install any
-          packages belonging to that repository anymore.`}
-      </p>
+      <Trans render="p">
+        Repository ({label}) will be {UserActions.DELETED}
+        from {Config.productName}. You will not be able to install any packages
+        belonging to that repository anymore.
+      </Trans>
       {error ? errorMessage : ""}
     </div>
   );
@@ -29,7 +30,11 @@ const RepositoriesDeleteConfirm = ({
   repository,
   deleteError
 }) => {
-  const heading = <ModalHeading>Delete Repository</ModalHeading>;
+  const heading = (
+    <ModalHeading>
+      <Trans render="span">Delete Repository</Trans>
+    </ModalHeading>
+  );
   const rightButtonText = `${StringUtil.capitalize(
     UserActions.DELETE
   )} Repository`;

--- a/plugins/catalog/src/js/repositories/components/RepositoriesDeleteConfirm.js
+++ b/plugins/catalog/src/js/repositories/components/RepositoriesDeleteConfirm.js
@@ -13,9 +13,9 @@ const RepositoriesDeleteConfirmMessage = ({ repository, error }) => {
   return (
     <div>
       <Trans render="p">
-        Repository ({label}) will be {UserActions.DELETED}
-        from {Config.productName}. You will not be able to install any packages
-        belonging to that repository anymore.
+        Repository ({label}) will be deleted from {Config.productName}. You will
+        not be able to install any packages belonging to that repository
+        anymore.
       </Trans>
       {error ? errorMessage : ""}
     </div>

--- a/plugins/catalog/src/js/repositories/components/RepositoriesPage.js
+++ b/plugins/catalog/src/js/repositories/components/RepositoriesPage.js
@@ -10,9 +10,9 @@ const RepositoriesBreadcrumbs = addButton => {
   const crumbs = [
     <Breadcrumb key={-1} title="Repositories">
       <BreadcrumbTextContent>
-        <Link to="/settings/repositories">
-          <Trans>Package Repositories</Trans>
-        </Link>
+        <Trans render={<Link to="/settings/repositories" />}>
+          Package Repositories
+        </Trans>
       </BreadcrumbTextContent>
     </Breadcrumb>
   ];

--- a/plugins/catalog/src/js/repositories/components/RepositoriesPage.js
+++ b/plugins/catalog/src/js/repositories/components/RepositoriesPage.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import { Link } from "react-router";
 import React from "react";
 
@@ -9,7 +10,9 @@ const RepositoriesBreadcrumbs = addButton => {
   const crumbs = [
     <Breadcrumb key={-1} title="Repositories">
       <BreadcrumbTextContent>
-        <Link to="/settings/repositories">Package Repositories</Link>
+        <Link to="/settings/repositories">
+          <Trans>Package Repositories</Trans>
+        </Link>
       </BreadcrumbTextContent>
     </Breadcrumb>
   ];

--- a/plugins/jobs/src/js/components/Breadcrumbs.js
+++ b/plugins/jobs/src/js/components/Breadcrumbs.js
@@ -11,9 +11,7 @@ export default function Breadcrumbs({ jobPath, jobName, jobInfo, children }) {
   let breadcrumbParts = [
     <Breadcrumb key={"Jobs"} title="Jobs">
       <BreadcrumbTextContent>
-        <Link to={"/jobs/overview/"}>
-          <Trans render="span">Jobs</Trans>
-        </Link>
+        <Trans render={<Link to={"/jobs/overview/"} />}>Jobs</Trans>
       </BreadcrumbTextContent>
     </Breadcrumb>
   ];

--- a/plugins/jobs/src/js/components/Breadcrumbs.js
+++ b/plugins/jobs/src/js/components/Breadcrumbs.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import { Link } from "react-router";
 import PropTypes from "prop-types";
 import React from "react";
@@ -10,7 +11,9 @@ export default function Breadcrumbs({ jobPath, jobName, jobInfo, children }) {
   let breadcrumbParts = [
     <Breadcrumb key={"Jobs"} title="Jobs">
       <BreadcrumbTextContent>
-        <Link to={"/jobs/overview/"}>{"Jobs"}</Link>
+        <Link to={"/jobs/overview/"}>
+          <Trans render="span">Jobs</Trans>
+        </Link>
       </BreadcrumbTextContent>
     </Breadcrumb>
   ];

--- a/plugins/jobs/src/js/components/JobDeleteModal.js
+++ b/plugins/jobs/src/js/components/JobDeleteModal.js
@@ -28,7 +28,7 @@ const ModalMessage = ({ jobId, stopCurrentJobRuns }) => {
   return (
     <div>
       <Trans render="h2" className="text-danger text-align-center flush-top">
-        {StringUtil.capitalize(UserActions.DELETE)} Job
+        Delete Job
       </Trans>
       <p>{stopCurrentJobRuns ? stopCurrentRunsMessage : defaultMessage}</p>
     </div>

--- a/plugins/jobs/src/js/components/JobDeleteModal.js
+++ b/plugins/jobs/src/js/components/JobDeleteModal.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import * as React from "react";
 import { Confirm } from "reactjs-components";
 import StringUtil from "#SRC/js/utils/StringUtil";
@@ -26,9 +27,9 @@ const ModalMessage = ({ jobId, stopCurrentJobRuns }) => {
 
   return (
     <div>
-      <h2 className="text-danger text-align-center flush-top">
+      <Trans render="h2" className="text-danger text-align-center flush-top">
         {StringUtil.capitalize(UserActions.DELETE)} Job
-      </h2>
+      </Trans>
       <p>{stopCurrentJobRuns ? stopCurrentRunsMessage : defaultMessage}</p>
     </div>
   );

--- a/plugins/jobs/src/js/components/JobFormModal.tsx
+++ b/plugins/jobs/src/js/components/JobFormModal.tsx
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import Ace from "react-ace";
 import * as React from "react";
 import { Modal } from "reactjs-components";
@@ -82,7 +83,7 @@ const ModalFooter = ({
         className="button button-primary-link flush-left"
         onClick={handleCancel}
       >
-        Cancel
+        <Trans>Cancel</Trans>
       </button>
       <button className="button button-primary" onClick={handleSubmit}>
         {submitLabel}
@@ -112,7 +113,7 @@ const ModalTitle = ({
             checked={isJsonMode}
             onChange={handleInputModeToggle}
           >
-            JSON mode
+            <Trans>JSON mode</Trans>
           </ToggleButton>
         </div>
       </div>

--- a/plugins/jobs/src/js/components/JobStopRunModal.js
+++ b/plugins/jobs/src/js/components/JobStopRunModal.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import { Confirm } from "reactjs-components";
 import PropTypes from "prop-types";
 import React from "react";
@@ -12,7 +13,9 @@ class JobStopRunModal extends React.Component {
 
     return (
       <ModalHeading key="confirmHeader">
-        {`Are you sure you want to stop ${headerContent}?`}
+        <Trans render="span">
+          Are you sure you want to stop {headerContent}?
+        </Trans>
       </ModalHeading>
     );
   }
@@ -26,7 +29,11 @@ class JobStopRunModal extends React.Component {
       bodyText = "the selected job runs";
     }
 
-    return <span key="confirmText">You are about to stop {bodyText}.</span>;
+    return (
+      <span key="confirmText">
+        <Trans render="span">You are about to stop {bodyText}.</Trans>
+      </span>
+    );
   }
 
   render() {

--- a/plugins/jobs/src/js/components/JobsOverviewEmpty.tsx
+++ b/plugins/jobs/src/js/components/JobsOverviewEmpty.tsx
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import * as React from "react";
 
 import AlertPanel from "#SRC/js/components/AlertPanel";
@@ -41,17 +42,19 @@ export default class JobsOverviewEmpty extends React.Component<
     return (
       <JobsPage jobPath={jobPath}>
         <AlertPanel>
-          <AlertPanelHeader>No active jobs</AlertPanelHeader>
-          <p className="tall">
+          <AlertPanelHeader>
+            <Trans>No active jobs</Trans>
+          </AlertPanelHeader>
+          <Trans render="p" className="tall">
             Create both one-off or scheduled jobs to perform tasks at a
             predefined interval.
-          </p>
+          </Trans>
           <div className="button-collection flush-bottom">
             <button
               className="button button-primary"
               onClick={this.handleOpenJobFormModal}
             >
-              Create a Job
+              <Trans>Create a Job</Trans>
             </button>
           </div>
         </AlertPanel>

--- a/plugins/jobs/src/js/components/JobsOverviewTable.js
+++ b/plugins/jobs/src/js/components/JobsOverviewTable.js
@@ -248,7 +248,7 @@ export default class JobsOverviewTable extends React.Component {
         <p className="flush-bottom" key="tooltip-success-at">
           <Trans render="span" className="text-success">
             Last Success:
-          </Trans>
+          </Trans>{" "}
           {new Date(lastSuccessAt).toLocaleString()}
         </p>
       );
@@ -259,7 +259,7 @@ export default class JobsOverviewTable extends React.Component {
         <p className="flush-bottom" key="tooltip-failure-at">
           <Trans render="span" className="text-danger">
             Last Failure:
-          </Trans>
+          </Trans>{" "}
           {new Date(lastFailureAt).toLocaleString()}
         </p>
       );

--- a/plugins/jobs/src/js/components/JobsOverviewTable.js
+++ b/plugins/jobs/src/js/components/JobsOverviewTable.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import classNames from "classnames";
 import { Link } from "react-router";
 import prettycron from "prettycron";
@@ -245,7 +246,9 @@ export default class JobsOverviewTable extends React.Component {
     if (lastSuccessAt != null) {
       nodes.push(
         <p className="flush-bottom" key="tooltip-success-at">
-          <span className="text-success">Last Success: </span>
+          <Trans render="span" className="text-success">
+            Last Success:
+          </Trans>
           {new Date(lastSuccessAt).toLocaleString()}
         </p>
       );
@@ -254,7 +257,9 @@ export default class JobsOverviewTable extends React.Component {
     if (lastFailureAt != null) {
       nodes.push(
         <p className="flush-bottom" key="tooltip-failure-at">
-          <span className="text-danger">Last Failure: </span>
+          <Trans render="span" className="text-danger">
+            Last Failure:
+          </Trans>
           {new Date(lastFailureAt).toLocaleString()}
         </p>
       );

--- a/plugins/jobs/src/js/components/__tests__/__snapshots__/Breadcrumbs-test.js.snap
+++ b/plugins/jobs/src/js/components/__tests__/__snapshots__/Breadcrumbs-test.js.snap
@@ -148,7 +148,11 @@ exports[`Breadcrumbs has no path 1`] = `
         onClick={[Function]}
         style={Object {}}
       >
-        Jobs
+        <span
+          className={undefined}
+        >
+          Jobs
+        </span>
       </a>
     </div>
   </div>
@@ -224,7 +228,11 @@ exports[`Breadcrumbs has no props at all 1`] = `
         onClick={[Function]}
         style={Object {}}
       >
-        Jobs
+        <span
+          className={undefined}
+        >
+          Jobs
+        </span>
       </a>
     </div>
   </div>
@@ -272,7 +280,11 @@ exports[`Breadcrumbs has path but no name 1`] = `
         onClick={[Function]}
         style={Object {}}
       >
-        Jobs
+        <span
+          className={undefined}
+        >
+          Jobs
+        </span>
       </a>
     </div>
   </div>

--- a/plugins/jobs/src/js/components/__tests__/__snapshots__/Breadcrumbs-test.js.snap
+++ b/plugins/jobs/src/js/components/__tests__/__snapshots__/Breadcrumbs-test.js.snap
@@ -148,11 +148,7 @@ exports[`Breadcrumbs has no path 1`] = `
         onClick={[Function]}
         style={Object {}}
       >
-        <span
-          className={undefined}
-        >
-          Jobs
-        </span>
+        Jobs
       </a>
     </div>
   </div>
@@ -228,11 +224,7 @@ exports[`Breadcrumbs has no props at all 1`] = `
         onClick={[Function]}
         style={Object {}}
       >
-        <span
-          className={undefined}
-        >
-          Jobs
-        </span>
+        Jobs
       </a>
     </div>
   </div>
@@ -280,11 +272,7 @@ exports[`Breadcrumbs has path but no name 1`] = `
         onClick={[Function]}
         style={Object {}}
       >
-        <span
-          className={undefined}
-        >
-          Jobs
-        </span>
+        Jobs
       </a>
     </div>
   </div>

--- a/plugins/jobs/src/js/pages/JobConfiguration.js
+++ b/plugins/jobs/src/js/pages/JobConfiguration.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import PropTypes from "prop-types";
 import React from "react";
 
@@ -11,29 +12,43 @@ import HashMapDisplay from "#SRC/js/components/HashMapDisplay";
 
 const GeneralSection = ({ id, description, cpus, mem, disk, command }) => (
   <ConfigurationMapSection>
-    <ConfigurationMapHeading>General</ConfigurationMapHeading>
+    <ConfigurationMapHeading>
+      <Trans>General</Trans>
+    </ConfigurationMapHeading>
     <ConfigurationMapRow>
-      <ConfigurationMapLabel>ID</ConfigurationMapLabel>
+      <ConfigurationMapLabel>
+        <Trans>ID</Trans>
+      </ConfigurationMapLabel>
       <ConfigurationMapValue>{id}</ConfigurationMapValue>
     </ConfigurationMapRow>
     <ConfigurationMapRow>
-      <ConfigurationMapLabel>Description</ConfigurationMapLabel>
+      <ConfigurationMapLabel>
+        <Trans>Description</Trans>
+      </ConfigurationMapLabel>
       <ConfigurationMapValue>{description}</ConfigurationMapValue>
     </ConfigurationMapRow>
     <ConfigurationMapRow>
-      <ConfigurationMapLabel>CPUs</ConfigurationMapLabel>
+      <ConfigurationMapLabel>
+        <Trans>CPUs</Trans>
+      </ConfigurationMapLabel>
       <ConfigurationMapValue>{cpus}</ConfigurationMapValue>
     </ConfigurationMapRow>
     <ConfigurationMapRow>
-      <ConfigurationMapLabel>Memory (MiB)</ConfigurationMapLabel>
+      <ConfigurationMapLabel>
+        <Trans>Memory (MiB)</Trans>
+      </ConfigurationMapLabel>
       <ConfigurationMapValue>{mem}</ConfigurationMapValue>
     </ConfigurationMapRow>
     <ConfigurationMapRow>
-      <ConfigurationMapLabel>Disk Space (Mib)</ConfigurationMapLabel>
+      <ConfigurationMapLabel>
+        <Trans>Disk Space (Mib)</Trans>
+      </ConfigurationMapLabel>
       <ConfigurationMapValue>{disk}</ConfigurationMapValue>
     </ConfigurationMapRow>
     <ConfigurationMapRow>
-      <ConfigurationMapLabel>Command</ConfigurationMapLabel>
+      <ConfigurationMapLabel>
+        <Trans>Command</Trans>
+      </ConfigurationMapLabel>
       <ConfigurationMapValue>
         <pre className="flush transparent wrap">{command}</pre>
       </ConfigurationMapValue>
@@ -49,25 +64,37 @@ const ScheduleSection = ({
   startingDeadlineSeconds
 }) => (
   <ConfigurationMapSection>
-    <ConfigurationMapHeading>Schedule</ConfigurationMapHeading>
+    <ConfigurationMapHeading>
+      <Trans>Schedule</Trans>
+    </ConfigurationMapHeading>
     <ConfigurationMapRow>
-      <ConfigurationMapLabel>ID</ConfigurationMapLabel>
+      <ConfigurationMapLabel>
+        <Trans>ID</Trans>
+      </ConfigurationMapLabel>
       <ConfigurationMapValue>{id}</ConfigurationMapValue>
     </ConfigurationMapRow>
     <ConfigurationMapRow>
-      <ConfigurationMapLabel>Enabled</ConfigurationMapLabel>
+      <ConfigurationMapLabel>
+        <Trans>Enabled</Trans>
+      </ConfigurationMapLabel>
       <ConfigurationMapValue>{enabled}</ConfigurationMapValue>
     </ConfigurationMapRow>
     <ConfigurationMapRow>
-      <ConfigurationMapLabel>CRON Schedule</ConfigurationMapLabel>
+      <ConfigurationMapLabel>
+        <Trans>CRON Schedule</Trans>
+      </ConfigurationMapLabel>
       <ConfigurationMapValue>{cron}</ConfigurationMapValue>
     </ConfigurationMapRow>
     <ConfigurationMapRow>
-      <ConfigurationMapLabel>Time Zone</ConfigurationMapLabel>
+      <ConfigurationMapLabel>
+        <Trans>Time Zone</Trans>
+      </ConfigurationMapLabel>
       <ConfigurationMapValue>{timezone}</ConfigurationMapValue>
     </ConfigurationMapRow>
     <ConfigurationMapRow>
-      <ConfigurationMapLabel>Starting Deadline</ConfigurationMapLabel>
+      <ConfigurationMapLabel>
+        <Trans>Starting Deadline</Trans>
+      </ConfigurationMapLabel>
       <ConfigurationMapValue>{startingDeadlineSeconds}</ConfigurationMapValue>
     </ConfigurationMapRow>
   </ConfigurationMapSection>
@@ -75,9 +102,13 @@ const ScheduleSection = ({
 
 const DockerContainerSection = ({ image }) => (
   <ConfigurationMapSection>
-    <ConfigurationMapHeading>Docker Container</ConfigurationMapHeading>
+    <ConfigurationMapHeading>
+      <Trans>Docker Container</Trans>
+    </ConfigurationMapHeading>
     <ConfigurationMapRow>
-      <ConfigurationMapLabel>Image</ConfigurationMapLabel>
+      <ConfigurationMapLabel>
+        <Trans>Image</Trans>
+      </ConfigurationMapLabel>
       <ConfigurationMapValue>{image}</ConfigurationMapValue>
     </ConfigurationMapRow>
   </ConfigurationMapSection>

--- a/plugins/jobs/src/js/pages/JobRunHistoryTable.js
+++ b/plugins/jobs/src/js/pages/JobRunHistoryTable.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import classNames from "classnames";
 import { Link } from "react-router";
 import PropTypes from "prop-types";
@@ -215,7 +216,7 @@ class JobRunHistoryTable extends React.Component {
           className="button button-outline button-danger"
           onClick={this.handleStopClick}
         >
-          Stop
+          <Trans>Stop</Trans>
         </div>
       </div>
     );
@@ -319,7 +320,7 @@ class JobRunHistoryTable extends React.Component {
     const time = row[prop];
 
     if (time == null) {
-      return <div>N/A</div>;
+      return <Trans render="div">N/A</Trans>;
     }
     const runTimeFormat = moment.duration(time).humanize();
 

--- a/plugins/nodes/src/js/components/LeaderGrid.js
+++ b/plugins/nodes/src/js/components/LeaderGrid.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import React from "react";
 import { FormattedMessage } from "react-intl";
 import { ToggleContent } from "@dcos/ui-kit";
@@ -29,7 +30,7 @@ export default function LeaderGrid({ leader }) {
     <div className="container">
       <ConfigurationMap>
         <ConfigurationMapHeading className="flush-top">
-          Leader
+          <Trans render="span">Leader</Trans>
         </ConfigurationMapHeading>
         <ConfigurationMapSection>
           <ConfigurationRow

--- a/plugins/nodes/src/js/components/NodeBreadcrumbs.js
+++ b/plugins/nodes/src/js/components/NodeBreadcrumbs.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import React from "react";
 import { Link } from "react-router";
 
@@ -14,7 +15,7 @@ const NodeBreadcrumbs = ({ nodeID, taskID, taskName, unitID }) => {
     <Breadcrumb key={-1} title="Nodes">
       <BreadcrumbTextContent>
         <Link to="/nodes" key={-1}>
-          Nodes
+          <Trans render="span">Nodes</Trans>
         </Link>
       </BreadcrumbTextContent>
     </Breadcrumb>

--- a/plugins/nodes/src/js/components/NodeBreadcrumbs.js
+++ b/plugins/nodes/src/js/components/NodeBreadcrumbs.js
@@ -14,9 +14,7 @@ const NodeBreadcrumbs = ({ nodeID, taskID, taskName, unitID }) => {
   const crumbs = [
     <Breadcrumb key={-1} title="Nodes">
       <BreadcrumbTextContent>
-        <Link to="/nodes" key={-1}>
-          <Trans render="span">Nodes</Trans>
-        </Link>
+        <Trans render={<Link to="/nodes" key={-1} />}>Nodes</Trans>
       </BreadcrumbTextContent>
     </Breadcrumb>
   ];

--- a/plugins/nodes/src/js/components/NodesGridView.js
+++ b/plugins/nodes/src/js/components/NodesGridView.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import classNames from "classnames";
 import PureRender from "react-addons-pure-render-mixin";
 import PropTypes from "prop-types";
@@ -90,7 +91,7 @@ var NodesGridView = React.createClass({
       items.push(
         <li key="other">
           <span className={classNameOther} />
-          <span>Other</span>
+          <Trans render="span">Other</Trans>
         </li>
       );
     }

--- a/plugins/nodes/src/js/components/NonLeadersGrid.js
+++ b/plugins/nodes/src/js/components/NonLeadersGrid.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import React from "react";
 
 import ConfigurationMap from "#SRC/js/components/ConfigurationMap";
@@ -35,7 +36,9 @@ const NonLeader = ({ master }) => {
 };
 
 const EmptyLeaderList = () => {
-  return <div>There are no more known masters in this cluster.</div>;
+  return (
+    <Trans render="div">There are no more known masters in this cluster.</Trans>
+  );
 };
 
 const NonLeaderList = ({ masters }) => {
@@ -64,7 +67,7 @@ export default function NonLeaderGrid({ masters }) {
     <div className="container">
       <ConfigurationMap>
         <ConfigurationMapHeading className="flush-top">
-          Non-Leaders
+          <Trans render="span">Non-Leaders</Trans>
         </ConfigurationMapHeading>
         {content}
       </ConfigurationMap>

--- a/plugins/nodes/src/js/components/__tests__/__snapshots__/LeaderGrid-test.js.snap
+++ b/plugins/nodes/src/js/components/__tests__/__snapshots__/LeaderGrid-test.js.snap
@@ -10,7 +10,11 @@ exports[`LeaderGrid renders with running status 1`] = `
     <h1
       className="detail-view-section-heading detail-view-section-heading-primary configuration-map-heading flush-top"
     >
-      Leader
+      <span
+        className={undefined}
+      >
+        Leader
+      </span>
     </h1>
     <div
       className="configuration-map-section"

--- a/plugins/nodes/src/js/components/__tests__/__snapshots__/NodeBreadcrumbs-test.js.snap
+++ b/plugins/nodes/src/js/components/__tests__/__snapshots__/NodeBreadcrumbs-test.js.snap
@@ -41,7 +41,11 @@ exports[`NodeBreadcrumbs renders no node breadcrumbs if node cant be found 1`] =
         onClick={[Function]}
         style={Object {}}
       >
-        Nodes
+        <span
+          className={undefined}
+        >
+          Nodes
+        </span>
       </a>
     </div>
   </div>
@@ -89,7 +93,11 @@ exports[`NodeBreadcrumbs renders no unitID breadcrumbs without nodeID 1`] = `
         onClick={[Function]}
         style={Object {}}
       >
-        Nodes
+        <span
+          className={undefined}
+        >
+          Nodes
+        </span>
       </a>
     </div>
   </div>
@@ -137,7 +145,11 @@ exports[`NodeBreadcrumbs renders with node breadcrumbs 1`] = `
         onClick={[Function]}
         style={Object {}}
       >
-        Nodes
+        <span
+          className={undefined}
+        >
+          Nodes
+        </span>
       </a>
     </div>
   </div>
@@ -210,7 +222,11 @@ exports[`NodeBreadcrumbs renders with taskID breadcrumbs 1`] = `
         onClick={[Function]}
         style={Object {}}
       >
-        Nodes
+        <span
+          className={undefined}
+        >
+          Nodes
+        </span>
       </a>
     </div>
   </div>
@@ -283,7 +299,11 @@ exports[`NodeBreadcrumbs renders with unitID breadcrumbs 1`] = `
         onClick={[Function]}
         style={Object {}}
       >
-        Nodes
+        <span
+          className={undefined}
+        >
+          Nodes
+        </span>
       </a>
     </div>
   </div>
@@ -388,7 +408,11 @@ exports[`NodeBreadcrumbs renders without breadcrumbs 1`] = `
         onClick={[Function]}
         style={Object {}}
       >
-        Nodes
+        <span
+          className={undefined}
+        >
+          Nodes
+        </span>
       </a>
     </div>
   </div>

--- a/plugins/nodes/src/js/components/__tests__/__snapshots__/NodeBreadcrumbs-test.js.snap
+++ b/plugins/nodes/src/js/components/__tests__/__snapshots__/NodeBreadcrumbs-test.js.snap
@@ -41,11 +41,7 @@ exports[`NodeBreadcrumbs renders no node breadcrumbs if node cant be found 1`] =
         onClick={[Function]}
         style={Object {}}
       >
-        <span
-          className={undefined}
-        >
-          Nodes
-        </span>
+        Nodes
       </a>
     </div>
   </div>
@@ -93,11 +89,7 @@ exports[`NodeBreadcrumbs renders no unitID breadcrumbs without nodeID 1`] = `
         onClick={[Function]}
         style={Object {}}
       >
-        <span
-          className={undefined}
-        >
-          Nodes
-        </span>
+        Nodes
       </a>
     </div>
   </div>
@@ -145,11 +137,7 @@ exports[`NodeBreadcrumbs renders with node breadcrumbs 1`] = `
         onClick={[Function]}
         style={Object {}}
       >
-        <span
-          className={undefined}
-        >
-          Nodes
-        </span>
+        Nodes
       </a>
     </div>
   </div>
@@ -222,11 +210,7 @@ exports[`NodeBreadcrumbs renders with taskID breadcrumbs 1`] = `
         onClick={[Function]}
         style={Object {}}
       >
-        <span
-          className={undefined}
-        >
-          Nodes
-        </span>
+        Nodes
       </a>
     </div>
   </div>
@@ -299,11 +283,7 @@ exports[`NodeBreadcrumbs renders with unitID breadcrumbs 1`] = `
         onClick={[Function]}
         style={Object {}}
       >
-        <span
-          className={undefined}
-        >
-          Nodes
-        </span>
+        Nodes
       </a>
     </div>
   </div>
@@ -408,11 +388,7 @@ exports[`NodeBreadcrumbs renders without breadcrumbs 1`] = `
         onClick={[Function]}
         style={Object {}}
       >
-        <span
-          className={undefined}
-        >
-          Nodes
-        </span>
+        Nodes
       </a>
     </div>
   </div>

--- a/plugins/nodes/src/js/components/__tests__/__snapshots__/NonLeaderGrid-test.js.snap
+++ b/plugins/nodes/src/js/components/__tests__/__snapshots__/NonLeaderGrid-test.js.snap
@@ -10,9 +10,15 @@ exports[`LeaderGrid renders empty 1`] = `
     <h1
       className="detail-view-section-heading detail-view-section-heading-primary configuration-map-heading flush-top"
     >
-      Non-Leaders
+      <span
+        className={undefined}
+      >
+        Non-Leaders
+      </span>
     </h1>
-    <div>
+    <div
+      className={undefined}
+    >
       There are no more known masters in this cluster.
     </div>
   </div>
@@ -29,7 +35,11 @@ exports[`LeaderGrid renders loading 1`] = `
     <h1
       className="detail-view-section-heading detail-view-section-heading-primary configuration-map-heading flush-top"
     >
-      Non-Leaders
+      <span
+        className={undefined}
+      >
+        Non-Leaders
+      </span>
     </h1>
     <div
       className="loader horizontal-center"
@@ -62,7 +72,11 @@ exports[`LeaderGrid renders masters 1`] = `
     <h1
       className="detail-view-section-heading detail-view-section-heading-primary configuration-map-heading flush-top"
     >
-      Non-Leaders
+      <span
+        className={undefined}
+      >
+        Non-Leaders
+      </span>
     </h1>
     <div
       className="configuration-map-section"

--- a/plugins/nodes/src/js/data/__tests__/__snapshots__/MesosMasters-test.js.snap
+++ b/plugins/nodes/src/js/data/__tests__/__snapshots__/MesosMasters-test.js.snap
@@ -11,7 +11,11 @@ exports[`LeaderGrid renders with running status 1`] = `
       <h1
         className="detail-view-section-heading detail-view-section-heading-primary configuration-map-heading flush-top"
       >
-        Leader
+        <span
+          className={undefined}
+        >
+          Leader
+        </span>
       </h1>
       <div
         className="configuration-map-section"

--- a/plugins/nodes/src/js/data/__tests__/__snapshots__/MesosMasters-test.js.snap
+++ b/plugins/nodes/src/js/data/__tests__/__snapshots__/MesosMasters-test.js.snap
@@ -124,7 +124,11 @@ exports[`LeaderGrid renders with running status 1`] = `
       <h1
         className="detail-view-section-heading detail-view-section-heading-primary configuration-map-heading flush-top"
       >
-        Non-Leaders
+        <span
+          className={undefined}
+        >
+          Non-Leaders
+        </span>
       </h1>
       <div
         className="configuration-map-section"

--- a/plugins/nodes/src/js/pages/NodesAgents.js
+++ b/plugins/nodes/src/js/pages/NodesAgents.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import classNames from "classnames";
 import React from "react";
 import { Link, routerShape } from "react-router";
@@ -220,7 +221,9 @@ var NodesAgents = React.createClass({
     return (
       <div className="flush-bottom">
         <Link className={listClassSet} onClick={resetFilter} to="/nodes/agents">
-          <span className="invisible">List</span>
+          <Trans render="span" className="invisible">
+            List
+          </Trans>
           <Icon family="system" id="list" size="mini" />
         </Link>
         <Link
@@ -228,7 +231,9 @@ var NodesAgents = React.createClass({
           onClick={resetFilter}
           to="/nodes/agents/grid"
         >
-          <span className="invisible">Grid</span>
+          <Trans render="span" className="invisible">
+            Grid
+          </Trans>
           <Icon family="system" id="donut" size="mini" />
         </Link>
       </div>
@@ -292,11 +297,13 @@ var NodesAgents = React.createClass({
     return (
       <Page>
         <AlertPanel>
-          <AlertPanelHeader>No nodes detected</AlertPanelHeader>
-          <p className="flush-bottom">
+          <AlertPanelHeader>
+            <Trans render="span">No nodes detected</Trans>
+          </AlertPanelHeader>
+          <Trans render="p" className="flush-bottom">
             There a currently no other nodes in your datacenter other than your
             DC/OS master node.
-          </p>
+          </Trans>
         </AlertPanel>
       </Page>
     );

--- a/plugins/nodes/src/js/pages/nodes/NodeDetailPage.js
+++ b/plugins/nodes/src/js/pages/nodes/NodeDetailPage.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import mixin from "reactjs-mixin";
 /* eslint-disable no-unused-vars */
 import React from "react";
@@ -123,8 +124,12 @@ class NodeDetailPage extends mixin(TabsMixin, StoreMixin) {
       <Page>
         <Page.Header breadcrumbs={<NodeBreadcrumbs />} />
         <div className="pod text-align-center">
-          <h3 className="flush-top text-align-center">Error finding node</h3>
-          <p className="flush">{`Did not find a node by the id "${nodeID}"`}</p>
+          <Trans render="h3" className="flush-top text-align-center">
+            Error finding node
+          </Trans>
+          <Trans render="p" className="flush">
+            Did not find a node by the id "{nodeID}"
+          </Trans>
         </div>
       </Page>
     );

--- a/plugins/nodes/src/js/pages/nodes/NodeDetailTab.js
+++ b/plugins/nodes/src/js/pages/nodes/NodeDetailTab.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import { request } from "@dcos/mesos-client";
@@ -65,29 +66,39 @@ class NodeDetailTab extends PureComponent {
         <ConfigurationMap>
           <ConfigurationMapSection>
             <ConfigurationMapRow>
-              <ConfigurationMapLabel>ID</ConfigurationMapLabel>
+              <ConfigurationMapLabel>
+                <Trans render="span">ID</Trans>
+              </ConfigurationMapLabel>
               <ConfigurationMapValue>{node.id}</ConfigurationMapValue>
             </ConfigurationMapRow>
             <ConfigurationMapRow>
-              <ConfigurationMapLabel>Active</ConfigurationMapLabel>
+              <ConfigurationMapLabel>
+                <Trans render="span">Active</Trans>
+              </ConfigurationMapLabel>
               <ConfigurationMapValue>
                 {StringUtil.capitalize(node.active.toString().toLowerCase())}
               </ConfigurationMapValue>
             </ConfigurationMapRow>
             <ConfigurationMapRow>
-              <ConfigurationMapLabel>Registered</ConfigurationMapLabel>
+              <ConfigurationMapLabel>
+                <Trans render="span">Registered</Trans>
+              </ConfigurationMapLabel>
               <ConfigurationMapValue>
                 {DateUtil.msToDateStr(node.registered_time.toFixed(3) * 1000)}
               </ConfigurationMapValue>
             </ConfigurationMapRow>
             <ConfigurationMapRow>
-              <ConfigurationMapLabel>Master Version</ConfigurationMapLabel>
+              <ConfigurationMapLabel>
+                <Trans render="span">Master Version</Trans>
+              </ConfigurationMapLabel>
               <ConfigurationMapValue>
                 {this.state.version || <Loader size="small" type="ballBeat" />}
               </ConfigurationMapValue>
             </ConfigurationMapRow>
             <ConfigurationMapRow>
-              <ConfigurationMapLabel>Region</ConfigurationMapLabel>
+              <ConfigurationMapLabel>
+                <Trans render="span">Region</Trans>
+              </ConfigurationMapLabel>
               <ConfigurationMapValue>
                 {node.getRegionName()}
                 {this.state.masterRegion === node.getRegionName()
@@ -96,7 +107,9 @@ class NodeDetailTab extends PureComponent {
               </ConfigurationMapValue>
             </ConfigurationMapRow>
             <ConfigurationMapRow>
-              <ConfigurationMapLabel>Zone</ConfigurationMapLabel>
+              <ConfigurationMapLabel>
+                <Trans render="span">Zone</Trans>
+              </ConfigurationMapLabel>
               <ConfigurationMapValue>
                 {node.getZoneName()}
               </ConfigurationMapValue>
@@ -104,21 +117,29 @@ class NodeDetailTab extends PureComponent {
           </ConfigurationMapSection>
           <HashMapDisplay hash={node.attributes} headline="Attributes" />
           <ConfigurationMapSection>
-            <ConfigurationMapHeading>Resources</ConfigurationMapHeading>
+            <ConfigurationMapHeading>
+              <Trans render="span">Resources</Trans>
+            </ConfigurationMapHeading>
             <ConfigurationMapRow>
-              <ConfigurationMapLabel>Disk</ConfigurationMapLabel>
+              <ConfigurationMapLabel>
+                <Trans render="span">Disk</Trans>
+              </ConfigurationMapLabel>
               <ConfigurationMapValue>
                 {Units.formatResource("disk", resources.disk)}
               </ConfigurationMapValue>
             </ConfigurationMapRow>
             <ConfigurationMapRow>
-              <ConfigurationMapLabel>Mem</ConfigurationMapLabel>
+              <ConfigurationMapLabel>
+                <Trans render="span">Mem</Trans>
+              </ConfigurationMapLabel>
               <ConfigurationMapValue>
                 {Units.formatResource("mem", resources.mem)}
               </ConfigurationMapValue>
             </ConfigurationMapRow>
             <ConfigurationMapRow>
-              <ConfigurationMapLabel>CPUs</ConfigurationMapLabel>
+              <ConfigurationMapLabel>
+                <Trans render="span">CPUs</Trans>
+              </ConfigurationMapLabel>
               <ConfigurationMapValue>
                 {Units.formatResource("cpus", resources.cpus)}
               </ConfigurationMapValue>

--- a/plugins/oauth/components/LoginPage.js
+++ b/plugins/oauth/components/LoginPage.js
@@ -105,7 +105,7 @@ class LoginPage extends mixin(StoreMixin) {
         </div>
         <Modal
           onClose={this.handleModalClose}
-          open={true}
+          open={this.state.showClusterError}
           showCloseButton={true}
           showHeader={false}
           showFooter={false}

--- a/plugins/oauth/components/LoginPage.js
+++ b/plugins/oauth/components/LoginPage.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import React from "react";
 import { routerShape } from "react-router";
 import mixin from "reactjs-mixin";
@@ -104,23 +105,25 @@ class LoginPage extends mixin(StoreMixin) {
         </div>
         <Modal
           onClose={this.handleModalClose}
-          open={this.state.showClusterError}
+          open={true}
           showCloseButton={true}
           showHeader={false}
           showFooter={false}
         >
-          <p className="text-align-center">
+          <Trans render="p" className="text-align-center">
             Unable to login to your DC/OS cluster. Clusters must be connected to
             the internet.
-          </p>
+          </Trans>
           <p className="flush-bottom text-align-center">
-            {"Please contact your system administrator or see the "}
-            <a
-              href={MetadataStore.buildDocsURI("/installing/")}
-              target="_blank"
-            >
-              documentation
-            </a>.
+            <Trans>
+              Please contact your system administrator or see the{" "}
+              <a
+                href={MetadataStore.buildDocsURI("/installing/")}
+                target="_blank"
+              >
+                documentation
+              </a>.
+            </Trans>
           </p>
         </Modal>
       </div>

--- a/plugins/services/src/js/pages/task-details/TaskDetailsTab.js
+++ b/plugins/services/src/js/pages/task-details/TaskDetailsTab.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import PropTypes from "prop-types";
 import React from "react";
 
@@ -27,7 +28,7 @@ class TaskDetailsTab extends React.Component {
     return (
       <ConfigurationMapSection>
         <ConfigurationMapHeading>
-          Container Configuration
+          <Trans>Container Configuration</Trans>
         </ConfigurationMapHeading>
         <ConfigurationMapRow>
           <pre className="flex-item-grow-1 mute prettyprint flush-bottom">
@@ -78,7 +79,9 @@ class TaskDetailsTab extends React.Component {
     if (service != null) {
       serviceRow = (
         <ConfigurationMapRow>
-          <ConfigurationMapLabel>Service</ConfigurationMapLabel>
+          <ConfigurationMapLabel>
+            <Trans>Service</Trans>
+          </ConfigurationMapLabel>
           <ConfigurationMapValue>
             {service.name} ({service.id})
           </ConfigurationMapValue>
@@ -89,7 +92,9 @@ class TaskDetailsTab extends React.Component {
     if (node != null) {
       nodeRow = (
         <ConfigurationMapRow>
-          <ConfigurationMapLabel>Node</ConfigurationMapLabel>
+          <ConfigurationMapLabel>
+            <Trans>Node</Trans>
+          </ConfigurationMapLabel>
           <ConfigurationMapValue>
             {node.getHostName()} ({node.getID()})
           </ConfigurationMapValue>
@@ -100,7 +105,9 @@ class TaskDetailsTab extends React.Component {
     if (sandBoxPath) {
       sandBoxRow = (
         <ConfigurationMapRow>
-          <ConfigurationMapLabel>Sandbox Path</ConfigurationMapLabel>
+          <ConfigurationMapLabel>
+            <Trans>Sandbox Path</Trans>
+          </ConfigurationMapLabel>
           <ConfigurationMapValue>{sandBoxPath}</ConfigurationMapValue>
         </ConfigurationMapRow>
       );
@@ -108,9 +115,13 @@ class TaskDetailsTab extends React.Component {
 
     return (
       <ConfigurationMapSection>
-        <ConfigurationMapHeading>Configuration</ConfigurationMapHeading>
+        <ConfigurationMapHeading>
+          <Trans>Configuration</Trans>
+        </ConfigurationMapHeading>
         <ConfigurationMapRow>
-          <ConfigurationMapLabel>Task ID</ConfigurationMapLabel>
+          <ConfigurationMapLabel>
+            <Trans>Task ID</Trans>
+          </ConfigurationMapLabel>
           <ConfigurationMapValue>{mesosTask.id}</ConfigurationMapValue>
         </ConfigurationMapRow>
         {serviceRow}
@@ -119,13 +130,17 @@ class TaskDetailsTab extends React.Component {
         <TaskIpAddressesRow taskId={mesosTask.id} />
         {resourceRows}
         <ConfigurationMapRow>
-          <ConfigurationMapLabel>Zone</ConfigurationMapLabel>
+          <ConfigurationMapLabel>
+            <Trans>Zone</Trans>
+          </ConfigurationMapLabel>
           <ConfigurationMapValue>
             {TaskUtil.getZoneName(mesosTask)}
           </ConfigurationMapValue>
         </ConfigurationMapRow>
         <ConfigurationMapRow>
-          <ConfigurationMapLabel>Region</ConfigurationMapLabel>
+          <ConfigurationMapLabel>
+            <Trans>Region</Trans>
+          </ConfigurationMapLabel>
           <ConfigurationMapValue>
             {TaskUtil.getRegionName(mesosTask)}
           </ConfigurationMapValue>
@@ -154,7 +169,9 @@ class TaskDetailsTab extends React.Component {
 
     return (
       <ConfigurationMapSection>
-        <ConfigurationMapHeading>Labels</ConfigurationMapHeading>
+        <ConfigurationMapHeading>
+          <Trans>Labels</Trans>
+        </ConfigurationMapHeading>
         {labelRows}
       </ConfigurationMapSection>
     );

--- a/plugins/services/src/js/pages/task-details/TaskIpAddressesRow.js
+++ b/plugins/services/src/js/pages/task-details/TaskIpAddressesRow.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import React from "react";
 import PropTypes from "prop-types";
 
@@ -36,7 +37,9 @@ export default class TaskIpAddressesRow extends React.Component {
 
     return (
       <ConfigurationMapRow>
-        <ConfigurationMapLabel>IP Addresses</ConfigurationMapLabel>
+        <ConfigurationMapLabel>
+          <Trans render="span">IP Addresses</Trans>
+        </ConfigurationMapLabel>
         <ConfigurationMapValue>
           {this.getIPAddressesForTask(service, taskId).join(", ")}
         </ConfigurationMapValue>

--- a/plugins/services/src/js/pages/task-details/__tests__/__snapshots__/TaskIpAddressesRow-test.js.snap
+++ b/plugins/services/src/js/pages/task-details/__tests__/__snapshots__/TaskIpAddressesRow-test.js.snap
@@ -7,7 +7,11 @@ exports[`TaskIpAddressesRow with a Pod renders IP Addresses 1`] = `
   <div
     className="configuration-map-label"
   >
-    IP Addresses
+    <span
+      className={undefined}
+    >
+      IP Addresses
+    </span>
   </div>
   <div
     className="configuration-map-value"
@@ -24,7 +28,11 @@ exports[`TaskIpAddressesRow with an Application renders IP Addresses 1`] = `
   <div
     className="configuration-map-label"
   >
-    IP Addresses
+    <span
+      className={undefined}
+    >
+      IP Addresses
+    </span>
   </div>
   <div
     className="configuration-map-value"

--- a/src/typings/lingui.d.ts
+++ b/src/typings/lingui.d.ts
@@ -1,0 +1,1 @@
+declare module "@lingui/macro";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "ESNext",
     "lib": ["es5", "es6", "esnext", "dom"],
     "allowJs": false,
-    "jsx": "react",
+    "jsx": "preserve",
     "sourceMap": true,
     "strict": true,
     "noImplicitAny": true,

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -89,6 +89,9 @@ module.exports = {
             loader: "thread-loader"
           },
           {
+            loader: "babel-loader"
+          },
+          {
             loader: "ts-loader",
             options: {
               happyPackMode: true


### PR DESCRIPTION
Use `Trans` macro from `@lingui/macro` to wrap text content in `/plugins` folder. All plugin components included except `/services/components` which will be added to this PR or in a separate PR by @TattdCodeMonkey. 

Adds configuration to enable use of macros in typescript files.

## Testing

There should be no visible difference when using any of the functionality that comes from the `/plugins` folder. The purpose of this PR is to localize text content that can be wrapped in the `Trans` macro from `@lingui/macro`.
