### PR TITLE
Enable renovate for organisation packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,18 @@
+{
+  "enabled": true,
+  "semanticCommits": true,
+  "rebaseStalePrs": true,
+  "labels": ["renovate"],
+  "packageRules": [
+    {
+      "packageNames": [
+        "@dcos/http-service",
+        "@dcos/mesos-client",
+        "@dcos/tslint-config",
+        "@dcos/ui-kit"
+      ],
+      "rangeStrategy": "pin",
+      "updateTypes": ["major", "minor", "patch", "pin"]
+    }
+  ]
+}


### PR DESCRIPTION
We want to introduce renovate, so that we can spare one manual task,
the bump and creation of a PR for each new package version.

## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

Please see https://github.com/DanielMSchmidt/test-renovate-for-one-dependency for a test of the one rule application of renovate

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

- Only update packages we own, so that we remove some friction
- Label updates so that we can quicker spot them and understand the impact of our merge better.

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
