### PR TITLE
DCOS-43373: Mark and translate jobs plugin constants

### DIFF
--- a/plugins/jobs/src/js/components/JobsOverviewTable.js
+++ b/plugins/jobs/src/js/components/JobsOverviewTable.js
@@ -285,7 +285,13 @@ export default class JobsOverviewTable extends React.Component {
       "text-danger": jobState.stateTypes.includes("failure")
     });
 
-    return <span className={statusClasses}>{jobState.displayName}</span>;
+    return (
+      <Trans
+        render="span"
+        className={statusClasses}
+        id={jobState.displayName}
+      />
+    );
   }
 
   render() {

--- a/plugins/jobs/src/js/constants/JobStates.ts
+++ b/plugins/jobs/src/js/constants/JobStates.ts
@@ -3,6 +3,8 @@
  * to least important (largest number, bottom of list)
  */
 
+import { i18nMark } from "@lingui/react";
+
 export interface JobStates {
   [state: string]: {
     stateTypes: string[];
@@ -14,42 +16,42 @@ export interface JobStates {
 const states: JobStates = {
   INITIAL: {
     stateTypes: ["active"],
-    displayName: "Starting",
+    displayName: i18nMark("Starting"),
     sortOrder: 3
   },
   STARTING: {
     stateTypes: ["active"],
-    displayName: "Starting",
+    displayName: i18nMark("Starting"),
     sortOrder: 3
   },
   ACTIVE: {
     stateTypes: ["active"],
-    displayName: "Running",
+    displayName: i18nMark("Running"),
     sortOrder: 4
   },
   FAILED: {
     stateTypes: ["completed", "failure"],
-    displayName: "Failed",
+    displayName: i18nMark("Failed"),
     sortOrder: 0
   },
   SUCCESS: {
     stateTypes: ["success"],
-    displayName: "Success",
+    displayName: i18nMark("Success"),
     sortOrder: 6
   },
   COMPLETED: {
     stateTypes: ["success"],
-    displayName: "Completed",
+    displayName: i18nMark("Completed"),
     sortOrder: 5
   },
   SCHEDULED: {
     stateTypes: [],
-    displayName: "Scheduled",
+    displayName: i18nMark("Scheduled"),
     sortOrder: 2
   },
   UNSCHEDULED: {
     stateTypes: [],
-    displayName: "Unscheduled",
+    displayName: i18nMark("Unscheduled"),
     sortOrder: 1
   }
 };

--- a/plugins/jobs/src/js/constants/JobStatus.ts
+++ b/plugins/jobs/src/js/constants/JobStatus.ts
@@ -2,25 +2,20 @@
  * Sort order is ordered by most important (lowest number, top of list)
  * to least important (largest number, bottom of list)
  */
-
 export interface JobStatus {
   [state: string]: {
-    displayName: string;
     sortOrder: number;
   };
 }
 
 const status: JobStatus = {
   "N/A": {
-    displayName: "N/A",
     sortOrder: 1
   },
   Success: {
-    displayName: "Success",
     sortOrder: 2
   },
   Failed: {
-    displayName: "Failed",
     sortOrder: 0
   }
 };

--- a/plugins/jobs/src/js/constants/JobTableHeaderLabels.js
+++ b/plugins/jobs/src/js/constants/JobTableHeaderLabels.js
@@ -1,7 +1,9 @@
+import { i18nMark } from "@lingui/react";
+
 const JobTableHeaderLabels = {
-  name: "Name",
-  status: "Status",
-  lastRun: "Last Run"
+  name: i18nMark("Name"),
+  status: i18nMark("Status"),
+  lastRun: i18nMark("Last Run")
 };
 
 module.exports = JobTableHeaderLabels;

--- a/plugins/jobs/src/js/pages/JobRunHistoryTable.js
+++ b/plugins/jobs/src/js/pages/JobRunHistoryTable.js
@@ -302,7 +302,13 @@ class JobRunHistoryTable extends React.Component {
         "text-neutral": status.stateTypes.includes("active")
       });
 
-      return <span className={statusClasses}>{status.displayName}</span>;
+      return (
+        <Trans
+          render="span"
+          className={statusClasses}
+          id={status.displayName}
+        />
+      );
     }
 
     const status = TaskStates[row[prop]];

--- a/src/js/structs/Job.d.ts
+++ b/src/js/structs/Job.d.ts
@@ -4,18 +4,14 @@ import JobRunList from "./JobRunList";
 export default class Job extends Item {
   getActiveRuns(): JobRunList;
   getCommand(): string;
-  getCpus(): Number;
+  getCpus(): number;
   getDescription(): string;
   getDocker(): string;
-  getDisk(): Number;
+  getDisk(): number;
   getId(): string;
-  getJobRuns(): JobRunList;
   getLabels(): object;
-  getMem(): Number;
-  getLastRunsSummary(): object;
-  getLastRunStatus(): object;
+  getMem(): number;
   getName(): string;
   getSchedules(): string[];
-  getScheduleStatus(): string;
   toJSON(): object;
 }

--- a/src/js/structs/__tests__/Job-test.js
+++ b/src/js/structs/__tests__/Job-test.js
@@ -119,46 +119,6 @@ describe("Job", function() {
     });
   });
 
