### PR TITLE
fix: remove extra curly brace

### DIFF
--- a/plugins/services/src/js/containers/pod-debug/PodDebugContainer.js
+++ b/plugins/services/src/js/containers/pod-debug/PodDebugContainer.js
@@ -215,7 +215,7 @@ class PodDebugTabView extends React.Component {
           message={
             <Trans render="span">
               DC/OS has been waiting for resources and is unable to complete
-              this deployment for {DateUtil.getDuration(timeWaiting, null)}.}
+              this deployment for {DateUtil.getDuration(timeWaiting, null)}.
             </Trans>
           }
           primaryAction={


### PR DESCRIPTION
Looks like we've overlooked one rouge `}`

## Testing

run `npm run lingui-extract-with-plugins && npm start` 
without this fix it won't start

## Trade-offs

I haven't included recompiled `messages.json` not quite sure what is our process here @natmegs @brandonc 