### PR TITLE
DCOS-43372 i18nmark services plugin constants

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -97,6 +97,15 @@
     ],
     "obsolete": true
   },
+  "A REX-Ray backed volume that is mounted on the agent from network attached storage.": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/VolumeDefinitions.js",
+        22
+      ]
+    ]
+  },
   "A health check passes if (1) its HTTP response code is between 200 and 399 inclusive, and (2) its response is received within the timeoutSeconds period. <0>More Information</0>.": {
     "translation": "",
     "origin": [
@@ -107,6 +116,33 @@
       [
         "plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js",
         471
+      ]
+    ]
+  },
+  "A host volume is a directory on the the local agent mapped to one in a container.": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/VolumeDefinitions.js",
+        29
+      ]
+    ]
+  },
+  "A locally persistent volume based upon the physical disks installed in the agent which has the capabilities of a single disk.": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/VolumeDefinitions.js",
+        14
+      ]
+    ]
+  },
+  "A locally persistent volume pre-created by the operator according to a storage profile.": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/VolumeDefinitions.js",
+        7
       ]
     ]
   },
@@ -188,7 +224,7 @@
     "origin": [
       [
         "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
-        182
+        185
       ]
     ]
   },
@@ -285,7 +321,7 @@
     "origin": [
       [
         "src/js/components/PlacementConstraintsPartial.js",
-        224
+        230
       ]
     ]
   },
@@ -375,11 +411,11 @@
     "origin": [
       [
         "plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js",
-        322
+        332
       ],
       [
         "plugins/services/src/js/components/forms/VolumesFormSection.js",
-        442
+        452
       ]
     ]
   },
@@ -388,7 +424,7 @@
     "origin": [
       [
         "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
-        428
+        431
       ]
     ]
   },
@@ -482,6 +518,15 @@
     ],
     "obsolete": true
   },
+  "Already exists": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorMessages.js",
+        13
+      ]
+    ]
+  },
   "An Error Occurred": {
     "translation": "",
     "origin": [
@@ -565,7 +610,7 @@
     "origin": [
       [
         "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
-        439
+        442
       ]
     ]
   },
@@ -611,6 +656,15 @@
       [
         "plugins/services/src/js/components/forms/EnvironmentFormSection.js",
         263
+      ]
+    ]
+  },
+  "Attached": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/VolumeStatus.js",
+        4
       ]
     ]
   },
@@ -671,6 +725,23 @@
       ]
     ]
   },
+  "CPU": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/PodTableHeaderLabels.js",
+        10
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceTableHeaderLabels.js",
+        4
+      ],
+      [
+        "plugins/services/src/js/constants/TaskTableHeaderLabels.js",
+        4
+      ]
+    ]
+  },
   "CPUs": {
     "translation": "",
     "origin": [
@@ -685,6 +756,10 @@
       [
         "plugins/services/src/js/components/forms/ContainerServiceFormSection.js",
         187
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        14
       ]
     ]
   },
@@ -726,6 +801,10 @@
       [
         "plugins/services/src/js/components/dsl/ServiceOtherDSLSection.js",
         46
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceOtherLabels.js",
+        4
       ],
       [
         "src/js/pages/catalog/PackageDetailTab.js",
@@ -822,6 +901,10 @@
     "translation": "",
     "origin": [
       [
+        "plugins/services/src/js/constants/OperatorTypes.js",
+        21
+      ],
+      [
         "src/js/components/ClusterHeader.js",
         59
       ]
@@ -871,6 +954,14 @@
       [
         "plugins/services/src/js/components/dsl/TaskStatusDSLSection.js",
         54
+      ],
+      [
+        "plugins/services/src/js/constants/PodContainerStatus.js",
+        73
+      ],
+      [
+        "plugins/services/src/js/constants/PodInstanceStatus.js",
+        37
       ]
     ]
   },
@@ -945,7 +1036,7 @@
     "origin": [
       [
         "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
-        348
+        351
       ]
     ]
   },
@@ -1051,7 +1142,7 @@
     "origin": [
       [
         "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
-        212
+        215
       ]
     ]
   },
@@ -1060,7 +1151,7 @@
     "origin": [
       [
         "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
-        173
+        176
       ],
       [
         "plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js",
@@ -1140,11 +1231,11 @@
     "origin": [
       [
         "plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js",
-        311
+        321
       ],
       [
         "plugins/services/src/js/components/forms/VolumesFormSection.js",
-        431
+        441
       ]
     ]
   },
@@ -1171,11 +1262,14 @@
     "translation": "",
     "origin": [
       [
-        ".dcos-ui-plugins-private/secrets/pages/SecretDetail.js",
-        229
+        "plugins/services/src/js/constants/PodContainerStatus.js",
+        7
+      ],
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        6
       ]
-    ],
-    "obsolete": true
+    ]
   },
   "Cryptographic Cluster ID": {
     "translation": "",
@@ -1195,6 +1289,15 @@
       ]
     ],
     "obsolete": true
+  },
+  "DC/OS Storage Volume": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/VolumeDefinitions.js",
+        5
+      ]
+    ]
   },
   "DC/OS UI cannot retrieve the requested information at this moment.": {
     "translation": "",
@@ -1237,11 +1340,11 @@
     "origin": [
       [
         "plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js",
-        258
+        268
       ],
       [
         "plugins/services/src/js/components/forms/VolumesFormSection.js",
-        404
+        414
       ]
     ]
   },
@@ -1272,6 +1375,15 @@
       ]
     ],
     "obsolete": true
+  },
+  "Delayed": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceStatusLabels.js",
+        8
+      ]
+    ]
   },
   "Delete": {
     "translation": "",
@@ -1343,6 +1455,10 @@
       [
         "plugins/services/src/js/components/dsl/ServiceStatusDSLSection.js",
         88
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceStatusLabels.js",
+        10
       ]
     ]
   },
@@ -1352,6 +1468,10 @@
       [
         "plugins/services/src/js/components/dsl/ServiceStatusDSLSection.js",
         57
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceStatusLabels.js",
+        5
       ]
     ]
   },
@@ -1361,6 +1481,15 @@
       [
         "plugins/jobs/src/js/pages/JobConfiguration.js",
         26
+      ]
+    ]
+  },
+  "Detached": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/VolumeStatus.js",
+        5
       ]
     ]
   },
@@ -1401,6 +1530,14 @@
       [
         "plugins/nodes/src/js/pages/nodes/NodeDetailTab.js",
         125
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceTableHeaderLabels.js",
+        5
+      ],
+      [
+        "plugins/services/src/js/constants/TaskTableHeaderLabels.js",
+        6
       ]
     ]
   },
@@ -1431,12 +1568,21 @@
       ]
     ]
   },
+  "Docker Engine": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ContainerConstants.js",
+        9
+      ]
+    ]
+  },
   "Docker Engine does not support GPU resources, please select Universal Container Runtime (UCR) if you want to use GPU resources.": {
     "translation": "",
     "origin": [
       [
         "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
-        252
+        255
       ]
     ]
   },
@@ -1449,12 +1595,30 @@
       ]
     ]
   },
+  "Docker’s container runtime. No support for multiple containers (Pods) or GPU resources.": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
+        49
+      ]
+    ]
+  },
   "Documentation": {
     "translation": "",
     "origin": [
       [
         "src/js/components/ClusterHeader.js",
         136
+      ]
+    ]
+  },
+  "Don't run app tasks on a particular set of attribute IDs": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/OperatorTypes.js",
+        60
       ]
     ]
   },
@@ -1483,6 +1647,15 @@
       [
         "src/js/components/modals/CliInstallModal.js",
         137
+      ]
+    ]
+  },
+  "Dropped": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        71
       ]
     ]
   },
@@ -1623,6 +1796,37 @@
       ]
     ]
   },
+  "Environment variables": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        22
+      ]
+    ]
+  },
+  "Ephemeral Storage": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/VolumeDefinitions.js",
+        34
+      ]
+    ]
+  },
+  "Error": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/PodContainerStatus.js",
+        49
+      ],
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        56
+      ]
+    ]
+  },
   "Error finding node": {
     "translation": "",
     "origin": [
@@ -1651,6 +1855,28 @@
       ]
     ],
     "obsolete": true
+  },
+  "External Persistent Volume": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/VolumeDefinitions.js",
+        20
+      ]
+    ]
+  },
+  "Failed": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/PodContainerStatus.js",
+        55
+      ],
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        46
+      ]
+    ]
   },
   "Failure %": {
     "translation": "",
@@ -1683,6 +1909,24 @@
       ]
     ],
     "obsolete": true
+  },
+  "Field": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/PlacementConstraintsPartial.js",
+        86
+      ]
+    ]
+  },
+  "Finished": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        36
+      ]
+    ]
   },
   "First success": {
     "translation": "",
@@ -1730,6 +1974,19 @@
       ]
     ]
   },
+  "GPU": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceTableHeaderLabels.js",
+        6
+      ],
+      [
+        "plugins/services/src/js/constants/TaskTableHeaderLabels.js",
+        5
+      ]
+    ]
+  },
   "GPUs": {
     "translation": "",
     "origin": [
@@ -1753,7 +2010,7 @@
     "origin": [
       [
         "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
-        380
+        383
       ]
     ]
   },
@@ -1763,6 +2020,24 @@
       [
         "plugins/services/src/js/components/LogView.js",
         301
+      ]
+    ]
+  },
+  "Gone": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        61
+      ]
+    ]
+  },
+  "Gone by operator": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        66
       ]
     ]
   },
@@ -1785,6 +2060,15 @@
       [
         "plugins/nodes/src/js/pages/NodesAgents.js",
         234
+      ]
+    ]
+  },
+  "Group By": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/OperatorTypes.js",
+        31
       ]
     ]
   },
@@ -1840,6 +2124,14 @@
       [
         "plugins/services/src/js/components/dsl/ServiceHealthDSLSection.js",
         35
+      ],
+      [
+        "plugins/services/src/js/constants/PodTableHeaderLabels.js",
+        9
+      ],
+      [
+        "plugins/services/src/js/constants/TaskTableHeaderLabels.js",
+        14
       ]
     ]
   },
