### PR TITLE
DCOS-43371: mark strings in src/js/constants files for translation

### DIFF
--- a/.linguirc
+++ b/.linguirc
@@ -13,6 +13,7 @@
       "node_modules/",
       "/__tests__/",
       "/reducers/",
+      "js/config",
       "js/core",
       "js/events",
       "js/routes",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -807,12 +807,12 @@
       ]
     ]
   },
-  "Caches recent cluster history in-memory so that the": {
+  "Caches recent cluster history in-memory so that the {0} web interface can show recent data": {
     "translation": "",
     "origin": [
       [
         "src/js/constants/UnitSummaries.js",
-        66
+        70
       ]
     ]
   },
@@ -1747,12 +1747,12 @@
       ]
     ]
   },
-  "Downloads and extracts the": {
+  "Downloads and extracts the {0} bootstrap tarball into /opt/mesosphere on your nodes.": {
     "translation": "",
     "origin": [
       [
         "src/js/constants/UnitSummaries.js",
-        98
+        103
       ]
     ]
   },
@@ -2975,7 +2975,7 @@
     "origin": [
       [
         "src/js/constants/UnitSummaries.js",
-        76
+        81
       ]
     ]
   },
@@ -3001,21 +3001,21 @@
       ]
     ]
   },
-  "Makes vendored": {
+  "Makes vendored {0} binaries, such as the mesos-master, mesos-slave, available at the command line when SSHing to a host.": {
     "translation": "",
     "origin": [
       [
         "src/js/constants/UnitSummaries.js",
-        86
+        92
       ]
     ]
   },
-  "Manages": {
+  "Manages {0} in-cluster Zookeeper, used by Mesos as well as {1} Marathon.": {
     "translation": "",
     "origin": [
       [
         "src/js/constants/UnitSummaries.js",
-        54
+        59
       ]
     ]
   },
@@ -3025,24 +3025,6 @@
       [
         "plugins/services/src/js/components/MarathonTaskDetailsList.js",
         53
-      ]
-    ]
-  },
-  "Marathon instance starts and monitors": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/constants/UnitSummaries.js",
-        10
-      ]
-    ]
-  },
-  "Marathon.": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/constants/UnitSummaries.js",
-        58
       ]
     ]
   },
@@ -3156,7 +3138,7 @@
     "origin": [
       [
         "src/js/constants/UnitSummaries.js",
-        20
+        23
       ]
     ]
   },
@@ -3166,15 +3148,6 @@
       [
         "plugins/services/src/js/constants/VolumeDefinitions.js",
         36
-      ]
-    ]
-  },
-  "Mesosphere DC/OS": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/config/Config.ts",
-        22
       ]
     ]
   },
@@ -3949,7 +3922,7 @@
     "origin": [
       [
         "src/js/constants/UnitSummaries.js",
-        198
+        205
       ]
     ]
   },
@@ -4084,7 +4057,7 @@
     "origin": [
       [
         "src/js/constants/UnitSummaries.js",
-        126
+        133
       ]
     ]
   },
@@ -4301,7 +4274,7 @@
     "origin": [
       [
         "src/js/constants/UnitSummaries.js",
-        136
+        144
       ]
     ]
   },
@@ -4355,7 +4328,7 @@
     "origin": [
       [
         "src/js/constants/UnitSummaries.js",
-        108
+        114
       ]
     ]
   },
@@ -4455,7 +4428,7 @@
     "origin": [
       [
         "src/js/constants/UnitSummaries.js",
-        167
+        175
       ]
     ]
   },
@@ -4464,7 +4437,7 @@
     "origin": [
       [
         "src/js/constants/UnitSummaries.js",
-        207
+        215
       ]
     ]
   },
@@ -4473,16 +4446,16 @@
     "origin": [
       [
         "src/js/constants/UnitSummaries.js",
-        174
+        182
       ]
     ]
   },
