### PR TITLE
DCOS-41626: Remove black screen transition

### DIFF
--- a/src/js/pages/catalog/DeployFrameworkConfiguration.js
+++ b/src/js/pages/catalog/DeployFrameworkConfiguration.js
@@ -9,6 +9,7 @@ import CosmosPackagesStore from "#SRC/js/stores/CosmosPackagesStore";
 import FrameworkConfiguration from "#SRC/js/components/FrameworkConfiguration";
 import Loader from "#SRC/js/components/Loader";
 import RequestErrorMsg from "#SRC/js/components/RequestErrorMsg";
+import Page from "#SRC/js/components/Page";
 import { getDefaultFormState } from "react-jsonschema-form/lib/utils";
 
 const METHODS_TO_BIND = [
@@ -120,7 +121,11 @@ class DeployFrameworkConfiguration extends mixin(StoreMixin) {
     } = this.state;
 
     if (packageDetails == null) {
-      return <Loader className="vertical-center" />;
+      return (
+        <Page>
+          <Loader className="vertical-center" />
+        </Page>
+      );
     }
 
     if (hasError) {


### PR DESCRIPTION
Remove black screen transition when loading form after clicking Review & Run from catalog. Used same loader from Catalog and other pages.

Closes DCOS-41626.

## Testing

Go to Catalog > Any package > click Review & Run. There should be no partial black screen when loading form.

## Trade-offs

None I'm aware of.

## Screenshots

Before:
![before](https://user-images.githubusercontent.com/19582796/46771100-ef866580-cca6-11e8-8a71-3a2911ac090e.gif)

After:
![after](https://user-images.githubusercontent.com/19582796/46771110-fc0abe00-cca6-11e8-96cb-7b322bcf436a.gif)

Catalog loader (for comparison):
![catalogloader](https://user-images.githubusercontent.com/19582796/46771116-07f68000-cca7-11e8-9fe5-90003eb9c524.gif)