@@ -1865,6 +2157,42 @@
       ]
     ]
   },
+  "Health check grace periods": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        82
+      ]
+    ]
+  },
+  "Health check intervals": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        86
+      ]
+    ]
+  },
+  "Health check max failures": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        94
+      ]
+    ]
+  },
+  "Health check timeouts": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        90
+      ]
+    ]
+  },
   "Health checks may be specified per application to be run against the application's instances.": {
     "translation": "",
     "origin": [
@@ -1886,6 +2214,10 @@
         46
       ],
       [
+        "plugins/services/src/js/constants/TaskHealthStates.js",
+        4
+      ],
+      [
         "src/js/constants/UnitHealthStatus.js",
         18
       ]
@@ -1905,6 +2237,10 @@
       [
         "plugins/services/src/js/components/forms/NetworkingFormSection.js",
         579
+      ],
+      [
+        "plugins/services/src/js/constants/TaskTableHeaderLabels.js",
+        7
       ]
     ]
   },
@@ -1923,7 +2259,7 @@
     "origin": [
       [
         "plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js",
-        212
+        222
       ],
       [
         "plugins/services/src/js/components/forms/VolumesFormSection.js",
@@ -1941,6 +2277,24 @@
       [
         "plugins/services/src/js/components/forms/NetworkingFormSection.js",
         112
+      ]
+    ]
+  },
+  "Host Volume": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/VolumeDefinitions.js",
+        27
+      ]
+    ]
+  },
+  "Host/Port": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/PodTableHeaderLabels.js",
+        5
       ]
     ]
   },
@@ -1967,6 +2321,10 @@
       [
         "plugins/nodes/src/js/pages/nodes/NodeDetailTab.js",
         70
+      ],
+      [
+        "plugins/services/src/js/constants/TaskTableHeaderLabels.js",
+        11
       ]
     ]
   },
@@ -2132,7 +2490,7 @@
     "origin": [
       [
         "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
-        329
+        332
       ]
     ]
   },
@@ -2189,7 +2547,15 @@
     "origin": [
       [
         "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
-        392
+        395
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        10
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceTableHeaderLabels.js",
+        11
       ]
     ]
   },
@@ -2203,6 +2569,15 @@
       [
         "plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js",
         108
+      ]
+    ]
+  },
+  "Is": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/OperatorTypes.js",
+        41
       ]
     ]
   },
@@ -2260,6 +2635,36 @@
       [
         "plugins/services/src/js/components/forms/EnvironmentFormSection.js",
         112
+      ]
+    ]
+  },
+  "Killed": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/PodContainerStatus.js",
+        67
+      ],
+      [
+        "plugins/services/src/js/constants/PodInstanceStatus.js",
+        31
+      ],
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        41
+      ]
+    ]
+  },
+  "Killing": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/PodContainerStatus.js",
+        61
+      ],
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        31
       ]
     ]
   },
@@ -2350,6 +2755,15 @@
     ],
     "obsolete": true
   },
+  "Like": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/OperatorTypes.js",
+        51
+      ]
+    ]
+  },
   "Link a cluster to switch between clusters.": {
     "translation": "",
     "origin": [
@@ -2422,6 +2836,15 @@
       ]
     ]
   },
+  "Local Persistent Volume": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/VolumeDefinitions.js",
+        12
+      ]
+    ]
+  },
   "Log out": {
     "translation": "",
     "origin": [
@@ -2447,6 +2870,19 @@
       [
         "src/js/components/modals/ErrorModal.js",
         24
+      ]
+    ]
+  },
+  "Lost": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/PodContainerStatus.js",
+        79
+      ],
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        51
       ]
     ]
   },
@@ -2481,6 +2917,37 @@
       ]
     ]
   },
+  "Max Per": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/OperatorTypes.js",
+        69
+      ]
+    ]
+  },
+  "May only contain digits (0-9), dashes (-) and lowercase letters (a-z) e.g. web-server": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorMessages.js",
+        32
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceErrorMessages.js",
+        39
+      ]
+    ]
+  },
+  "May only contain digits (0-9), dashes (-), dots (.),lowercase letters (a-z), and slashes (/) e.g. /group/my-service": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorMessages.js",
+        18
+      ]
+    ]
+  },
   "Media": {
     "translation": "",
     "origin": [
@@ -2496,6 +2963,27 @@
       [
         "plugins/nodes/src/js/pages/nodes/NodeDetailTab.js",
         133
+      ],
+      [
+        "plugins/services/src/js/constants/PodTableHeaderLabels.js",
+        11
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceTableHeaderLabels.js",
+        7
+      ],
+      [
+        "plugins/services/src/js/constants/TaskTableHeaderLabels.js",
+        10
+      ]
+    ]
+  },
+  "Memory": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        18
       ]
     ]
   },
@@ -2512,6 +3000,15 @@
       ]
     ]
   },
+  "Mesos default for allocating temporary disk space to a service. Enough for many stateless or semi-stateless 12-factor and cloud native applications.": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/VolumeDefinitions.js",
+        36
+      ]
+    ]
+  },
   "Mode": {
     "translation": "",
     "origin": [
@@ -2521,12 +3018,21 @@
       ]
     ]
   },
+  "Modified": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/TaskDirectoryHeaderLabels.js",
+        8
+      ]
+    ]
+  },
   "More Settings": {
     "translation": "",
     "origin": [
       [
         "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
-        94
+        97
       ],
       [
         "plugins/services/src/js/components/modals/CreateServiceModalForm.js",
@@ -2556,16 +3062,37 @@
       ]
     ]
   },
+  "Must be defined": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorMessages.js",
+        8
+      ]
+    ]
+  },
   "N/A": {
     "translation": "",
     "origin": [
       [
         "plugins/jobs/src/js/pages/JobRunHistoryTable.js",
-        323
+        325
       ],
       [
         "plugins/services/src/js/components/dsl/ServiceHealthDSLSection.js",
         55
+      ],
+      [
+        "plugins/services/src/js/constants/PodContainerStatus.js",
+        85
+      ],
+      [
+        "plugins/services/src/js/constants/PodInstanceStatus.js",
+        43
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceStatusLabels.js",
+        7
       ],
       [
         "src/js/constants/UnitHealthStatus.js",
@@ -2578,11 +3105,27 @@
     "origin": [
       [
         "plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js",
-        184
+        194
       ],
       [
         "plugins/services/src/js/components/forms/VolumesFormSection.js",
         252
+      ],
+      [
+        "plugins/services/src/js/constants/PodTableHeaderLabels.js",
+        4
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceTableHeaderLabels.js",
+        8
+      ],
+      [
+        "plugins/services/src/js/constants/TaskDirectoryHeaderLabels.js",
+        4
+      ],
+      [
+        "plugins/services/src/js/constants/TaskTableHeaderLabels.js",
+        12
       ],
       [
         "src/js/constants/RepositoriesTableHeaderLabels.js",
@@ -2608,7 +3151,7 @@
     "origin": [
       [
         "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
-        139
+        142
       ]
     ]
   },
@@ -2709,6 +3252,15 @@
       ]
     ],
     "obsolete": true
+  },
+  "No health checks available": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/tasks/TaskTable.js",
+        388
+      ]
+    ]
   },
   "No linked clusters": {
     "translation": "",
@@ -2818,6 +3370,15 @@
     ],
     "obsolete": true
   },
+  "Not Available": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/VolumeProfile.js",
+        4
+      ]
+    ]
+  },
   "Number of Agents": {
     "translation": "",
     "origin": [
@@ -2870,6 +3431,15 @@
       ]
     ]
   },
+  "Operator": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/PlacementConstraintsPartial.js",
+        87
+      ]
+    ]
+  },
   "Other": {
     "translation": "",
     "origin": [
@@ -2902,6 +3472,15 @@
       [
         "src/js/pages/system/OverviewDetailTab.js",
         43
+      ]
+    ]
+  },
+  "Owner": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/TaskDirectoryHeaderLabels.js",
+        6
       ]
     ]
   },
@@ -2974,6 +3553,15 @@
     ],
     "obsolete": true
   },
+  "Permissions": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/TaskDirectoryHeaderLabels.js",
+        5
+      ]
+    ]
+  },
   "Placement": {
     "translation": "",
     "origin": [
@@ -3008,7 +3596,7 @@
     "origin": [
       [
         "plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js",
-        294
+        304
       ]
     ]
   },
@@ -3045,6 +3633,15 @@
       [
         "plugins/services/src/js/components/dsl/ServiceOtherDSLSection.js",
         55
+      ]
+    ]
+  },
+  "Pods": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceOtherLabels.js",
+        6
       ]
     ]
   },
@@ -3151,15 +3748,15 @@
     "origin": [
       [
         "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
-        275
+        278
       ],
       [
         "plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js",
-        163
+        171
       ],
       [
         "plugins/services/src/js/components/forms/VolumesFormSection.js",
-        374
+        382
       ]
     ]
   },
@@ -3169,6 +3766,10 @@
       [
         "plugins/services/src/js/components/dsl/ServiceStatusDSLSection.js",
         66
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceStatusLabels.js",
+        11
       ]
     ]
   },
@@ -3178,6 +3779,18 @@
       [
         "plugins/nodes/src/js/pages/nodes/NodeDetailTab.js",
         100
+      ],
+      [
+        "plugins/services/src/js/constants/PodTableHeaderLabels.js",
+        7
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceTableHeaderLabels.js",
+        12
+      ],
+      [
+        "plugins/services/src/js/constants/TaskTableHeaderLabels.js",
+        9
       ],
       [
         "plugins/services/src/js/pages/task-details/TaskDetailsTab.js",
@@ -3299,12 +3912,90 @@
       ]
     ]
   },