-  "Runs the": {
+  "Runs the {0} web interface, as well as a reverse proxy so that administrative interfaces of {1} Service can be accessed from outside the cluster.": {
     "translation": "",
     "origin": [
       [
         "src/js/constants/UnitSummaries.js",
-        184
+        193
       ]
     ]
   },
@@ -4676,12 +4649,12 @@
       ]
     ]
   },
-  "Sends a periodic ping back to Mesosphere with high-level cluster information to help improve": {
+  "Sends a periodic ping back to Mesosphere with high-level cluster information to help improve {0}, and provides advance monitoring of cluster issues.": {
     "translation": "",
     "origin": [
       [
         "src/js/constants/UnitSummaries.js",
-        34
+        37
       ]
     ]
   },
@@ -4781,15 +4754,6 @@
       [
         "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
         6
-      ]
-    ]
-  },
-  "Service can be accessed from outside the cluster.": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/constants/UnitSummaries.js",
-        190
       ]
     ]
   },
@@ -4903,7 +4867,7 @@
     "origin": [
       [
         "src/js/constants/UnitSummaries.js",
-        146
+        155
       ]
     ]
   },
@@ -4912,7 +4876,7 @@
     "origin": [
       [
         "src/js/constants/UnitSummaries.js",
-        46
+        49
       ]
     ]
   },
@@ -4921,7 +4885,7 @@
     "origin": [
       [
         "src/js/constants/UnitSummaries.js",
-        118
+        125
       ]
     ]
   },
@@ -4965,12 +4929,12 @@
       ]
     ]
   },
-  "Specializes the": {
+  "Specializes the {0} bootstrap tarball for the particular cluster, as well as its cluster role.": {
     "translation": "",
     "origin": [
       [
         "src/js/constants/UnitSummaries.js",
-        156
+        165
       ]
     ]
   },
@@ -5255,7 +5219,7 @@
     "origin": [
       [
         "src/js/constants/UnitSummaries.js",
-        27
+        30
       ]
     ]
   },
@@ -5350,6 +5314,15 @@
       [
         "plugins/services/src/js/constants/OperatorTypes.js",
         11
+      ]
+    ]
+  },
+  "The {0} Marathon instance starts and monitors {1} applications and services.": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/constants/UnitSummaries.js",
+        12
       ]
     ]
   },
@@ -6135,51 +6108,6 @@
       ]
     ]
   },
-  "and provides advance monitoring of cluster issues.": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/constants/UnitSummaries.js",
-        38
-      ]
-    ]
-  },
-  "applications and services.": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/constants/UnitSummaries.js",
-        12
-      ]
-    ]
-  },
-  "binaries, such as the mesos-master, mesos-slave, available at the command line when SSHing to a host.": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/constants/UnitSummaries.js",
-        88
-      ]
-    ]
-  },
-  "bootstrap tarball for the particular cluster, as well as its cluster role.": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/constants/UnitSummaries.js",
-        158
-      ]
-    ]
-  },
-  "bootstrap tarball into /opt/mesosphere on your nodes.": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/constants/UnitSummaries.js",
-        100
-      ]
-    ]
-  },
   "documentation": {
     "translation": "",
     "origin": [
@@ -6189,39 +6117,12 @@
       ]
     ]
   },
-  "in-cluster Zookeeper, used by Mesos as well as": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/constants/UnitSummaries.js",
-        56
-      ]
-    ]
-  },
   "or": {
     "translation": "",
     "origin": [
       [
         ".dcos-ui-plugins-private/auth-providers/components/LoginModalProviders.js",
         113
-      ]
-    ]
-  },
-  "web interface can show recent data": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/constants/UnitSummaries.js",
-        68
-      ]
-    ]
-  },
-  "web interface, as well as a reverse proxy so that administrative interfaces of": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/constants/UnitSummaries.js",
-        186
       ]
     ]
   },

--- a/src/js/components/UnitsHealthNodeDetail.js
+++ b/src/js/components/UnitsHealthNodeDetail.js
@@ -3,7 +3,6 @@ import mixin from "reactjs-mixin";
 import React from "react";
 /* eslint-enable no-unused-vars */
 import { StoreMixin } from "mesosphere-shared-reactjs";
