### PR TITLE
DCOS-43637 Translate messages in ErrorMessageUtil

### DIFF
--- a/plugins/services/src/js/components/modals/CreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/CreateServiceModalForm.js
@@ -1,4 +1,5 @@
 import { Trans } from "@lingui/macro";
+import { withI18n } from "@lingui/react";
 import classNames from "classnames";
 import isEqual from "lodash.isequal";
 import { MountService } from "foundation-ui";
@@ -361,7 +362,8 @@ class CreateServiceModalForm extends Component {
   getErrors() {
     return ErrorMessageUtil.translateErrorMessages(
       this.props.errors,
-      ServiceErrorMessages
+      ServiceErrorMessages,
+      this.props.i18n
     );
   }
 
@@ -835,4 +837,4 @@ CreateServiceModalForm.propTypes = {
   showAllErrors: PropTypes.bool
 };
 
-module.exports = CreateServiceModalForm;
+module.exports = withI18n()(CreateServiceModalForm);

--- a/src/js/components/ErrorsAlert.js
+++ b/src/js/components/ErrorsAlert.js
@@ -1,4 +1,5 @@
 import { Trans } from "@lingui/macro";
+import { withI18n } from "@lingui/react";
 import PropTypes from "prop-types";
 import React from "react";
 
@@ -10,7 +11,8 @@ const ErrorsAlert = function(props) {
     errors,
     hideTopLevelErrors,
     hidePermissiveErrors,
-    pathMapping
+    pathMapping,
+    i18n
   } = props;
   let showErrors = [].concat.apply([], errors);
 
@@ -30,7 +32,7 @@ const ErrorsAlert = function(props) {
 
   // De-duplicate error messages that have exactly the same translated output
   const errorMessages = showErrors.reduce(function(messages, error) {
-    const message = getUnanchoredErrorMessage(error, pathMapping);
+    const message = getUnanchoredErrorMessage(error, pathMapping, i18n);
     if (messages.indexOf(message) !== -1) {
       return messages;
     }
@@ -66,4 +68,4 @@ ErrorsAlert.propTypes = {
   pathMapping: PropTypes.array
 };
 
-module.exports = ErrorsAlert;
+module.exports = withI18n()(ErrorsAlert);

--- a/src/js/utils/ErrorMessageUtil.js
+++ b/src/js/utils/ErrorMessageUtil.js
@@ -8,9 +8,10 @@ const ErrorMessageUtil = {
    *
    * @param {Object} error - The error message
    * @param {Array} pathTranslationRules - The path translation rules
+   * @param {object} i18n - lingui internationalization instance object
    * @returns {String} Returns the composed error string
    */
-  getUnanchoredErrorMessage(error, pathTranslationRules) {
+  getUnanchoredErrorMessage(error, pathTranslationRules, i18n = null) {
     const { message, path = [] } = error;
     const pathString = path.join(".");
     const rule = pathTranslationRules.find(function(rule) {
@@ -31,7 +32,12 @@ const ErrorMessageUtil = {
     // in order to compose a proper sentence with the resolved path name.
     const errorMessage = message[0].toLowerCase() + message.substr(1);
 
-    return `${rule.name} ${errorMessage}`;
+    let name = rule.name;
+    if (i18n) {
+      name = i18n._(name);
+    }
+
+    return `${name} ${errorMessage}`;
   },
 
   /**
@@ -40,9 +46,10 @@ const ErrorMessageUtil = {
    *
    * @param {Array} errors - The list of errors to translate
    * @param {Array} translationRules - The translation rules to use
+   * @param {object} i18n - lingui internationalization instance object
    * @returns {Array} Returns a new list with the translated error messages
    */
-  translateErrorMessages(errors, translationRules) {
+  translateErrorMessages(errors, translationRules, i18n = null) {
     return errors.map(function(error) {
       const { path = [], type, variables } = error;
       const pathString = path.join(".");
@@ -56,12 +63,14 @@ const ErrorMessageUtil = {
         return error;
       }
 
+      let message = rule.message;
+      if (i18n) {
+        message = i18n._(message);
+      }
+
       // Return the translated message
       return {
-        message: rule.message.replace(MESSAGE_VARIABLE, function(
-          match,
-          variable
-        ) {
+        message: message.replace(MESSAGE_VARIABLE, function(match, variable) {
           return "" + variables[variable] || "";
         }),
         path,

--- a/src/js/utils/__tests__/ErrorMessageUtil-test.js
+++ b/src/js/utils/__tests__/ErrorMessageUtil-test.js
@@ -230,4 +230,216 @@ describe("ErrorMessageUtil", function() {
       expect(translatedErrors).toEqual([{ message: null }]);
     });
   });
+
+  describe("#getUnanchoredErrorMessage", function() {
+    it("passes through if error.isUnanchored", function() {
+      const errorInput = {
+        message: "An error message",
+        isUnanchored: true,
+        path: []
+      };
+      const pathTranslationRules = [];
+      const i18n = {
+        _(text) {
+          return text;
+        }
+      };
+
+      expect(
+        ErrorMessageUtil.getUnanchoredErrorMessage(
+          errorInput,
+          pathTranslationRules,
+          i18n
+        )
+      ).toEqual("An error message");
+    });
+
+    it("passes through if a rule is not found and path is empty", function() {
+      const errorInput = {
+        message: "An error message",
+        isUnanchored: false,
+        path: []
+      };
+      const pathTranslationRules = [];
+
+      expect(
+        ErrorMessageUtil.getUnanchoredErrorMessage(
+          errorInput,
+          pathTranslationRules
+        )
+      ).toEqual("An error message");
+    });
+
+    it("passes through if path is empty", function() {
+      const errorInput = {
+        message: "An error message",
+        isUnanchored: false,
+        path: []
+      };
+      const pathTranslationRules = [
+        {
+          match: /^foo.*/,
+          name: "Unit test"
+        }
+      ];
+
+      expect(
+        ErrorMessageUtil.getUnanchoredErrorMessage(
+          errorInput,
+          pathTranslationRules
+        )
+      ).toEqual("An error message");
+    });
+
+    it("appends path string if rule not found", function() {
+      const errorInput = {
+        message: "An error message",
+        isUnanchored: false,
+        path: ["foo", "bar"]
+      };
+      const pathTranslationRules = [];
+
+      expect(
+        ErrorMessageUtil.getUnanchoredErrorMessage(
+          errorInput,
+          pathTranslationRules
+        )
+      ).toEqual("foo.bar: An error message");
+    });
+
+    it("builds error message from name and message", function() {
+      const errorInput = {
+        message: "Error occurred doing stuff",
+        isUnanchored: false,
+        path: ["foo"]
+      };
+      const pathTranslationRules = [
+        {
+          match: /^foo.*/,
+          name: "Unit test"
+        }
+      ];
+
+      expect(
+        ErrorMessageUtil.getUnanchoredErrorMessage(
+          errorInput,
+          pathTranslationRules
+        )
+      ).toEqual("Unit test error occurred doing stuff");
+    });
+  });
+
+  describe("Localization", function() {
+    describe("#getUnanchoredErrorMessage", function() {
+      it("translated name if i18n given", function() {
+        const errorInput = {
+          message: "Error occurred doing stuff",
+          isUnanchored: false,
+          path: ["foo"]
+        };
+        const pathTranslationRules = [
+          {
+            match: /^foo.*/,
+            name: "Unit test"
+          }
+        ];
+        const i18n = {
+          _() {
+            return "Translated name";
+          }
+        };
+
+        expect(
+          ErrorMessageUtil.getUnanchoredErrorMessage(
+            errorInput,
+            pathTranslationRules,
+            i18n
+          )
+        ).toEqual("Translated name error occurred doing stuff");
+      });
+    });
+
+    describe("#translateErrorMessages", function() {
+      it("translates if path and type matches", function() {
+        const errorInput = [
+          {
+            message: "message1",
+            type: "TYPE1",
+            path: [],
+            variables: {}
+          }
+        ];
+        const translationRules = [
+          {
+            type: "TYPE1",
+            path: /.*/,
+            message: "message2"
+          }
+        ];
+        const i18n = {
+          _() {
+            return "test2";
+          }
+        };
+
+        expect(
+          ErrorMessageUtil.translateErrorMessages(
+            errorInput,
+            translationRules,
+            i18n
+          )
+        ).toEqual([
+          {
+            message: "test2",
+            type: "TYPE1",
+            path: [],
+            variables: {}
+          }
+        ]);
+      });
+
+      it("replaces variables", function() {
+        const errorInput = [
+          {
+            message: "message1 is 3",
+            type: "TYPE1",
+            path: [],
+            variables: {
+              value: 3
+            }
+          }
+        ];
+        const translationRules = [
+          {
+            type: "TYPE1",
+            path: /.*/,
+            message: "message2 is ||value||"
+          }
+        ];
+
+        const i18n = {
+          _() {
+            return "Nachricht ist ||value||";
+          }
+        };
+
+        expect(
+          ErrorMessageUtil.translateErrorMessages(
+            errorInput,
+            translationRules,
+            i18n
+          )
+        ).toEqual([
+          {
+            message: "Nachricht ist 3",
+            type: "TYPE1",
+            path: [],
+            variables: {
+              value: 3
+            }
+          }
+        ]);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Updated `ErrorMessageUtil` functions to take the `i18n` instance object as an optional
parameter. If given,`i18n` will be used to translate the error message
before replacing variables and returning result. 

The two components that use `ErrorMessageUtil` are also updated to pass `i18n` as a parameter by wrapping them in the `withI18n` higher-order component.

I also added unit tests for `getUnanchoredErrorMessage` since I was updating it and there were not any tests for this function currently.

*Note* This PR is base on #3359 and should not be merged until it has been merged first.

## Testing

There should be no visible changes to the UI from this change until the error messages have been translated and the local switch is implemented. There are new unit tests for the additions to `ErrorMessageUtil`

## Trade-offs

I made `i18n` an optional parameter instead of requiring it. This helps with back compatibility and allowed us to not refactor all the tests. But I could easily make an argument that it should be required and we should upgrade all the unit tests since I also updated the usages to always provide the `i18n` parameter.

The way `getUnanchoredErrorMessage` prefixes the name onto the error message is going to be pretty dubious when it comes to translating, but I stuck with that approach for now because I didn't have any better alternatives.