### PR TITLE
DCOS-44676: fix status bar tooltip

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -375,7 +375,7 @@
       ],
       [
         ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
-        353
+        354
       ]
     ]
   },
@@ -1359,7 +1359,7 @@
     "origin": [
       [
         ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
-        233
+        234
       ]
     ]
   },
@@ -1666,7 +1666,11 @@
     "origin": [
       [
         ".dcos-ui-plugins-private/secrets/pages/CertificatesPage.js",
-        35
+        36
+      ],
+      [
+        ".dcos-ui-plugins-private/secrets/pages/CertificatesPage.js",
+        193
       ]
     ]
   },
@@ -1803,7 +1807,7 @@
       ],
       [
         ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
-        221
+        222
       ]
     ]
   },
@@ -4103,7 +4107,7 @@
     "origin": [
       [
         ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
-        328
+        329
       ]
     ]
   },
@@ -4675,7 +4679,7 @@
       ],
       [
         ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
-        186
+        187
       ]
     ]
   },
@@ -4746,6 +4750,10 @@
       [
         ".dcos-ui-plugins-private/organization/submodules/groups/pages/GroupsPage.js",
         40
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/pages/GroupsPage.js",
+        202
       ]
     ]
   },
@@ -5253,7 +5261,11 @@
       ],
       [
         ".dcos-ui-plugins-private/auth-providers/pages/AuthProvidersTab.js",
-        34
+        35
+      ],
+      [
+        ".dcos-ui-plugins-private/auth-providers/pages/AuthProvidersTab.js",
+        181
       ]
     ]
   },
@@ -5648,7 +5660,11 @@
     "origin": [
       [
         ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
-        38
+        39
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
+        382
       ]
     ]
   },
@@ -5874,7 +5890,7 @@
     "origin": [
       [
         ".dcos-ui-plugins-private/cluster-linking/pages/LinkedClustersPage.js",
-        57
+        58
       ]
     ]
   },
@@ -5887,7 +5903,11 @@
       ],
       [
         ".dcos-ui-plugins-private/cluster-linking/pages/LinkedClustersPage.js",
-        25
+        26
+      ],
+      [
+        ".dcos-ui-plugins-private/cluster-linking/pages/LinkedClustersPage.js",
+        128
       ]
     ]
   },
@@ -7106,7 +7126,7 @@
     "origin": [
       [
         ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
-        342
+        343
       ]
     ]
   },
@@ -7137,7 +7157,7 @@
     "origin": [
       [
         ".dcos-ui-plugins-private/cluster-linking/pages/LinkedClustersPage.js",
-        55
+        56
       ]
     ]
   },
@@ -8861,7 +8881,7 @@
     "origin": [
       [
         ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
-        257
+        258
       ]
     ]
   },
@@ -9068,7 +9088,11 @@
     "origin": [
       [
         ".dcos-ui-plugins-private/secrets/pages/SecretStorePage.js",
-        23
+        24
+      ],
+      [
+        ".dcos-ui-plugins-private/secrets/pages/SecretStorePage.js",
+        101
       ]
     ]
   },
@@ -9095,6 +9119,14 @@
       [
         ".dcos-ui-plugins-private/secrets/pages/SecretsPage.js",
         56
+      ],
+      [
+        ".dcos-ui-plugins-private/secrets/pages/SecretsPage.js",
+        363
+      ],
+      [
+        ".dcos-ui-plugins-private/secrets/pages/SecurityPage.js",
+        13
       ]
     ]
   },
@@ -9328,6 +9360,10 @@
       [
         ".dcos-ui-plugins-private/organization/submodules/service-accounts/pages/ServiceAccountsPage.js",
         33
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/service-accounts/pages/ServiceAccountsPage.js",
+        147
       ]
     ]
   },
@@ -9337,6 +9373,10 @@
       [
         ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/BackendDetailPage.js",
         41
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/LoadBalancingPage.js",
+        11
       ],
       [
         ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.js",
@@ -9571,7 +9611,7 @@
     "origin": [
       [
         ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
-        344
+        345
       ]
     ]
   },