-import { Trans } from "@lingui/macro";
 
 import Loader from "./Loader";
 import RequestErrorMsg from "./RequestErrorMsg";
@@ -85,11 +84,6 @@ class UnitsHealthNodeDetail extends mixin(StoreMixin) {
     const unitSummary = UnitSummaries[unit.get("id")] || {};
     const unitDocsURL =
       unitSummary.getDocumentationURI && unitSummary.getDocumentationURI();
-    const joinedUnitSummary = unitSummary.summary
-      .map((sumPiece, i) => (
-        <Trans key={sumPiece + i} render="span" id={sumPiece} />
-      ))
-      .reduce((prev, curr) => [...prev, " ", curr], []);
 
     return (
       <UnitsHealthNodeDetailPanel
@@ -98,7 +92,7 @@ class UnitsHealthNodeDetail extends mixin(StoreMixin) {
         docsURL={unitDocsURL}
         hostIP={node.get("host_ip")}
         output={node.getOutput()}
-        summary={joinedUnitSummary}
+        summary={unitSummary.summary}
       />
     );
   }

--- a/src/js/config/Config.ts
+++ b/src/js/config/Config.ts
@@ -1,5 +1,5 @@
 /* eslint no-redeclare: 0 */
-import { i18nMark } from "@lingui/react";
+
 import ConfigDev from "./Config.dev";
 import ConfigTest from "./Config.test";
 
@@ -56,7 +56,7 @@ let Config: IConfiguration = {
   fullProductName: "Mesosphere DC/OS",
   marathonAPIPrefix: "/service/marathon/v2",
   metronomeAPI: "/service/metronome",
-  productName: i18nMark("Mesosphere DC/OS"),
+  productName: "Mesosphere DC/OS",
   productHomepageURI: "https://dcos.io",
   setInactiveAfter: 30000,
   testHistoryInterval: 10000,

--- a/src/js/constants/UnitSummaries.js
+++ b/src/js/constants/UnitSummaries.js
@@ -1,210 +1,218 @@
-import { i18nMark } from "@lingui/react";
+/* eslint-disable no-unused-vars */
+import React from "react";
+/* eslint-enable no-unused-vars */
+
+import { Trans } from "@lingui/macro";
 import Config from "../config/Config";
 import MetadataStore from "../stores/MetadataStore";
 
 const UnitSummaries = {
   "dcos-marathon.service": {
-    summary: [
-      i18nMark(`The`),
-      Config.productName,
-      i18nMark("Marathon instance starts and monitors"),
-      Config.productName,
-      i18nMark("applications and services.")
-    ],
+    summary: (
+      <Trans>
+        The {Config.productName} Marathon instance starts and monitors{" "}
+        {Config.productName} applications and services.
+      </Trans>
+    ),
     getDocumentationURI() {
       return MetadataStore.buildDocsURI("/overview/architecture/components/");
     }
   },
   "dcos-mesos-dns.service": {
-    summary: [
-      i18nMark("Mesos DNS provides service discovery within the cluster.")
-    ],
+    summary: (
+      <Trans>Mesos DNS provides service discovery within the cluster.</Trans>
+    ),
     getDocumentationURI() {
       return MetadataStore.buildDocsURI("/overview/architecture/components/");
     }
   },
   "dcos-mesos-master.service": {
-    summary: i18nMark("The Mesos master process orchestrates agent tasks."),
+    summary: <Trans>The Mesos master process orchestrates agent tasks.</Trans>,
     getDocumentationURI() {
       return MetadataStore.buildDocsURI("/installing/ent/");
     }
   },
   "dcos-signal.service": {
-    summary: [
-      i18nMark(
-        "Sends a periodic ping back to Mesosphere with high-level cluster information to help improve"
-      ),
-      Config.productName,
-      i18nMark("and provides advance monitoring of cluster issues.")
-    ],
+    summary: (
+      <Trans>
+        Sends a periodic ping back to Mesosphere with high-level cluster
+        information to help improve {Config.productName}, and provides advance
+        monitoring of cluster issues.
+      </Trans>
+    ),
     getDocumentationURI() {
       return MetadataStore.buildDocsURI("/");
     }
   },
   "dcos-gen-resolvconf.timer": {
-    summary: [
-      i18nMark("Sets the dcos-gen-resolvconf.service to be run once a minute.")
-    ],
+    summary: (
+      <Trans>
+        Sets the dcos-gen-resolvconf.service to be run once a minute.
+      </Trans>
+    ),
     getDocumentationURI() {
       return MetadataStore.buildDocsURI("/installing/ent/");
     }
   },
   "dcos-exhibitor.service": {
-    summary: [
-      i18nMark("Manages"),
-      Config.productName,
-      i18nMark("in-cluster Zookeeper, used by Mesos as well as"),
-      Config.productName,
-      i18nMark("Marathon.")
-    ],
+    summary: (
+      <Trans>
+        Manages {Config.productName} in-cluster Zookeeper, used by Mesos as well
+        as {Config.productName} Marathon.
+      </Trans>
+    ),
     getDocumentationURI() {
       return MetadataStore.buildDocsURI("/overview/what-is-dcos/");
     }
   },
   "dcos-history-service.service": {
-    summary: [
-      i18nMark("Caches recent cluster history in-memory so that the"),
-      Config.productName,
-      i18nMark("web interface can show recent data")
-    ],
+    summary: (
+      <Trans>
+        Caches recent cluster history in-memory so that the {Config.productName}{" "}
+        web interface can show recent data
+      </Trans>
+    ),
     getDocumentationURI() {
       return MetadataStore.buildDocsURI("/");
     }
   },
   "dcos-logrotate.service": {
-    summary: [
-      i18nMark(
-        "Logrotate allows for the automatic rotation compression, removal, and mailing of log files."
-      )
-    ],
+    summary: (
+      <Trans>
+        Logrotate allows for the automatic rotation compression, removal, and
+        mailing of log files.
+      </Trans>
+    ),
     getDocumentationURI() {
       return "https://github.com/logrotate/logrotate/blob/master/README.md";
     }
   },
   "dcos-link-env.service": {
-    summary: [
-      i18nMark("Makes vendored"),
-      Config.productName,
-      i18nMark(
-        "binaries, such as the mesos-master, mesos-slave, available at the command line when SSHing to a host."
-      )
-    ],
+    summary: (
+      <Trans>
+        Makes vendored {Config.productName} binaries, such as the mesos-master,
+        mesos-slave, available at the command line when SSHing to a host.
+      </Trans>
+    ),
     getDocumentationURI() {
       return MetadataStore.buildDocsURI("/");
     }
   },
   "dcos-download.service": {
-    summary: [
-      i18nMark("Downloads and extracts the"),
-      Config.productName,
-      i18nMark("bootstrap tarball into /opt/mesosphere on your nodes.")
-    ],
+    summary: (
+      <Trans>
+        Downloads and extracts the {Config.productName} bootstrap tarball into
+        /opt/mesosphere on your nodes.
+      </Trans>
+    ),
     getDocumentationURI() {
       return MetadataStore.buildDocsURI("/");
     }
   },
   "dcos-logrotate.timer": {
-    summary: [
-      i18nMark(
-        "Rotates the Mesos master and agent log files to prevent filling the disk."
-      )
-    ],
+    summary: (
+      <Trans>
+        Rotates the Mesos master and agent log files to prevent filling the
+        disk.
+      </Trans>
+    ),
     getDocumentationURI() {
       return MetadataStore.buildDocsURI("/");
     }
   },
   "dcos-signal.timer": {
-    summary: [
-      i18nMark("Sets the dcos-signal.service interval at once an hour.")
-    ],
+    summary: (
+      <Trans>Sets the dcos-signal.service interval at once an hour.</Trans>
+    ),
     getDocumentationURI() {
       return MetadataStore.buildDocsURI("/");
     }
   },
   "dcos-gunicorn-bouncer.service": {
-    summary: [
-      i18nMark(
-        "Processes login requests from users, as well as checking if an authorization token is valid."
-      )
-    ],
+    summary: (
+      <Trans>
+        Processes login requests from users, as well as checking if an
+        authorization token is valid.
+      </Trans>
+    ),
     getDocumentationURI() {
       return MetadataStore.buildDocsURI("/");
     }
   },
   "dcos-adminrouter-reload.service": {
-    summary: [
-      i18nMark(
-        "Restart the Admin Router Nginx server so that it picks up new DNS resolutions, for example master.mesos, leader.mesos."
-      )
-    ],
+    summary: (
+      <Trans>
+        Restart the Admin Router Nginx server so that it picks up new DNS
+        resolutions, for example master.mesos, leader.mesos.
+      </Trans>
+    ),
     getDocumentationURI() {
       return MetadataStore.buildDocsURI("/");
     }
   },
   "dcos-nginx-reload.timer": {
-    summary: [
-      i18nMark(
-        "Sets the dcos-adminrouter-reload.service interval at once an hour."
-      )
-    ],
+    summary: (
+      <Trans>
+        Sets the dcos-adminrouter-reload.service interval at once an hour.
+      </Trans>
+    ),
     getDocumentationURI() {
       return MetadataStore.buildDocsURI("/");
     }
   },
   "dcos-setup.service": {
-    summary: [
-      i18nMark("Specializes the"),
-      Config.productName,
-      i18nMark(
-        "bootstrap tarball for the particular cluster, as well as its cluster role."
-      )
-    ],
+    summary: (
+      <Trans>
+        Specializes the {Config.productName} bootstrap tarball for the
+        particular cluster, as well as its cluster role.
+      </Trans>
+    ),
     getDocumentationURI() {
       return MetadataStore.buildDocsURI("/");
     }
   },
   "dcos-mesos-slave.service": {
-    summary: [i18nMark("Runs a Mesos agent on the node.")],
+    summary: <Trans>Runs a Mesos agent on the node.</Trans>,
     getDocumentationURI() {
       return MetadataStore.buildDocsURI("/");
     }
   },
   "dcos-keepalived.service": {
-    summary: [
-      i18nMark(
-        "Runs keepalived to make a VRRP load balancer that can be used to access the masters."
-      )
-    ],
+    summary: (
+      <Trans>
+        Runs keepalived to make a VRRP load balancer that can be used to access
+        the masters.
+      </Trans>
+    ),
     getDocumentationURI() {
       return MetadataStore.buildDocsURI("/");
     }
   },
   "dcos-adminrouter-agent.service": {
-    summary: [
-      i18nMark("Runs the"),
-      Config.productName,
-      i18nMark(
-        "web interface, as well as a reverse proxy so that administrative interfaces of"
-      ),
-      Config.productName,
-      i18nMark("Service can be accessed from outside the cluster.")
-    ],
+    summary: (
+      <Trans>
+        Runs the {Config.productName} web interface, as well as a reverse proxy
+        so that administrative interfaces of {Config.productName} Service can be
+        accessed from outside the cluster.
+      </Trans>
+    ),
     getDocumentationURI() {
       return MetadataStore.buildDocsURI("/");
     }
   },
   "dcos-gen-resolvconf.service": {
-    summary: [
-      i18nMark(
-        "Periodically writes /etc/resolv.conf so that only currently active Mesos masters with working Mesos DNS are in it."
-      )
-    ],
+    summary: (
+      <Trans>
+        Periodically writes /etc/resolv.conf so that only currently active Mesos
+        masters with working Mesos DNS are in it.
+      </Trans>
+    ),
     getDocumentationURI() {
       return MetadataStore.buildDocsURI("/installing/ent/");
     }
   },
   "dcos-mesos-slave-public": {
-    summary: [i18nMark("Runs a publicly accessible Mesos agent on the node.")],
+    summary: <Trans>Runs a publicly accessible Mesos agent on the node.</Trans>,
     getDocumentationURI() {
       return MetadataStore.buildDocsURI("/security/");
     }

--- a/src/js/pages/system/ComponentsUnitsHealthNodeDetailPage.js
+++ b/src/js/pages/system/ComponentsUnitsHealthNodeDetailPage.js
@@ -133,11 +133,6 @@ class UnitsHealthNodeDetail extends mixin(StoreMixin) {
     const unitSummary = UnitSummaries[unit.get("id")] || {};
     const unitDocsURL =
       unitSummary.getDocumentationURI && unitSummary.getDocumentationURI();
-    const joinedUnitSummary = unitSummary.summary
-      .map((sumPiece, i) => (
-        <Trans key={sumPiece + i} render="span" id={sumPiece} />
-      ))
-      .reduce((prev, curr) => [...prev, " ", curr], []);
 
     return (
       <UnitsHealthNodeDetailPanel
@@ -146,7 +141,7 @@ class UnitsHealthNodeDetail extends mixin(StoreMixin) {
         docsURL={unitDocsURL}
         hostIP={node.get("host_ip")}
         output={node.getOutput()}
-        summary={joinedUnitSummary}
+        summary={unitSummary.summary}
       />
     );
   }

--- a/src/js/pages/system/OrganizationTab.js
+++ b/src/js/pages/system/OrganizationTab.js
@@ -308,6 +308,7 @@ class OrganizationTab extends mixin(StoreMixin, InternalStorageMixin) {
 
     // Get first Action to set as initially selected option in dropdown.
     initialID = Object.keys(actionPhrases)[0] || null;
+
     const dropdownItems = this.getActionsDropdownItems(actionPhrases);
     if (dropdownItems.length === 1) {
       return (

--- a/src/js/pages/system/units-health-node-detail/NodeInfoPanel.js
+++ b/src/js/pages/system/units-health-node-detail/NodeInfoPanel.js
@@ -48,7 +48,7 @@ class NodeInfoPanel extends React.Component {
 NodeInfoPanel.propTypes = {
   docsURL: PropTypes.string,
   output: PropTypes.string,
-  summary: PropTypes.oneOfType(PropTypes.string, PropTypes.array)
+  summary: PropTypes.node
 };
 
 module.exports = NodeInfoPanel;

--- a/src/js/pages/system/units-health-node-detail/UnitsHealthNodeDetailPanel.js
+++ b/src/js/pages/system/units-health-node-detail/UnitsHealthNodeDetailPanel.js
@@ -27,7 +27,7 @@ UnitsHealthNodeDetailPanel.propTypes = {
   docsURL: PropTypes.string,
   hostIP: PropTypes.string,
   output: PropTypes.string,
-  summary: PropTypes.oneOfType(PropTypes.string, PropTypes.array)
+  summary: PropTypes.node
 };
 
 module.exports = UnitsHealthNodeDetailPanel;


### PR DESCRIPTION
Mark strings in src/js/constants files for translation. Note: most of these files do not contain user-facing strings and therefore do not need to be marked/translated.

## Testing

Should be no visual changes.... but to be safe:

**To test `UnitSummaries`:**
Go to Nodes > click a node > Health > click any entry > see if Summary renders correctly

**To test `BulkOptions`:**
Note: the oss version of this feature is replaced with the plugins-private version, so in src/js/plugin-bridge/Loader.js replace `externalPluginList` as follows:

```
let pluginsList;
let externalPluginsList = {};

// Try loading the list of plugins.
try {
  pluginsList = require("#PLUGINS/index.js");
} catch (err) {
  // No plugins
  pluginsList = {};
}

// Try loading the list of plugins.
// try {
//   externalPluginsList = require("#EXTERNAL_PLUGINS/index.js");
// } catch (err) {
//   externalPluginsList = {};
// }
```

- run app and go to Organization > Users
- click checkbox beside a user > Delete button should appear beside filter input
- click Delete button > modal text should appear as expected

## Trade-offs

Composing strings of multiple different constants = headache for localization and for translators as sentences have to be chopped up & grammatical context is lost