+  "Run app tasks evenly distributed across a certain attribute": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/OperatorTypes.js",
+        32
+      ]
+    ]
+  },
+  "Run app tasks on a particular set of attribute IDs": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/OperatorTypes.js",
+        52
+      ]
+    ]
+  },
+  "Run app tasks on nodes having attribute ID with a specific value": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/OperatorTypes.js",
+        42
+      ]
+    ]
+  },
+  "Run app tasks on nodes that share a certain attribute ID": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/OperatorTypes.js",
+        22
+      ]
+    ]
+  },
+  "Run each app task on a unique attribute ID": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/OperatorTypes.js",
+        14
+      ]
+    ]
+  },
+  "Run max number of app tasks on each attribute ID": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/OperatorTypes.js",
+        70
+      ]
+    ]
+  },
   "Running": {
     "translation": "",
     "origin": [
       [
         "plugins/services/src/js/components/dsl/ServiceStatusDSLSection.js",
         48
+      ],
+      [
+        "plugins/services/src/js/constants/PodContainerStatus.js",
+        31
+      ],
+      [
+        "plugins/services/src/js/constants/PodContainerStatus.js",
+        43
+      ],
+      [
+        "plugins/services/src/js/constants/PodInstanceStatus.js",
+        7
+      ],
+      [
+        "plugins/services/src/js/constants/PodInstanceStatus.js",
+        19
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceStatusLabels.js",
+        4
+      ],
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        26
       ]
     ]
   },
@@ -3584,7 +4275,50 @@
     "origin": [
       [
         "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
-        357
+        360
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        6
+      ]
+    ]
+  },
+  "Service endpoint container ports": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        70
+      ]
+    ]
+  },
+  "Service endpoint host ports": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        54
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        58
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        74
+      ]
+    ]
+  },
+  "Service endpoint names": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        50
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        66
       ]
     ]
   },
@@ -3670,12 +4404,21 @@
       ]
     ]
   },
+  "Size": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/TaskDirectoryHeaderLabels.js",
+        7
+      ]
+    ]
+  },
   "Size (MiB)": {
     "translation": "",
     "origin": [
       [
         "plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js",
-        240
+        250
       ]
     ]
   },
@@ -3688,12 +4431,55 @@
       ]
     ]
   },
+  "Staging": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/PodContainerStatus.js",
+        13
+      ],
+      [
+        "plugins/services/src/js/constants/PodInstanceStatus.js",
+        25
+      ],
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        11
+      ]
+    ]
+  },
+  "Started": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/PodContainerStatus.js",
+        25
+      ],
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        21
+      ]
+    ]
+  },
   "Started at": {
     "translation": "",
     "origin": [
       [
         "plugins/services/src/js/components/MarathonTaskDetailsList.js",
         87
+      ]
+    ]
+  },
+  "Starting": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/PodContainerStatus.js",
+        19
+      ],
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        16
       ]
     ]
   },
@@ -3720,6 +4506,18 @@
       [
         "plugins/services/src/js/components/dsl/TaskStatusDSLSection.js",
         34
+      ],
+      [
+        "plugins/services/src/js/constants/PodTableHeaderLabels.js",
+        8
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceTableHeaderLabels.js",
+        9
+      ],
+      [
+        "plugins/services/src/js/constants/TaskTableHeaderLabels.js",
+        13
       ]
     ]
   },
@@ -3747,6 +4545,10 @@
       [
         "plugins/services/src/js/components/dsl/ServiceStatusDSLSection.js",
         79
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceStatusLabels.js",
+        6
       ]
     ]
   },
@@ -3839,7 +4641,7 @@
     "origin": [
       [
         "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
-        415
+        418
       ]
     ]
   },
@@ -3895,7 +4697,7 @@
     "origin": [
       [
         "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
-        226
+        229
       ]
     ]
   },
@@ -3958,6 +4760,24 @@
       ]
     ],
     "obsolete": true
+  },
+  "The service is currently locked by one or more deployments. Press again to force this operation.": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorMessages.js",
+        25
+      ]
+    ]
+  },
+  "The unique operator does not accept a value.": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/OperatorTypes.js",
+        11
+      ]
+    ]
   },
   "There a currently no other nodes in your datacenter other than your DC/OS master node.": {
     "translation": "",
@@ -4215,6 +5035,15 @@
       ]
     ]
   },
+  "Unavailable": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/VolumeStatus.js",
+        6
+      ]
+    ]
+  },
   "Unhealthy": {
     "translation": "",
     "origin": [
@@ -4223,8 +5052,91 @@
         68
       ],
       [
+        "plugins/services/src/js/constants/PodContainerStatus.js",
+        37
+      ],
+      [
+        "plugins/services/src/js/constants/PodInstanceStatus.js",
+        13
+      ],
+      [
+        "plugins/services/src/js/constants/TaskHealthStates.js",
+        5
+      ],
+      [
         "src/js/constants/UnitHealthStatus.js",
         25
+      ]
+    ]
+  },
+  "Unique": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/OperatorTypes.js",
+        13
+      ]
+    ]
+  },
+  "Universal Container Runtime (UCR)": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ContainerConstants.js",
+        10
+      ]
+    ]
+  },
+  "Universal Container Runtime using native Mesos engine. Supports Docker file format, multiple containers (Pods) and GPU resources.": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
+        55
+      ]
+    ]
+  },
+  "Unknown": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/TaskHealthStates.js",
+        6
+      ],
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        81
+      ]
+    ]
+  },
+  "Unlike": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/OperatorTypes.js",
+        59
+      ]
+    ]
+  },
+  "Unreachable": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        76
+      ]
+    ]
+  },
+  "Updated": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/PodTableHeaderLabels.js",
+        12
+      ],
+      [
+        "plugins/services/src/js/constants/TaskTableHeaderLabels.js",
+        15
       ]
     ]
   },
@@ -4320,6 +5232,10 @@
       [
         "plugins/services/src/js/components/forms/EnvironmentFormSection.js",
         121
+      ],
+      [
+        "src/js/components/PlacementConstraintsPartial.js",
+        88
       ]
     ]
   },
@@ -4339,6 +5255,18 @@
       [
         "plugins/services/src/js/components/MarathonTaskDetailsList.js",
         95
+      ],
+      [
+        "plugins/services/src/js/constants/PodTableHeaderLabels.js",
+        13
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceTableHeaderLabels.js",
+        10
+      ],
+      [
+        "plugins/services/src/js/constants/TaskTableHeaderLabels.js",
+        16
       ]
     ]
   },
@@ -4373,6 +5301,42 @@
       ]
     ]
   },
+  "Volume container path": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        30
+      ]
+    ]
+  },
+  "Volume host path": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        38
+      ]
+    ]
+  },
+  "Volume mode": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        42
+      ]
+    ]
+  },
+  "Volume size": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        34
+      ]
+    ]
+  },
   "Volumes": {
     "translation": "",
     "origin": [
@@ -4382,11 +5346,24 @@
       ],
       [
         "plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js",
-        270
+        280
       ],
       [
         "plugins/services/src/js/components/forms/VolumesFormSection.js",
-        416
+        426
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceOtherLabels.js",
+        5
+      ]
+    ]
+  },
+  "Waiting": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceStatusLabels.js",
+        9
       ]
     ]
   },
@@ -4405,6 +5382,15 @@
       [
         "src/js/components/Modals.js",
         100
+      ]
+    ]
+  },
+  "When you attempt to deploy a service, DC/OS waits for offers to match the resources your service requires. If the offer does not satisfy the requirement, it is declined and DC/OS retries. <0>Learn more</0>.": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/DeclinedOffersHelpText.js",
+        12
       ]
     ]
   },
@@ -4459,7 +5445,7 @@
     "origin": [
       [
         "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
-        193
+        196
       ]
     ]
   },