-  describe("#getJobRuns", function() {
-    it("returns an instance of JobRunList", function() {
-      const job = new Job({ id: "foo", activeRuns: [] });
-
-      expect(job.getJobRuns()).toEqual(jasmine.any(JobRunList));
-    });
-
-    it("includes failed finished runs", function() {
-      const job = new Job({
-        id: "foo",
-        activeRuns: [],
-        history: {
-          failedFinishedRuns: [
-            {
-              id: "bar"
-            }
-          ]
-        }
-      });
-
-      expect(job.getJobRuns().getItems()[0].id).toEqual("bar");
-    });
-
-    it("includes successful finished runs", function() {
-      const job = new Job({
-        id: "foo",
-        activeRuns: [],
-        history: {
-          successfulFinishedRuns: [
-            {
-              id: "bar"
-            }
-          ]
-        }
-      });
-
-      expect(job.getJobRuns().getItems()[0].id).toEqual("bar");
-    });
-  });
-
   describe("#getLabels", function() {
     it("returns the correct labels", function() {
       const job = new Job({
@@ -205,76 +165,6 @@ describe("Job", function() {
     });
   });
 
-  describe("#getLastRunStatus", function() {
-    it("returns an object with the time in ms", function() {
-      const job = new Job({
-        id: "test.job",
-        historySummary: {
-          lastSuccessAt: "1990-04-30T00:00:00Z",
-          lastFailureAt: "1985-04-30T00:00:00Z"
-        }
-      });
-
-      expect(job.getLastRunStatus().time).toEqual(641433600000);
-    });
-
-    it("returns the most recent status", function() {
-      const job = new Job({
-        id: "test.job",
-        historySummary: {
-          lastSuccessAt: "1990-04-30T00:00:00Z",
-          lastFailureAt: "1985-04-30T00:00:00Z"
-        }
-      });
-
-      expect(job.getLastRunStatus().status).toEqual("Success");
-    });
-
-    it("returns the most recent status", function() {
-      const job = new Job({
-        id: "test.job",
-        historySummary: {
-          lastSuccessAt: "1985-04-30T00:00:00Z",
-          lastFailureAt: "1990-04-30T00:00:00Z"
-        }
-      });
-
-      expect(job.getLastRunStatus().status).toEqual("Failed");
-    });
-
-    it("returns N/A status if both are undefiend", function() {
-      const job = new Job({
-        id: "test.job",
-        historySummary: {}
-      });
-
-      expect(job.getLastRunStatus().status).toEqual("N/A");
-      expect(job.getLastRunStatus().time).toEqual(null);
-    });
-
-    it("returns success if lastFailureAt is undefiend", function() {
-      const job = new Job({
-        id: "test.job",
-        historySummary: {
-          lastSuccessAt: "1990-04-30T00:00:00Z"
-        }
-      });
-
-      expect(job.getLastRunStatus().status).toEqual("Success");
-    });
-
-    it("returns success if lastSuccessAt is undefiend", function() {
-      const job = new Job({
-        id: "test.job",
-        historySummary: {
-          lastFailureAt: "1990-04-30T00:00:00Z"
-        }
-      });
-
-      expect(job.getLastRunStatus().status).toEqual("Failed");
-    });
-  });
-
   describe("#getName", function() {
     it("returns correct name", function() {
       const job = new Job({ id: "test.job" });
@@ -294,64 +184,6 @@ describe("Job", function() {
       const job = new Job({ id: "/foo" });
 
       expect(job.getSchedules()).toEqual([]);
-    });
-  });
-
-  describe("#getScheduleStatus", function() {
-    it("returns the longest running job's status", function() {
-      const job = new Job({
-        id: "/foo",
-        activeRuns: [
-          {
-            status: "foo",
-            createdAt: "1985-01-03t00:00:00z-1"
-          },
-          {
-            status: "bar",
-            createdAt: "1990-01-03t00:00:00z-1"
-          }
-        ],
-        schedules: ["bar"]
-      });
-
-      expect(job.getScheduleStatus()).toEqual("foo");
-    });
-
-    it("returns scheduled if there are no active runs and the schedule is enabled", function() {
-      const job = new Job({
-        id: "/foo",
-        activeRuns: [],
-        schedules: [
-          {
-            enabled: true
-          }
-        ]
-      });
-
-      expect(job.getScheduleStatus()).toEqual("SCHEDULED");
-    });
-
-    it("returns unscheduled if there are no active runs and no enabled schedule", function() {
-      const job = new Job({
-        id: "/foo",
-        activeRuns: [],
-        scheduled: [
-          {
-            enabled: false
-          }
-        ]
-      });
-
-      expect(job.getScheduleStatus()).toEqual("UNSCHEDULED");
-    });
-
-    it("returns unscheduled if there are no active runs and no schedule", function() {
-      const job = new Job({
-        id: "/foo",
-        activeRuns: []
-      });
-
-      expect(job.getScheduleStatus()).toEqual("UNSCHEDULED");
     });
   });
 


### PR DESCRIPTION
## Testing

There should be no visual differences or markup changes after this PR is merged.

## Dependencies

Once the dust settles we need to run `npm run lingui-extract-with-plugins` and commit the message catalog.

## Notes

I was able to remove some unused job methods that depended on some unused job status constants