@@ -9589,7 +9629,7 @@
     "origin": [
       [
         ".dcos-ui-plugins-private/secrets/hooks.js",
-        363
+        364
       ]
     ]
   },
@@ -11396,7 +11436,7 @@
       ],
       [
         ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
-        151
+        152
       ]
     ]
   },
@@ -11471,6 +11511,10 @@
       [
         ".dcos-ui-plugins-private/organization/submodules/groups/components/GroupDetailPage.js",
         275
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/users/components/UserDetailPage.js",
+        142
       ],
       [
         ".dcos-ui-plugins-private/organization/submodules/users/pages/UsersPage.js",
@@ -11976,7 +12020,7 @@
     "origin": [
       [
         ".dcos-ui-plugins-private/cluster-linking/pages/LinkedClustersPage.js",
-        44
+        45
       ]
     ]
   },
@@ -12189,7 +12233,7 @@
     "origin": [
       [
         ".dcos-ui-plugins-private/cluster-linking/pages/LinkedClustersPage.js",
-        40
+        41
       ]
     ]
   },
@@ -12247,6 +12291,15 @@
       ]
     ]
   },
+  "resources": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/hooks.js",
+        436
+      ]
+    ]
+  },
   "scaling each service to 0 instances": {
     "translation": "",
     "origin": [
@@ -12262,6 +12315,19 @@
       [
         ".dcos-ui-plugins-private/organization/constants/BulkOptions.js",
         50
+      ]
+    ]
+  },
+  "system": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/hooks.js",
+        42
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/hooks.js",
+        32
       ]
     ]
   },
@@ -12365,15 +12431,11 @@
       ],
       [
         ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
-        245
+        246
       ],
       [
         ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
-        251
-      ],
-      [
-        "src/js/components/Sidebar.js",
-        167
+        252
       ]
     ]
   },
@@ -12553,6 +12615,15 @@
       [
         "plugins/services/src/js/components/ServiceList.js",
         54
+      ]
+    ]
+  },
+  "{runningInstances, plural, one {# instance running out of {instancesTotal}} other {# instances running out of {instancesTotal}}}": {
+    "translation": "",
+    "origin": [
+      [
+        "plugins/services/src/js/components/ServiceStatusProgressBar.js",
+        22
       ]
     ]
   },

--- a/plugins/services/src/js/components/ServiceStatusProgressBar.js
+++ b/plugins/services/src/js/components/ServiceStatusProgressBar.js
@@ -1,7 +1,9 @@
 import PropTypes from "prop-types";
 import React from "react";
 import { Tooltip } from "reactjs-components";
-import { Plural } from "@lingui/macro";
+/* eslint-disable no-unused-vars */
+import { Trans, Plural } from "@lingui/macro";
+/* eslint-enable no-unused-vars */
 
 import ProgressBar from "#SRC/js/components/ProgressBar";
 import Pod from "../structs/Pod";


### PR DESCRIPTION
Ensure status bar tooltip shows correct pluralized message from translation catalog instead of bare id.

Closes DCOS-46676.

## Testing

- Create production build with `npm run build-assets`
- Serve with `npx http-server -p 4200 --proxy-secure=false -P https://frontend-ElasticL-15A1BH9DJMPZ6-380004668.us-west-2.elb.amazonaws.com ./dist` (use up to date cluster url)
- Go to Catalog - run Cassandra
- Go (quickly) to services page and hover over the status bar in the services table while it's deploying
- Should see tooltip with a regular looking sentence instead of translation message syntax

## Trade-offs

Had to import `Trans` despite not using it in `ServiceStatusProgressBar` because otherwise the `Plural` message is not extracted. See lingui [issue](https://github.com/lingui/js-lingui/issues/382)


## Screenshots

See before screenshot in [JIRA](https://jira.mesosphere.com/browse/DCOS-44676).

After: 
![status-after](https://user-images.githubusercontent.com/19582796/48227704-daf5c580-e357-11e8-84d8-8e966664f5bf.gif)