@@ -4530,6 +5516,14 @@
       [
         "plugins/nodes/src/js/pages/nodes/NodeDetailTab.js",
         111
+      ],
+      [
+        "plugins/services/src/js/constants/PodTableHeaderLabels.js",
+        6
+      ],
+      [
+        "plugins/services/src/js/constants/TaskTableHeaderLabels.js",
+        8
       ],
       [
         "plugins/services/src/js/pages/task-details/TaskDetailsTab.js",

--- a/plugins/jobs/src/js/components/breadcrumbs/Status.js
+++ b/plugins/jobs/src/js/components/breadcrumbs/Status.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import PropTypes from "prop-types";
 import React from "react";
 import TaskStates from "#PLUGINS/services/src/js/constants/TaskStates";
@@ -7,7 +8,7 @@ export default function Status({ status }) {
   return (
     <BreadcrumbSupplementalContent>
       <div className="service-page-header-status muted">
-        ({TaskStates[status].displayName})
+        (<Trans render="span" id={TaskStates[status].displayName} />)
       </div>
     </BreadcrumbSupplementalContent>
   );

--- a/plugins/jobs/src/js/components/breadcrumbs/__tests__/__snapshots__/Status-test.js.snap
+++ b/plugins/jobs/src/js/components/breadcrumbs/__tests__/__snapshots__/Status-test.js.snap
@@ -8,7 +8,11 @@ exports[`Status renders TASK_FAILED 1`] = `
     className="service-page-header-status muted"
   >
     (
-    Failed
+    <span
+      className={undefined}
+    >
+      Failed
+    </span>
     )
   </div>
 </div>
@@ -22,7 +26,11 @@ exports[`Status renders TASK_RUNNING 1`] = `
     className="service-page-header-status muted"
   >
     (
-    Running
+    <span
+      className={undefined}
+    >
+      Running
+    </span>
     )
   </div>
 </div>
@@ -36,7 +44,11 @@ exports[`Status renders TASK_STARTED 1`] = `
     className="service-page-header-status muted"
   >
     (
-    Started
+    <span
+      className={undefined}
+    >
+      Started
+    </span>
     )
   </div>
 </div>
@@ -50,7 +62,11 @@ exports[`Status renders TASK_STARTING 1`] = `
     className="service-page-header-status muted"
   >
     (
-    Starting
+    <span
+      className={undefined}
+    >
+      Starting
+    </span>
     )
   </div>
 </div>

--- a/plugins/jobs/src/js/pages/JobRunHistoryTable.js
+++ b/plugins/jobs/src/js/pages/JobRunHistoryTable.js
@@ -319,7 +319,9 @@ class JobRunHistoryTable extends React.Component {
       "text-danger": status.stateTypes.includes("failure")
     });
 
-    return <span className={statusClasses}>{status.displayName}</span>;
+    return (
+      <Trans id={status.displayName} render="span" className={statusClasses} />
+    );
   }
 
   renderRunTimeColumn(prop, row) {

--- a/plugins/services/src/js/components/MarathonTaskDetailsList.js
+++ b/plugins/services/src/js/components/MarathonTaskDetailsList.js
@@ -71,7 +71,7 @@ class MarathonTaskDetailsList extends React.Component {
             <Trans render="span">Status</Trans>
           </ConfigurationMapLabel>
           <ConfigurationMapValue>
-            {this.getTaskStatus(task)}
+            <Trans id={this.getTaskStatus(task)} render="span" />
           </ConfigurationMapValue>
         </ConfigurationMapRow>
         <ConfigurationMapRow>

--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -1,4 +1,5 @@
 import { Trans } from "@lingui/macro";
+import { i18nMark } from "@lingui/react";
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { Confirm, Tooltip } from "reactjs-components";
@@ -44,14 +45,16 @@ const METHODS_TO_BIND = [
 
 const containerRuntimes = {
   [DOCKER]: {
-    label: <span>{labelMap[DOCKER]}</span>,
-    helpText:
+    label: <Trans render="span" id={labelMap[DOCKER]} />,
+    helpText: i18nMark(
       "Docker’s container runtime. No support for multiple containers (Pods) or GPU resources."
+    )
   },
   [MESOS]: {
-    label: <span>{labelMap[MESOS]}</span>,
-    helpText:
+    label: <Trans render="span" id={labelMap[MESOS]} />,
+    helpText: i18nMark(
       "Universal Container Runtime using native Mesos engine. Supports Docker file format, multiple containers (Pods) and GPU resources."
+    )
   }
 };
 
@@ -277,7 +280,7 @@ class GeneralServiceFormSection extends Component {
               </span>
             )}
           </div>
-          <FieldHelp>{helpText}</FieldHelp>
+          <Trans render={<FieldHelp />} id={helpText} />
         </FieldLabel>
       );
 

--- a/plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js
@@ -155,10 +155,18 @@ class MultiContainerVolumesFormSection extends Component {
                         <SelectOption
                           key={index}
                           value={type}
-                          label={VolumeDefinitions[type].name}
+                          label={
+                            <Trans
+                              id={VolumeDefinitions[type].name}
+                              render="span"
+                            />
+                          }
                         >
                           <div className="dropdown-select-item-title">
-                            <span>{VolumeDefinitions[type].name}</span>
+                            <Trans
+                              id={VolumeDefinitions[type].name}
+                              render="span"
+                            />
                             {VolumeDefinitions[type].recommended ? (
                               <Trans
                                 render="span"
@@ -168,9 +176,11 @@ class MultiContainerVolumesFormSection extends Component {
                               </Trans>
                             ) : null}
                           </div>
-                          <span className="dropdown-select-item-description">
-                            {VolumeDefinitions[type].description}
-                          </span>
+                          <Trans
+                            id={VolumeDefinitions[type].description}
+                            render="span"
+                            className="dropdown-select-item-description"
+                          />
                         </SelectOption>
                       );
                     })}

--- a/plugins/services/src/js/components/forms/VolumesFormSection.js
+++ b/plugins/services/src/js/components/forms/VolumesFormSection.js
@@ -366,10 +366,18 @@ class VolumesFormSection extends Component {
                         <SelectOption
                           key={index}
                           value={type}
-                          label={VolumeDefinitions[type].name}
+                          label={
+                            <Trans
+                              id={VolumeDefinitions[type].name}
+                              render="span"
+                            />
+                          }
                         >
                           <div className="dropdown-select-item-title">
-                            <span>{VolumeDefinitions[type].name}</span>
+                            <Trans
+                              id={VolumeDefinitions[type].name}
+                              render="span"
+                            />
                             {VolumeDefinitions[type].recommended ? (
                               <Trans
                                 render="span"
@@ -379,9 +387,11 @@ class VolumesFormSection extends Component {
                               </Trans>
                             ) : null}
                           </div>
-                          <span className="dropdown-select-item-description">
-                            {VolumeDefinitions[type].description}
-                          </span>
+                          <Trans
+                            id={VolumeDefinitions[type].description}
+                            render="span"
+                            className="dropdown-select-item-description"
+                          />
                         </SelectOption>
                       );
                     })}

--- a/plugins/services/src/js/constants/ContainerConstants.js
+++ b/plugins/services/src/js/constants/ContainerConstants.js
@@ -1,10 +1,12 @@
+import { i18nMark } from "@lingui/react";
+
 module.exports = {
   type: {
     MESOS: "MESOS",
     DOCKER: "DOCKER"
   },
   labelMap: {
-    DOCKER: "Docker Engine",
-    MESOS: "Universal Container Runtime (UCR)"
+    DOCKER: i18nMark("Docker Engine"),
+    MESOS: i18nMark("Universal Container Runtime (UCR)")
   }
 };

--- a/plugins/services/src/js/constants/DeclinedOffersHelpText.js
+++ b/plugins/services/src/js/constants/DeclinedOffersHelpText.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import React from "react";
 
 import MetadataStore from "#SRC/js/stores/MetadataStore";
