### PR TITLE
1.12 backport: don't allow table cell containing label to collapse

### DIFF
--- a/plugins/services/src/js/service-configuration/ServiceEnvironmentVariablesConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceEnvironmentVariablesConfigSection.js
@@ -102,7 +102,7 @@ class ServiceEnvironmentVariablesConfigSection extends ServiceConfigBaseSectionD
             return (
               <Table
                 key="secrets-table"
-                className="table table-flush table-borderless-outer table-borderless-inner-columns vertical-align-top table-break-word table-fixed-layout flush-bottom"
+                className="table table-flush table-borderless-outer table-borderless-inner-columns vertical-align-top table-break-word flush-bottom"
                 columns={columns}
                 data={data}
               />

--- a/plugins/services/src/js/service-configuration/ServiceLabelsConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceLabelsConfigSection.js
@@ -93,7 +93,7 @@ class ServiceLabelsConfigSection extends ServiceConfigBaseSectionDisplay {
             return (
               <Table
                 key="labels-table"
-                className="table table-flush table-borderless-outer table-borderless-inner-columns vertical-align-top table-break-word table-fixed-layout flush-bottom"
+                className="table table-flush table-borderless-outer table-borderless-inner-columns vertical-align-top table-break-word flush-bottom"
                 columns={columns}
                 data={data}
               />

--- a/src/styles/components/configuration-map/styles.less
+++ b/src/styles/components/configuration-map/styles.less
@@ -126,6 +126,14 @@
       &-label {
         width: @configuration-map-label-width;
       }
+
+      &-value {
+        // This is a hack to prevent the "label" table cell
+        // from collapsing because of the `min-width: 0px`
+        // rule on table cells we require for maintaining 
+        // the desired column width behavior in the tasks table
+        width: 0;
+      }
     }
   }
 }


### PR DESCRIPTION
Removed min-width table-cell truncation hack because most browsers will obey the min-width: 0 style, causing the layout to break.

Tested in Firefox, Edge, Safari, and Chrome. Also tested to ensure text truncation still works.

## Testing
**Test in Firefox or Edge**
0. Check out `mp/fix/DCOS-43897-ff-table-cell` from dcos-ui-plugins-private
1. Create a new service
2. Go to the "Environment" tab
3. Click "+ Add Environment Variable" and enter a key and a value
4. Click "+ Add " and enter a key and a value
5. Click "+ Add " and enter a key and a value
6. Go to "Networking" tab
7. Click "+ Add Service Endpoint"
8. Go to "Health Checks" tab
9. Click "+ Add Health Check" and add enter dummy info
10. Click "Review & Run"

No columns in the table should be collapsed

## Trade-offs
This solution is a little bit of a table layout hack

## Dependencies
None

## Screenshots
Before:
<img width="933" alt="screen shot 2018-10-31 at 9 42 28 am" src="https://user-images.githubusercontent.com/2313998/47804387-e579e480-dcf1-11e8-9569-a47c127c1b81.png">


After:
<img width="921" alt="screen shot 2018-10-31 at 9 43 21 am" src="https://user-images.githubusercontent.com/2313998/47804393-e90d6b80-dcf1-11e8-98d4-802b05dc7ada.png">
