### PR TITLE
fix(ServiceRestartModal): Missing space

### DIFF
--- a/plugins/services/src/js/components/modals/ServiceRestartModal.js
+++ b/plugins/services/src/js/components/modals/ServiceRestartModal.js
@@ -127,7 +127,7 @@ class ServiceRestartModal extends React.Component {
         showHeader={true}
       >
         <Trans render="p">
-          Restarting the <strong>{serviceName}</strong>
+          Restarting the <strong>{serviceName}</strong>{" "}
           {serviceLabel.toLowerCase()} will remove all currently running
           instances of the {serviceLabel.toLowerCase()} and then attempt to
           create new instances identical to those removed.


### PR DESCRIPTION
Noticed this while smoke testing. Hard to see that we needed a literal space between two container expressions.