@@ -8,13 +9,13 @@ const summaryDocsURL = MetadataStore.buildDocsURI(
 
 module.exports = {
   summaryIntro: (
-    <span>
-      {
-        "When you attempt to deploy a service, DC/OS waits for offers to match the resources your service requires. If the offer does not satisfy the requirement, it is declined and DC/OS retries. "
-      }
+    <Trans render="span">
+      When you attempt to deploy a service, DC/OS waits for offers to match the{" "}
+      resources your service requires. If the offer does not satisfy the{" "}
+      requirement, it is declined and DC/OS retries.{" "}
       <a href={summaryDocsURL} target="_blank">
         Learn more
       </a>.
-    </span>
+    </Trans>
   )
 };

--- a/plugins/services/src/js/constants/OperatorTypes.js
+++ b/plugins/services/src/js/constants/OperatorTypes.js
@@ -1,60 +1,73 @@
+import { Trans } from "@lingui/macro";
+import { i18nMark } from "@lingui/react";
+import React from "react";
+
 const OperatorTypes = {
   UNIQUE: {
     requiresValue: false,
     requiresEmptyValue: true,
     stringNumberValue: false,
-    tooltipContent: "The unique operator does not accept a value.",
-    name: "Unique",
-    description: "Run each app task on a unique attribute ID"
+    tooltipContent: (
+      <Trans render="span">The unique operator does not accept a value.</Trans>
+    ),
+    name: i18nMark("Unique"),
+    description: i18nMark("Run each app task on a unique attribute ID")
   },
   CLUSTER: {
     requiresValue: true,
     requiresEmptyValue: false,
     stringNumberValue: false,
     tooltipContent: null,
-    name: "Cluster",
-    description: "Run app tasks on nodes that share a certain attribute ID"
+    name: i18nMark("Cluster"),
+    description: i18nMark(
+      "Run app tasks on nodes that share a certain attribute ID"
+    )
   },
   GROUP_BY: {
     requiresValue: false,
     requiresEmptyValue: false,
     stringNumberValue: true,
     tooltipContent: null,
-    name: "Group By",
-    description: "Run app tasks evenly distributed across a certain attribute"
+    name: i18nMark("Group By"),
+    description: i18nMark(
+      "Run app tasks evenly distributed across a certain attribute"
+    )
   },
   IS: {
     requiresValue: true,
     requiresEmptyValue: false,
     stringNumberValue: false,
     tooltipContent: null,
-    name: "Is",
-    description:
+    name: i18nMark("Is"),
+    description: i18nMark(
       "Run app tasks on nodes having attribute ID with a specific value"
+    )
   },
   LIKE: {
     requiresValue: true,
     requiresEmptyValue: false,
     stringNumberValue: false,
     tooltipContent: null,
-    name: "Like",
-    description: "Run app tasks on a particular set of attribute IDs"
+    name: i18nMark("Like"),
+    description: i18nMark("Run app tasks on a particular set of attribute IDs")
   },
   UNLIKE: {
     requiresValue: true,
     requiresEmptyValue: false,
     stringNumberValue: false,
     tooltipContent: null,
-    name: "Unlike",
-    description: "Don't run app tasks on a particular set of attribute IDs"
+    name: i18nMark("Unlike"),
+    description: i18nMark(
+      "Don't run app tasks on a particular set of attribute IDs"
+    )
   },
   MAX_PER: {
     requiresValue: true,
     requiresEmptyValue: false,
     stringNumberValue: true,
     tooltipContent: null,
-    name: "Max Per",
-    description: "Run max number of app tasks on each attribute ID"
+    name: i18nMark("Max Per"),
+    description: i18nMark("Run max number of app tasks on each attribute ID")
   }
 };
 

--- a/plugins/services/src/js/constants/PodContainerStatus.js
+++ b/plugins/services/src/js/constants/PodContainerStatus.js
@@ -1,86 +1,88 @@
+import { i18nMark } from "@lingui/react";
+
 const POD_CONTAINER_STATUS = {
   CREATED: {
     dotClassName: "dot inactive unknown",
     textClassName: "",
-    displayName: "Created",
+    displayName: i18nMark("Created"),
     healthStatus: "NA"
   },
   STAGING: {
     dotClassName: "dot inactive unknown",
     textClassName: "",
-    displayName: "Staging",
+    displayName: i18nMark("Staging"),
     healthStatus: "NA"
   },
   STARTING: {
     dotClassName: "dot inactive unknown",
     textClassName: "",
-    displayName: "Starting",
+    displayName: i18nMark("Starting"),
     healthStatus: "NA"
   },
   STARTED: {
     dotClassName: "dot inactive unknown",
     textClassName: "",
-    displayName: "Started",
+    displayName: i18nMark("Started"),
     healthStatus: "NA"
   },
   HEALTHY: {
     dotClassName: "dot healthy",
     textClassName: "task-status-running",
-    displayName: "Running",
+    displayName: i18nMark("Running"),
     healthStatus: "HEALTHY"
   },
   UNHEALTHY: {
     dotClassName: "dot unhealthy",
     textClassName: "task-status-running",
-    displayName: "Unhealthy",
+    displayName: i18nMark("Unhealthy"),
     healthStatus: "UNHEALTHY"
   },
   RUNNING: {
     dotClassName: "dot running",
     textClassName: "task-status-running",
-    displayName: "Running",
+    displayName: i18nMark("Running"),
     healthStatus: "NA"
   },
   ERROR: {
     dotClassName: "dot danger",
     textClassName: "task-status-error",
-    displayName: "Error",
+    displayName: i18nMark("Error"),
     healthStatus: "UNHEALTHY"
   },
   FAILED: {
     dotClassName: "dot danger",
     textClassName: "task-status-error",
-    displayName: "Failed",
+    displayName: i18nMark("Failed"),
     healthStatus: "UNHEALTHY"
   },
   KILLING: {
     dotClassName: "dot danger",
     textClassName: "",
-    displayName: "Killing",
+    displayName: i18nMark("Killing"),
     healthStatus: "UNHEALTHY"
   },
   KILLED: {
     dotClassName: "dot inactive danger",
     textClassName: "",
-    displayName: "Killed",
+    displayName: i18nMark("Killed"),
     healthStatus: "NA"
   },
   FINISHED: {
     dotClassName: "dot inactive danger",
     textClassName: "",
-    displayName: "Completed",
+    displayName: i18nMark("Completed"),
     healthStatus: "NA"
   },
   LOST: {
     dotClassName: "dot inactive danger",
     textClassName: "",
-    displayName: "Lost",
+    displayName: i18nMark("Lost"),
     healthStatus: "NA"
   },
   NA: {
     dotClassName: "dot inactive unknown",
     textClassName: "",
-    displayName: "N/A",
+    displayName: i18nMark("N/A"),
     healthStatus: "NA"
   }
 };

--- a/plugins/services/src/js/constants/PodInstanceStatus.js
+++ b/plugins/services/src/js/constants/PodInstanceStatus.js
@@ -1,44 +1,46 @@
+import { i18nMark } from "@lingui/react";
+
 const POD_INSTANCE_STATUS = {
   HEALTHY: {
     dotClassName: "dot healthy",
     textClassName: "task-status-running",
-    displayName: "Running",
+    displayName: i18nMark("Running"),
     healthStatus: "HEALTHY"
   },
   UNHEALTHY: {
     dotClassName: "dot unhealthy",
     textClassName: "task-status-running",
-    displayName: "Unhealthy",
+    displayName: i18nMark("Unhealthy"),
     healthStatus: "UNHEALTHY"
   },
   RUNNING: {
     dotClassName: "dot running",
     textClassName: "task-status-running",
-    displayName: "Running",
+    displayName: i18nMark("Running"),
     healthStatus: "NA"
   },
   STAGED: {
     dotClassName: "dot staged",
     textClassName: "task-status-staging",
-    displayName: "Staging",
+    displayName: i18nMark("Staging"),
     healthStatus: "NA"
   },
   KILLED: {
     dotClassName: "dot inactive danger",
     textClassName: "",
-    displayName: "Killed",
+    displayName: i18nMark("Killed"),
     healthStatus: "NA"
   },
   FINISHED: {
     dotClassName: "dot inactive danger",
     textClassName: "",
-    displayName: "Completed",
+    displayName: i18nMark("Completed"),
     healthStatus: "NA"
   },
   NA: {
     dotClassName: "dot inactive unknown",
     textClassName: "",
-    displayName: "N/A",
+    displayName: i18nMark("N/A"),
     healthStatus: "NA"
   }
 };

--- a/plugins/services/src/js/constants/PodTableHeaderLabels.js
+++ b/plugins/services/src/js/constants/PodTableHeaderLabels.js
@@ -1,12 +1,14 @@
+import { i18nMark } from "@lingui/react";
+
 module.exports = {
-  name: "Name",
-  address: "Host/Port",
-  zone: "Zone",
-  region: "Region",
-  status: "Status",
-  health: "Health",
-  cpus: "CPU",
-  mem: "Mem",
-  updated: "Updated",
-  version: "Version"
+  name: i18nMark("Name"),
+  address: i18nMark("Host/Port"),
+  zone: i18nMark("Zone"),
+  region: i18nMark("Region"),
+  status: i18nMark("Status"),
+  health: i18nMark("Health"),
+  cpus: i18nMark("CPU"),
+  mem: i18nMark("Mem"),
+  updated: i18nMark("Updated"),
+  version: i18nMark("Version")
 };

--- a/plugins/services/src/js/constants/ServiceErrorMessages.js
+++ b/plugins/services/src/js/constants/ServiceErrorMessages.js
@@ -1,43 +1,44 @@
+import { i18nMark } from "@lingui/react";
 import DefaultErrorMessages from "#SRC/js/constants/DefaultErrorMessages";
 
 const ServiceErrorMessages = [
   {
     path: /^id$/,
     type: "PROP_IS_MISSING",
-    message: "Must be defined"
+    message: i18nMark("Must be defined")
   },
   {
     path: /^id$/,
     type: "ALREADY_EXISTS",
-    message: "Already exists"
+    message: i18nMark("Already exists")
   },
   {
     path: /^id$/,
     type: "STRING_PATTERN",
-    message:
-      "May only contain digits (0-9), dashes (-), " +
-      "dots (.),lowercase letters (a-z), and slashes (/) e.g. /group/my-service"
+    message: i18nMark(
+      "May only contain digits (0-9), dashes (-), dots (.),lowercase letters (a-z), and slashes (/) e.g. /group/my-service"
+    )
   },
   {
     path: /.*/,
     type: "SERVICE_DEPLOYING",
-    message:
-      "The service is currently locked by one or more deployments. " +
-      "Press again to force this operation."
+    message: i18nMark(
+      "The service is currently locked by one or more deployments. Press again to force this operation."
+    )
   },
   {
     path: /^container\.docker\.portMappings\.[0-9]+\.name$/,
     type: "STRING_PATTERN",
-    message:
-      "May only contain digits (0-9), dashes (-) and " +
-      "lowercase letters (a-z) e.g. web-server"
+    message: i18nMark(
+      "May only contain digits (0-9), dashes (-) and lowercase letters (a-z) e.g. web-server"
+    )
   },
   {
     path: /^portDefinitions\.[0-9]+\.name$/,
     type: "STRING_PATTERN",
-    message:
-      "May only contain digits (0-9), dashes (-) and " +
-      "lowercase letters (a-z) e.g. web-server"
+    message: i18nMark(
+      "May only contain digits (0-9), dashes (-) and lowercase letters (a-z) e.g. web-server"
+    )
   }
 ].concat(DefaultErrorMessages);
 

--- a/plugins/services/src/js/constants/ServiceErrorPathMapping.js
+++ b/plugins/services/src/js/constants/ServiceErrorPathMapping.js
@@ -1,23 +1,25 @@
+import { i18nMark } from "@lingui/react";
+
 const ServiceErrorPathMapping = [
   {
     match: /^id$/,
-    name: "Service ID"
+    name: i18nMark("Service ID")
   },
   {
     match: /^instances$/,
-    name: "Instances"
+    name: i18nMark("Instances")
   },
   {
     match: /^cpus$/,
-    name: "CPUs"
+    name: i18nMark("CPUs")
   },
   {
     match: /^mem$/,
-    name: "Memory"
+    name: i18nMark("Memory")
   },
   {
     match: /^env\.\*$/,
-    name: "Environment variables"
+    name: i18nMark("Environment variables")
   },
 
   //
@@ -25,19 +27,19 @@ const ServiceErrorPathMapping = [
   //
   {
     match: /^container\.volumes\.[0-9]+\.containerPath$/,
-    name: "Volume container path"
+    name: i18nMark("Volume container path")
   },
   {
     match: /^container\.volumes\.[0-9]+\..*size$/,
-    name: "Volume size"
+    name: i18nMark("Volume size")
   },
   {
     match: /^container\.volumes\.[0-9]+\.hostPath$/,
-    name: "Volume host path"
+    name: i18nMark("Volume host path")
   },
   {
     match: /^container\.volumes\.[0-9]+\.mode$/,
-    name: "Volume mode"
+    name: i18nMark("Volume mode")
   },
 
   //
@@ -45,15 +47,15 @@ const ServiceErrorPathMapping = [
   //
   {
     match: /^portDefinitions\.[0-9]+\.name$/,
-    name: "Service endpoint names"
+    name: i18nMark("Service endpoint names")
   },
   {
     match: /^portDefinitions\.[0-9]+\.port$/,
-    name: "Service endpoint host ports"
+    name: i18nMark("Service endpoint host ports")
   },
   {
     match: /^portDefinitions\.[0-9]+\.labels\.VIP_/,
-    name: "Service endpoint host ports"
+    name: i18nMark("Service endpoint host ports")
   },
 
   //
@@ -61,15 +63,15 @@ const ServiceErrorPathMapping = [
   //
   {
     match: /^container\.docker\.portMappings\.[0-9]+\.name/,
-    name: "Service endpoint names"
+    name: i18nMark("Service endpoint names")
   },
   {
     match: /^container\.docker\.portMappings\.[0-9]+\.containerPort/,
-    name: "Service endpoint container ports"
+    name: i18nMark("Service endpoint container ports")
   },
   {
     match: /^container\.docker\.portMappings\.[0-9]+\.hostPort/,
-    name: "Service endpoint host ports"
+    name: i18nMark("Service endpoint host ports")
   },
 
   //
@@ -77,19 +79,19 @@ const ServiceErrorPathMapping = [
   //
   {
     match: /^healthChecks\.[0-9]+\.gracePeriodSeconds/,
-    name: "Health check grace periods"
+    name: i18nMark("Health check grace periods")
   },
   {
     match: /^healthChecks\.[0-9]+\.intervalSeconds/,
-    name: "Health check intervals"
+    name: i18nMark("Health check intervals")
   },
   {
     match: /^healthChecks\.[0-9]+\.timeoutSeconds/,
-    name: "Health check timeouts"
+    name: i18nMark("Health check timeouts")
   },
   {
     match: /^healthChecks\.[0-9]+\.maxConsecutiveFailures/,
-    name: "Health check max failures"
+    name: i18nMark("Health check max failures")
   }
 ];
 

--- a/plugins/services/src/js/constants/ServiceOtherLabels.js
+++ b/plugins/services/src/js/constants/ServiceOtherLabels.js
@@ -1,7 +1,9 @@
-var ServiceOtherLabels = {
-  CATALOG: "Catalog",
-  VOLUMES: "Volumes",
-  PODS: "Pods"
+import { i18nMark } from "@lingui/react";
+
+const ServiceOtherLabels = {
+  CATALOG: i18nMark("Catalog"),
+  VOLUMES: i18nMark("Volumes"),
+  PODS: i18nMark("Pods")
 };
 
 module.exports = ServiceOtherLabels;

--- a/plugins/services/src/js/constants/ServiceStatusLabels.js
+++ b/plugins/services/src/js/constants/ServiceStatusLabels.js
@@ -1,12 +1,14 @@
-var ServiceStatusLabels = {
-  RUNNING: "Running",
-  DEPLOYING: "Deploying",
-  STOPPED: "Stopped",
-  NA: "N/A",
-  DELAYED: "Delayed",
-  WAITING: "Waiting",
-  DELETING: "Deleting",
-  RECOVERING: "Recovering"
+import { i18nMark } from "@lingui/react";
+
+const ServiceStatusLabels = {
+  RUNNING: i18nMark("Running"),
+  DEPLOYING: i18nMark("Deploying"),
+  STOPPED: i18nMark("Stopped"),
+  NA: i18nMark("N/A"),
+  DELAYED: i18nMark("Delayed"),
+  WAITING: i18nMark("Waiting"),
+  DELETING: i18nMark("Deleting"),
+  RECOVERING: i18nMark("Recovering")
 };
 
 module.exports = ServiceStatusLabels;

--- a/plugins/services/src/js/constants/ServiceTableHeaderLabels.js
+++ b/plugins/services/src/js/constants/ServiceTableHeaderLabels.js
@@ -1,13 +1,15 @@
-var ServiceTableHeaderLabels = {
-  cpus: "CPU",
-  disk: "Disk",
-  gpus: "GPU",
-  mem: "Mem",
-  name: "Name",
-  status: "Status",
-  version: "Version",
-  instances: "Instances",
-  regions: "Region"
+import { i18nMark } from "@lingui/react";
+
+const ServiceTableHeaderLabels = {
+  cpus: i18nMark("CPU"),
+  disk: i18nMark("Disk"),
+  gpus: i18nMark("GPU"),
+  mem: i18nMark("Mem"),
+  name: i18nMark("Name"),
+  status: i18nMark("Status"),
+  version: i18nMark("Version"),
+  instances: i18nMark("Instances"),
+  regions: i18nMark("Region")
 };
 
 module.exports = ServiceTableHeaderLabels;

--- a/plugins/services/src/js/constants/TaskDirectoryHeaderLabels.js
+++ b/plugins/services/src/js/constants/TaskDirectoryHeaderLabels.js
@@ -1,9 +1,11 @@
-var TaskDirectoryHeaderLabels = {
-  path: "Name",
-  mode: "Permissions",
-  uid: "Owner",
-  size: "Size",
-  mtime: "Modified"
+import { i18nMark } from "@lingui/react";
+
+const TaskDirectoryHeaderLabels = {
+  path: i18nMark("Name"),
+  mode: i18nMark("Permissions"),
+  uid: i18nMark("Owner"),
+  size: i18nMark("Size"),
+  mtime: i18nMark("Modified")
 };
 
 module.exports = TaskDirectoryHeaderLabels;

--- a/plugins/services/src/js/constants/TaskHealthStates.js
+++ b/plugins/services/src/js/constants/TaskHealthStates.js
@@ -1,7 +1,9 @@
+import { i18nMark } from "@lingui/react";
+
 const TaskHealthStates = {
-  HEALTHY: "Healthy",
-  UNHEALTHY: "Unhealthy",
-  UNKNOWN: "Unknown"
+  HEALTHY: i18nMark("Healthy"),
+  UNHEALTHY: i18nMark("Unhealthy"),
+  UNKNOWN: i18nMark("Unknown")
 };
 
 module.exports = TaskHealthStates;

--- a/plugins/services/src/js/constants/TaskStates.js
+++ b/plugins/services/src/js/constants/TaskStates.js
@@ -1,82 +1,84 @@
+import { i18nMark } from "@lingui/react";
+
 const TaskStates = {
   TASK_CREATED: {
     stateTypes: ["active", "success"],
-    displayName: "Created"
+    displayName: i18nMark("Created")
   },
 
   TASK_STAGING: {
     stateTypes: ["active", "success"],
-    displayName: "Staging"
+    displayName: i18nMark("Staging")
   },
 
   TASK_STARTING: {
     stateTypes: ["active", "success"],
-    displayName: "Starting"
+    displayName: i18nMark("Starting")
   },
 
   TASK_STARTED: {
     stateTypes: ["active", "success"],
-    displayName: "Started"
+    displayName: i18nMark("Started")
   },
 
   TASK_RUNNING: {
     stateTypes: ["active", "success"],
-    displayName: "Running"
+    displayName: i18nMark("Running")
   },
 
   TASK_KILLING: {
     stateTypes: ["active", "failure"],
-    displayName: "Killing"
+    displayName: i18nMark("Killing")
   },
 
   TASK_FINISHED: {
     stateTypes: ["completed", "success"],
-    displayName: "Finished"
+    displayName: i18nMark("Finished")
   },
 
   TASK_KILLED: {
     stateTypes: ["completed", "failure"],
-    displayName: "Killed"
+    displayName: i18nMark("Killed")
   },
 
   TASK_FAILED: {
     stateTypes: ["completed", "failure"],
-    displayName: "Failed"
+    displayName: i18nMark("Failed")
   },
 
   TASK_LOST: {
     stateTypes: ["completed", "failure"],
-    displayName: "Lost"
+    displayName: i18nMark("Lost")
   },
 
   TASK_ERROR: {
     stateTypes: ["completed", "failure"],
-    displayName: "Error"
+    displayName: i18nMark("Error")
   },
 
   TASK_GONE: {
     stateTypes: ["completed", "failure"],
-    displayName: "Gone"
+    displayName: i18nMark("Gone")
   },
 
   TASK_GONE_BY_OPERATOR: {
     stateTypes: ["completed", "failure"],
-    displayName: "Gone by operator"
+    displayName: i18nMark("Gone by operator")
   },
 
   TASK_DROPPED: {
     stateTypes: ["completed", "failure"],
-    displayName: "Dropped"
+    displayName: i18nMark("Dropped")
   },
 
   TASK_UNREACHABLE: {
     stateTypes: ["active", "failure"],
-    displayName: "Unreachable"
+    displayName: i18nMark("Unreachable")
   },
 
   TASK_UNKNOWN: {
     stateTypes: ["completed", "failure"],
-    displayName: "Unknown"
+    displayName: i18nMark("Unknown")
   }
 };
 

--- a/plugins/services/src/js/constants/TaskTableHeaderLabels.js
+++ b/plugins/services/src/js/constants/TaskTableHeaderLabels.js
@@ -1,17 +1,19 @@
-var TaskTableHeaderLabels = {
-  cpus: "CPU",
-  gpus: "GPU",
-  disk: "Disk",
-  host: "Host",
-  zone: "Zone",
-  region: "Region",
-  mem: "Mem",
-  id: "ID",
-  name: "Name",
-  status: "Status",
-  health: "Health",
-  updated: "Updated",
-  version: "Version"
+import { i18nMark } from "@lingui/react";
+
+const TaskTableHeaderLabels = {
+  cpus: i18nMark("CPU"),
+  gpus: i18nMark("GPU"),
+  disk: i18nMark("Disk"),
+  host: i18nMark("Host"),
+  zone: i18nMark("Zone"),
+  region: i18nMark("Region"),
+  mem: i18nMark("Mem"),
+  id: i18nMark("ID"),
+  name: i18nMark("Name"),
+  status: i18nMark("Status"),
+  health: i18nMark("Health"),
+  updated: i18nMark("Updated"),
+  version: i18nMark("Version")
 };
 
 module.exports = TaskTableHeaderLabels;

--- a/plugins/services/src/js/constants/VolumeDefinitions.js
+++ b/plugins/services/src/js/constants/VolumeDefinitions.js
@@ -1,34 +1,41 @@
-var VolumeDefinitions = {
+import { i18nMark } from "@lingui/react";
+
+const VolumeDefinitions = {
   DSS: {
-    name: "DC/OS Storage Volume",
+    name: i18nMark("DC/OS Storage Volume"),
     type: "DC/OS",
-    description:
+    description: i18nMark(
       "A locally persistent volume pre-created by the operator according to a storage profile."
+    )
   },
   PERSISTENT: {
-    name: "Local Persistent Volume",
+    name: i18nMark("Local Persistent Volume"),
     type: "Persistent",
-    description:
-      "A locally persistent volume based upon the physical disks installed in the agent which has the capabilities of a single disk.",
+    description: i18nMark(
+      "A locally persistent volume based upon the physical disks installed in the agent which has the capabilities of a single disk."
+    ),
     recommended: true
   },
   EXTERNAL: {
-    name: "External Persistent Volume",
+    name: i18nMark("External Persistent Volume"),
     type: "External",
-    description:
+    description: i18nMark(
       "A REX-Ray backed volume that is mounted on the agent from network attached storage."
+    )
   },
   HOST: {
-    name: "Host Volume",
+    name: i18nMark("Host Volume"),
     type: "Host",
-    description:
+    description: i18nMark(
       "A host volume is a directory on the the local agent mapped to one in a container."
+    )
   },
   EPHEMERAL: {
-    name: "Ephemeral Storage",
+    name: i18nMark("Ephemeral Storage"),
     type: "Ephemeral",
-    description:
+    description: i18nMark(
       "Mesos default for allocating temporary disk space to a service. Enough for many stateless or semi-stateless 12-factor and cloud native applications."
+    )
   }
 };
 

--- a/plugins/services/src/js/constants/VolumeProfile.js
+++ b/plugins/services/src/js/constants/VolumeProfile.js
@@ -1,5 +1,7 @@
-var VolumeProfile = {
-  UNAVAILABLE: "Not Available"
+import { i18nMark } from "@lingui/react";
+
+const VolumeProfile = {
+  UNAVAILABLE: i18nMark("Not Available")
 };
 
 module.exports = VolumeProfile;

--- a/plugins/services/src/js/constants/VolumeStatus.js
+++ b/plugins/services/src/js/constants/VolumeStatus.js
@@ -1,7 +1,9 @@
-var VolumeStatus = {
-  ATTACHED: "Attached",
-  DETACHED: "Detached",
-  UNAVAILABLE: "Unavailable"
+import { i18nMark } from "@lingui/react";
+
+const VolumeStatus = {
+  ATTACHED: i18nMark("Attached"),
+  DETACHED: i18nMark("Detached"),
+  UNAVAILABLE: i18nMark("Unavailable")
 };
 
 module.exports = VolumeStatus;

--- a/plugins/services/src/js/containers/pod-detail/PodHeader.js
+++ b/plugins/services/src/js/containers/pod-detail/PodHeader.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import classNames from "classnames/dedupe";
 import { Dropdown } from "reactjs-components";
 import PropTypes from "prop-types";
@@ -111,7 +112,7 @@ class PodHeader extends React.Component {
     const subHeaderItems = [
       {
         classes: `media-object-item ${serviceStatusClassSet}`,
-        label: serviceStatus.displayName,
+        label: <Trans id={serviceStatus.displayName} />,
         shouldShow: serviceHealth.key != null
       },
       {

--- a/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
+++ b/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import classNames from "classnames";
 import isEqual from "lodash.isequal";
 import PropTypes from "prop-types";
@@ -398,9 +399,11 @@ class PodInstancesTable extends React.Component {
 
     return this.renderWithClickHandler(
       rowOptions,
-      <span className={`status-text ${status.textClassName}`}>
-        {status.displayName}
-      </span>
+      <Trans
+        id={status.displayName}
+        render="span"
+        className={`status-text ${status.textClassName}`}
+      />
     );
   }
 

--- a/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
+++ b/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
@@ -124,7 +124,7 @@ class PodInstancesTable extends React.Component {
 
     return (
       <span>
-        {PodTableHeaderLabels[prop]}
+        <Trans render="span" id={PodTableHeaderLabels[prop]} />
         <span className={caretClassNames} />
       </span>
     );

--- a/plugins/services/src/js/containers/pod-instances/__tests__/PodInstancesTable-test.js
+++ b/plugins/services/src/js/containers/pod-instances/__tests__/PodInstancesTable-test.js
@@ -134,7 +134,7 @@ describe("PodInstancesTable", function() {
 
       it("renders the status column", function() {
         const names = thisInstance
-          .find(".task-table-column-status .status-text")
+          .find(".task-table-column-status span.status-text")
           .map(function(el) {
             return el.text();
           });
@@ -251,10 +251,11 @@ describe("PodInstancesTable", function() {
       beforeEach(function() {
         // Create a stub router context because when the items are expanded
         // the are creating <Link /> instances.
+        const instances = pod.getInstanceList().getItems();
         const component = JestUtil.stubRouterContext(
           PodInstancesTable,
           { pod },
-          { instances: pod.getInstanceList().getItems() },
+          { instances },
           { service: pod }
         );
         thisInstance = mount(component);
@@ -316,7 +317,7 @@ describe("PodInstancesTable", function() {
 
       it("renders the status column", function() {
         const names = thisInstance
-          .find(".task-table-column-status .status-text")
+          .find(".task-table-column-status span.status-text")
           .map(function(el) {
             return el.text();
           });

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import classNames from "classnames";
 import { Dropdown, Table, Tooltip } from "reactjs-components";
 import { injectIntl } from "react-intl";
@@ -401,7 +402,11 @@ class ServicesTable extends React.Component {
             tooltipContent={tooltipContent}
           />
           {hasStatusText && (
-            <span className="status-bar-text">{serviceStatusText}</span>
+            <Trans
+              id={serviceStatusText}
+              render="span"
+              className="status-bar-text"
+            />
           )}
         </div>
         <div className="service-status-progressbar-wrapper">

--- a/plugins/services/src/js/containers/tasks/TaskTable.js
+++ b/plugins/services/src/js/containers/tasks/TaskTable.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import classNames from "classnames";
 import { routerShape, Link } from "react-router";
 import PropTypes from "prop-types";
@@ -373,14 +374,14 @@ class TaskTable extends React.Component {
     const unhealthy = task.health === TaskHealthStates.UNHEALTHY;
     const unknown = task.health === TaskHealthStates.UNKNOWN;
 
-    let tooltipContent = TaskHealthStates.HEALTHY;
+    let tooltipContent = <Trans id={TaskHealthStates.HEALTHY} render="span" />;
 
     if (unhealthy) {
-      tooltipContent = TaskHealthStates.UNHEALTHY;
+      tooltipContent = <Trans id={TaskHealthStates.UNHEALTHY} render="span" />;
     }
 
     if (!activeState || unknown || transitional) {
-      tooltipContent = "No health checks available";
+      tooltipContent = <Trans render="span">No health checks available</Trans>;
     }
 
     const failing = ["TASK_ERROR", "TASK_FAILED"].includes(state);

--- a/plugins/services/src/js/containers/tasks/TaskTable.js
+++ b/plugins/services/src/js/containers/tasks/TaskTable.js
@@ -1,4 +1,5 @@
 import { Trans } from "@lingui/macro";
+import { withI18n } from "@lingui/react";
 import classNames from "classnames";
 import { routerShape, Link } from "react-router";
 import PropTypes from "prop-types";
@@ -58,7 +59,7 @@ class TaskTable extends React.Component {
   }
 
   getStatusValue(task) {
-    return TaskStates[task.state].displayName;
+    return this.props.i18n._(TaskStates[task.state].displayName);
   }
 
   getVersionValue(task) {
@@ -354,7 +355,11 @@ class TaskTable extends React.Component {
 
     return (
       <div className="flex-box flex-box-align-vertical-center table-cell-flex-box">
-        <span className={statusLabelClasses}>{this.getStatusValue(task)}</span>
+        <Trans
+          id={this.getStatusValue(task)}
+          render="span"
+          className={statusLabelClasses}
+        />
       </div>
     );
   }
@@ -459,4 +464,5 @@ TaskTable.defaultProps = {
   tasks: []
 };
 
-module.exports = TaskTable;
+export default withI18n()(TaskTable);
+export { TaskTable };

--- a/plugins/services/src/js/containers/tasks/TaskTable.js
+++ b/plugins/services/src/js/containers/tasks/TaskTable.js
@@ -1,5 +1,4 @@
 import { Trans } from "@lingui/macro";
-import { withI18n } from "@lingui/react";
 import classNames from "classnames";
 import { routerShape, Link } from "react-router";
 import PropTypes from "prop-types";
@@ -455,7 +454,8 @@ TaskTable.propTypes = {
   className: PropTypes.string,
   onCheckboxChange: PropTypes.func,
   params: PropTypes.object.isRequired,
-  tasks: PropTypes.array.isRequired
+  tasks: PropTypes.array.isRequired,
+  i18n: PropTypes.object
 };
 
 TaskTable.defaultProps = {
@@ -464,5 +464,4 @@ TaskTable.defaultProps = {
   tasks: []
 };
 
-export default withI18n()(TaskTable);
-export { TaskTable };
+module.exports = TaskTable;

--- a/plugins/services/src/js/containers/tasks/TasksView.js
+++ b/plugins/services/src/js/containers/tasks/TasksView.js
@@ -4,6 +4,7 @@ import { Tooltip } from "reactjs-components";
 import { routerShape } from "react-router";
 import PropTypes from "prop-types";
 import React from "react";
+import { withI18n } from "@lingui/react";
 
 import DCOSStore from "#SRC/js/stores/DCOSStore";
 import DSLFilterField from "#SRC/js/components/DSLFilterField";
@@ -97,6 +98,7 @@ class TasksView extends mixin(SaveStateMixin) {
         params={params}
         onCheckboxChange={this.handleItemCheck}
         tasks={tasks}
+        i18n={this.props.i18n}
       />
     );
   }
@@ -292,4 +294,4 @@ TasksView.contextTypes = {
   router: routerShape
 };
 
-module.exports = TasksView;
+module.exports = withI18n()(TasksView);

--- a/plugins/services/src/js/containers/tasks/__tests__/TaskTable-test.js
+++ b/plugins/services/src/js/containers/tasks/__tests__/TaskTable-test.js
@@ -7,7 +7,7 @@ const DCOSStore = require("#SRC/js/stores/DCOSStore");
 const JestUtil = require("#SRC/js/utils/JestUtil");
 const MesosStateStore = require("#SRC/js/stores/MesosStateStore");
 
-const TaskTable = require("../TaskTable");
+const { TaskTable } = require("../TaskTable");
 
 let thisTaskTable, thisGetNodeFromID;
 

--- a/plugins/services/src/js/containers/tasks/__tests__/TaskTable-test.js
+++ b/plugins/services/src/js/containers/tasks/__tests__/TaskTable-test.js
@@ -7,7 +7,7 @@ const DCOSStore = require("#SRC/js/stores/DCOSStore");
 const JestUtil = require("#SRC/js/utils/JestUtil");
 const MesosStateStore = require("#SRC/js/stores/MesosStateStore");
 
-const { TaskTable } = require("../TaskTable");
+const TaskTable = require("../TaskTable");
 
 let thisTaskTable, thisGetNodeFromID;
 

--- a/plugins/services/src/js/pages/task-details/TaskDetail.js
+++ b/plugins/services/src/js/pages/task-details/TaskDetail.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import mixin from "reactjs-mixin";
 import PropTypes from "prop-types";
 /* eslint-disable no-unused-vars */
@@ -260,7 +261,7 @@ class TaskDetail extends mixin(TabsMixin, StoreMixin) {
       <DetailViewHeader
         icon={taskIcon}
         iconClassName="icon-app-container  icon-image-container"
-        subTitle={serviceStatus}
+        subTitle={<Trans render="span" id={serviceStatus} />}
         subTitleClassName={serviceStatusClassSet}
         navigationTabs={navigationTabs}
         title={task.getName()}

--- a/plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import React from "react";
 import { Table } from "reactjs-components";
 
@@ -90,7 +91,9 @@ class ServiceGeneralConfigSection extends ServiceConfigBaseSectionDisplay {
           key: "container.type",
           label: "Container Runtime",
           transformValue(runtime) {
-            return labelMap[runtime] || labelMap[MESOS];
+            const transId = labelMap[runtime] || labelMap[MESOS];
+
+            return <Trans render="span" id={transId} />;
           }
         },
         {

--- a/plugins/services/src/js/service-configuration/ServiceStorageConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceStorageConfigSection.js
@@ -1,3 +1,5 @@
+import { Trans } from "@lingui/macro";
+import React from "react";
 import { formatResource } from "#SRC/js/utils/Units";
 import Util from "#SRC/js/utils/Util";
 import VolumeDefinitions from "#PLUGINS/services/src/js/constants/VolumeDefinitions";
@@ -71,7 +73,7 @@ class ServiceStorageConfigSection extends ServiceConfigBaseSectionDisplay {
         // DSS
         return [
           {
-            heading: VolumeDefinitions.DSS.name,
+            heading: <Trans id={VolumeDefinitions.DSS.name} render="span" />,
             headingLevel: 2
           },
           {
@@ -94,7 +96,9 @@ class ServiceStorageConfigSection extends ServiceConfigBaseSectionDisplay {
         // Local Persistent
         return [
           {
-            heading: VolumeDefinitions.PERSISTENT.name,
+            heading: (
+              <Trans id={VolumeDefinitions.PERSISTENT.name} render="span" />
+            ),
             headingLevel: 2
           },
           {
@@ -122,7 +126,9 @@ class ServiceStorageConfigSection extends ServiceConfigBaseSectionDisplay {
 
         return [
           {
-            heading: VolumeDefinitions.EXTERNAL.name,
+            heading: (
+              <Trans id={VolumeDefinitions.EXTERNAL.name} render="span" />
+            ),
             headingLevel: 2
           },
           {
@@ -139,7 +145,7 @@ class ServiceStorageConfigSection extends ServiceConfigBaseSectionDisplay {
       // Host
       return [
         {
-          heading: VolumeDefinitions.HOST.name,
+          heading: <Trans id={VolumeDefinitions.HOST.name} render="span" />,
           headingLevel: 2
         },
         {

--- a/src/js/components/JobsBreadcrumbs.js
+++ b/src/js/components/JobsBreadcrumbs.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import { Link } from "react-router";
 import prettycron from "prettycron";
 import PropTypes from "prop-types";
@@ -36,10 +37,13 @@ function getItemStatus(item) {
     return null;
   }
 
+  const longestRunningTaskState =
+    TaskStates[longestRunningTask.getStatus()].displayName;
+
   return (
     <BreadcrumbSupplementalContent>
       <div className="service-page-header-status muted">
-        ({TaskStates[longestRunningTask.getStatus()].displayName})
+        (<Trans id={longestRunningTaskState} render="span" />)
       </div>
     </BreadcrumbSupplementalContent>
   );

--- a/src/js/components/PlacementConstraintsPartial.js
+++ b/src/js/components/PlacementConstraintsPartial.js
@@ -1,4 +1,5 @@
-import { Trans } from "@lingui/macro";
+import { Trans, t } from "@lingui/macro";
+import { withI18n } from "@lingui/react";
 import React, { Component } from "react";
 import { Tooltip, Select, SelectOption } from "reactjs-components";
 
@@ -20,7 +21,7 @@ import PlacementConstraintsUtil from "#PLUGINS/services/src/js/utils/PlacementCo
 // &nbsp; to space the table rows
 const NBSP = "\u00A0";
 
-export default class PlacementConstraintsPartial extends Component {
+class PlacementConstraintsPartial extends Component {
   getPlacementConstraintLabel(name) {
     return (
       <FieldLabel>
@@ -45,7 +46,7 @@ export default class PlacementConstraintsPartial extends Component {
     );
   }
 
-  getPlacementConstraintsFields(data = []) {
+  getPlacementConstraintsFields(data = [], i18n) {
     const constraintsErrors = findNestedPropertyInObject(
       this.props.errors,
       "constraints"
@@ -81,9 +82,9 @@ export default class PlacementConstraintsPartial extends Component {
       const commonFieldsClassNames = "column-4";
 
       if (isFirstConstraint) {
-        fieldLabel = this.getPlacementConstraintLabel("Field");
-        operatorLabel = this.getPlacementConstraintLabel("Operator");
-        valueLabel = this.getPlacementConstraintLabel("Value");
+        fieldLabel = this.getPlacementConstraintLabel(i18n._(t`Field`));
+        operatorLabel = this.getPlacementConstraintLabel(i18n._(t`Operator`));
+        valueLabel = this.getPlacementConstraintLabel(i18n._(t`Value`));
       }
 
       const fieldValue = (
@@ -116,14 +117,18 @@ export default class PlacementConstraintsPartial extends Component {
                   <SelectOption
                     key={index}
                     value={type}
-                    label={OperatorTypes[type].name}
+                    label={i18n._(t(OperatorTypes[type].name))}
                   >
-                    <span className="dropdown-select-item-title">
-                      {OperatorTypes[type].name}
-                    </span>
-                    <span className="dropdown-select-item-description">
-                      {OperatorTypes[type].description}
-                    </span>
+                    <Trans
+                      render="span"
+                      id={OperatorTypes[type].name}
+                      className="dropdown-select-item-title"
+                    />
+                    <Trans
+                      render="span"
+                      id={OperatorTypes[type].description}
+                      className="dropdown-select-item-description"
+                    />
                   </SelectOption>
                 );
               })}
@@ -192,7 +197,7 @@ export default class PlacementConstraintsPartial extends Component {
   }
 
   render() {
-    const { data = {} } = this.props;
+    const { data = {}, i18n } = this.props;
     const constraintsErrors = findNestedPropertyInObject(
       this.props.errors,
       "constraints"
@@ -211,7 +216,7 @@ export default class PlacementConstraintsPartial extends Component {
 
     return (
       <div>
-        {this.getPlacementConstraintsFields(data.constraints)}
+        {this.getPlacementConstraintsFields(data.constraints, i18n)}
         {errorNode}
         <FormRow>
           <FormGroup className="column-12">
@@ -229,3 +234,5 @@ export default class PlacementConstraintsPartial extends Component {
     );
   }
 }
+
+export default withI18n()(PlacementConstraintsPartial);

--- a/src/js/components/PlacementConstraintsPartial.js
+++ b/src/js/components/PlacementConstraintsPartial.js
@@ -46,7 +46,8 @@ class PlacementConstraintsPartial extends Component {
     );
   }
 
-  getPlacementConstraintsFields(data = [], i18n) {
+  getPlacementConstraintsFields(data = []) {
+    const { i18n } = this.props;
     const constraintsErrors = findNestedPropertyInObject(
       this.props.errors,
       "constraints"
@@ -197,7 +198,7 @@ class PlacementConstraintsPartial extends Component {
   }
 
   render() {
-    const { data = {}, i18n } = this.props;
+    const { data = {} } = this.props;
     const constraintsErrors = findNestedPropertyInObject(
       this.props.errors,
       "constraints"
@@ -216,7 +217,7 @@ class PlacementConstraintsPartial extends Component {
 
     return (
       <div>
-        {this.getPlacementConstraintsFields(data.constraints, i18n)}
+        {this.getPlacementConstraintsFields(data.constraints)}
         {errorNode}
         <FormRow>
           <FormGroup className="column-12">

--- a/src/js/components/PlacementConstraintsPartial.js
+++ b/src/js/components/PlacementConstraintsPartial.js
@@ -117,7 +117,7 @@ class PlacementConstraintsPartial extends Component {
                   <SelectOption
                     key={index}
                     value={type}
-                    label={i18n._(t(OperatorTypes[type].name))}
+                    label={i18n._(OperatorTypes[type].name)}
                   >
                     <Trans
                       render="span"


### PR DESCRIPTION
Using `i18nMark` to mark strings used in the `plugins/services/src/js/constants` for translation. Also updating usages of the constants to be translated using either the `Trans` macro or `i18n` instance object.

## Testing

There _should_ be no visual changes.

## Trade-offs

Instead of wrapping the `TaskTable` component in the `withI18n()` higher-order component directly, I wrapped it's parent `TaskView` in `withI18n()` and passed the `i18n` instance object to `TaskTable` as a prop. This was to not disrupt the existing `TaskTable` unit tests that are testing function on the `TaskTable` component. By wrapping `TaskTable` with `withI18n()` the functions were no longer easily accessible in the unit tests.  Another option would of been to wrap `TaskTable` in `withI18n()` for the default export but also export the unwrapped component. And yet another option would be to refactor the functions we want to unit test to a utils file instead of trying to access them on the component directly. 

The `ServiceErrorMessages` file was marked in this PR, but translations of error messages will be done in another PR by refactoring functions in the `ErrorMessageUtil` file.
