### PR TITLE
DCOS-43529: [1.13] Debug deployment time is not correct

### DIFF
--- a/plugins/services/src/js/components/ServiceStatusIcon.js
+++ b/plugins/services/src/js/components/ServiceStatusIcon.js
@@ -35,9 +35,16 @@ const getTooltipContent = (service, content) => {
 class ServiceStatusIcon extends Component {
   getDeclinedOffersWarning(service) {
     if (DeclinedOffersUtil.displayDeclinedOffersWarning(service)) {
-      const timeWaiting =
-        Date.now() -
-        DateUtil.strToMs(DeclinedOffersUtil.getTimeWaiting(service.getQueue()));
+      // We are getting the last config change time in a different way for services and pods.
+      let lastChange = service.getQueue().since;
+
+      if (service.versionInfo) {
+        lastChange = service.versionInfo.lastConfigChangeAt;
+      } else if (service.spec) {
+        lastChange = service.spec.version;
+      }
+
+      const timeWaiting = Date.now() - DateUtil.strToMs(lastChange);
 
       return this.getTooltip(
         `DC/OS has been waiting for resources and is unable to complete this deployment for ${DateUtil.getDuration(
@@ -101,9 +108,18 @@ class ServiceStatusIcon extends Component {
 
   getUnableToLaunchWarning(service) {
     if (this.isUnableToLaunch(service)) {
+      // We are getting the last config change time in a different way for services and pods.
+      let lastChange = service.getQueue().since;
+
+      if (service.versionInfo) {
+        lastChange = service.versionInfo.lastConfigChangeAt;
+      } else if (service.spec) {
+        lastChange = service.spec.version;
+      }
+
       return this.getTooltip(
         `DC/OS has been unable to complete this deployment for ${DateUtil.getDuration(
-          Date.now() - DateUtil.strToMs(service.getQueue().since),
+          Date.now() - DateUtil.strToMs(lastChange),
           null
         )}.`
       );

--- a/plugins/services/src/js/containers/pod-debug/PodDebugContainer.js
+++ b/plugins/services/src/js/containers/pod-debug/PodDebugContainer.js
@@ -194,7 +194,8 @@ class PodDebugTabView extends React.Component {
       return null;
     }
 
-    const waitingSince = DateUtil.strToMs(queue.since);
+    const lastConfigChangeAt = this.props.pod.spec.version;
+    const waitingSince = DateUtil.strToMs(lastConfigChangeAt);
     const timeWaiting = Date.now() - waitingSince;
 
     // If the service has been waiting for less than five minutes, we don't

--- a/plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js
+++ b/plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js
@@ -257,7 +257,9 @@ class ServiceDebugContainer extends React.Component {
       return null;
     }
 
-    const waitingSince = DateUtil.strToMs(queue.since);
+    const lastConfigChangeAt = this.props.service.versionInfo
+      .lastConfigChangeAt;
+    const waitingSince = DateUtil.strToMs(lastConfigChangeAt);
     const timeWaiting = Date.now() - waitingSince;
 
     // If the service has been waiting for less than five minutes, we don't


### PR DESCRIPTION
Show time since last configuration when a service cannot deploy.

Closes https://jira.mesosphere.com/browse/DCOS-43529
Parent jira: https://jira.mesosphere.com/browse/DCOS-40674

## Testing
1. Start a single-container service.
2. Wait a few minutes.
3. Edit it so that it can't start (for example by setting a huge memory).
4. Wait 5 more minutes.
5. Verify that the warning message in the Debug tab of the service calculates time since last configuration update, not since the service was created.
6. Verify that the tooltip for this service in the services table is also using the correct time.
7. Test the same for multi-container service.

## Trade-offs
1. I noticed that for multi-container services, the configuration displayed is being updated every 2 seconds.
![peek 2018-10-12 11-55](https://user-images.githubusercontent.com/40791275/46863297-b9202600-ce1f-11e8-83d6-b5f76debe6aa.gif)

Not sure if this is intended. I still used the time it was last configured for the message. @leemunroe you created the jira, can you tell me if my assumption is correct?

2. Scale or restart actions don't reset the timer. Again, not sure if this is intended.
![screenshot from 2018-10-12 12-45-30](https://user-images.githubusercontent.com/40791275/46863407-03090c00-ce20-11e8-9597-d4e5306a5ccf.png)

## Dependencies
None.

## Screenshots

### Before
![screenshot from 2018-10-12 11-57-29](https://user-images.githubusercontent.com/40791275/46863470-30ee5080-ce20-11e8-8511-5b1bb61dd6b3.png)

### After
![screenshot from 2018-10-12 12-29-24](https://user-images.githubusercontent.com/40791275/46863550-6d21b100-ce20-11e8-8f2f-060ad97d4f45.png)

