### PR TITLE
DCOS-44138: i18n Mark is imported twice in VirtualNetworkDetail

### DIFF
--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.js
@@ -1,6 +1,5 @@
 import { i18nMark } from "@lingui/react";
 import { Trans } from "@lingui/macro";
-import { i18nMark } from "@lingui/react";
 import mixin from "reactjs-mixin";
 import { Link, routerShape } from "react-router";
 /* eslint-disable no-unused-vars */


### PR DESCRIPTION
Removed one of the imports.

Closes DCOS-44138

## Testing
The localhost site should work after `npm start`.

## Trade-offs
None.

## Dependencies
None.

## Screenshots

### Before
![screenshot from 2018-10-26 10-41-34](https://user-images.githubusercontent.com/40791275/47552896-6447d980-d90e-11e8-84d0-cecfd8dea585.png)

### After
![screenshot from 2018-10-26 11-00-56](https://user-images.githubusercontent.com/40791275/47552922-71fd5f00-d90e-11e8-9d8f-d57081a593d3.png)
