### PR TITLE
DCOS-43340: remove .dcosrc file

### DIFF
--- a/.dcosrc
+++ b/.dcosrc
@@ -1,3 +1,0 @@
-{
-  "base": "master"
-}

--- a/.releaserc
+++ b/.releaserc
@@ -6,7 +6,7 @@
   "publish": [
     {
       "path": "@semantic-release/exec",
-      "cmd": "./scripts/ci/upload-release v${nextRelease.version}",
+      "cmd": "./scripts/ci/upload-release v${nextRelease.version} master",
       "shell": "/bin/bash"
     },
     "@semantic-release/github"

--- a/scripts/ci/upload-release
+++ b/scripts/ci/upload-release
@@ -28,13 +28,11 @@ SCRIPT_PATH="$(cd $(dirname "$0")/$(dirname "$(readlink "$0")") && pwd)"
 # project root for this file
 PROJECT_ROOT="$( cd "$( echo "${SCRIPT_PATH}" | sed s+/scripts/ci++)" && pwd )"
 
-# get correct DC/OS target (=base branch!) from .dcosrc file
-PKG_TARGET=$(python -c "import sys, json; \
-  dcosrc = json.load(open('$PROJECT_ROOT/.dcosrc')); \
-  sys.stdout.write(str(dcosrc['base']));")
-
 # next release version (passed in by semantic-release)
 PKG_VERSION="${1}"
+
+# get correct DC/OS target (=base branch!) passed in from semantic-release
+PKG_TARGET="${2}"
 
 # build release name for branch and file names
 # Examples:


### PR DESCRIPTION
This removes .dcosrc file in order to consolidate all version strings in .releaserc file

## Testing

🤷‍♂️ 
<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs

its just a first step to forward port the changes we did to fix 1.12 branch, later we'll go ahead and change .releaserc file from JSON to javascript.
see this for reference: https://github.com/dcos/dcos-ui/pull/3349
<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
