### PR TITLE
feat(locale): Adds initial chinese catalog

### DIFF
--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -1,0 +1,12661 @@
+{
+  "(AT BEGINNING OF FILE)": {
+    "translation": "（运行文件时）",
+    "origin": [
+      [
+        "plugins/services/src/js/components/LogView.js",
+        309
+      ]
+    ]
+  },
+  "(Clear)": {
+    "translation": "（清除）",
+    "origin": [
+      [
+        "src/js/components/FilterHeadline.js",
+        69
+      ]
+    ]
+  },
+  "(No data)": {
+    "translation": "（无数据）",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/pod-debug/PodDebugContainer.js",
+        68
+      ]
+    ]
+  },
+  "(Optional. Default: 20): Number of seconds after which a health check is considered a failure regardless of the response.": {
+    "translation": "（可选。默认值：20）：运行状况检查被视为失败（无论响应如何）后的秒数。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/HealthChecksFormSection.js",
+        64
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js",
+        45
+      ]
+    ]
+  },
+  "(Optional. Default: 3): Number of consecutive health check failures after which the unhealthy instance should be killed. HTTP & TCP health checks: If this value is 0, instances will not be killed if they fail the health check.": {
+    "translation": "（可选。默认值：3）：不健康实例应被杀死之后运行状况检查连续失败的次数。HTTP 和 TCP 运行状况检查：如果此值为 0，那么尽管实例执行运行状况检查失败，也不会被杀死。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/HealthChecksFormSection.js",
+        71
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js",
+        52
+      ]
+    ]
+  },
+  "(Optional. Default: 300): Health check failures are ignored within this number of seconds or until the instance becomes healthy for the first time.": {
+    "translation": "（可选。默认值：300）：运行状况检查失败在此秒数内或直到实例第一次变为健康时被忽略。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/HealthChecksFormSection.js",
+        49
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js",
+        30
+      ]
+    ]
+  },
+  "(Optional. Default: 60): Number of seconds to wait between health checks.": {
+    "translation": "（可选。默认值：60）：运行状况检查之间等待的秒数。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/HealthChecksFormSection.js",
+        57
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js",
+        38
+      ]
+    ]
+  },
+  "(Role: {0})": {
+    "translation": "（角色： {0}）",
+    "origin": [
+      [
+        "plugins/services/src/js/components/DeclinedOffersTable.js",
+        116
+      ],
+      [
+        "plugins/services/src/js/components/DeclinedOffersTable.js",
+        119
+      ]
+    ]
+  },
+  "(Show less)": {
+    "translation": "（显示较少）",
+    "origin": [
+      [
+        "src/js/components/CollapsibleErrorMessage.js",
+        85
+      ]
+    ]
+  },
+  "(Show more)": {
+    "translation": "（显示更多）",
+    "origin": [
+      [
+        "src/js/components/CollapsibleErrorMessage.js",
+        86
+      ]
+    ]
+  },
+  "1 Backend": {
+    "translation": "1 后端",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/BackendsTable.js",
+        174
+      ]
+    ]
+  },
+  "1 Client": {
+    "translation": "1 客户端",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/ClientsTable.js",
+        105
+      ]
+    ]
+  },
+  "1 Total Backend": {
+    "translation": "1 总后端",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPDetailPage.js",
+        154
+      ]
+    ]
+  },
+  "1 Total Client": {
+    "translation": "1 总客户端",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/BackendDetailPage.js",
+        159
+      ]
+    ]
+  },
+  "<0/> Download": {
+    "translation": "<0/> 下载",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-connection/SDKServiceConnectionEndpointList.js",
+        106
+      ]
+    ]
+  },
+  "<0><1/> Download config.json</0>": {
+    "translation": "<0><1/> 下载 config.json</0>",
+    "origin": [
+      [
+        "src/js/components/ReviewConfig.js",
+        57
+      ]
+    ]
+  },
+  "<0>Important:</0> Because telemetry is disabled you must manually notify users of ACL changes.": {
+    "translation": "<0>重要信息：</0> 因为遥测被禁用，您必须手动通知用户 ACL 的更改。",
+    "origin": [
+      [
+        "src/js/components/modals/UserFormModal.js",
+        125
+      ]
+    ]
+  },
+  "<0>Note:</0> Scaling to fewer instances is not supported. <1>More information</1>": {
+    "translation": "<0>注意：</0> 不支持缩放到较少的实例。<1>更多信息</1>",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceActionDisabledModal.js",
+        140
+      ]
+    ]
+  },
+  "<0>See documentation</0>.": {
+    "translation": "<0>查看文档</0>.",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/PermissionBuilderModal.js",
+        297
+      ]
+    ]
+  },
+  "A REX-Ray backed volume that is mounted on the agent from network attached storage.": {
+    "translation": "从网络连接存储安装到代理上的 REX-Ray 备份卷。",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/VolumeDefinitions.js",
+        22
+      ]
+    ]
+  },
+  "A health check passes if (1) its HTTP response code is between 200 and 399 inclusive, and (2) its response is received within the timeoutSeconds period. <0>More Information</0>.": {
+    "translation": "如果 (1) 其 HTTP 响应代码在 200 和 399 之间（包含 200 和 399），以及 (2) 在超时秒数内收到其响应，则运行状况检查通过。<0>更多信息</0>.",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/HealthChecksFormSection.js",
+        501
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js",
+        471
+      ]
+    ]
+  },
+  "A host volume is a directory on the the local agent mapped to one in a container.": {
+    "translation": "主机卷是与容器中的代理相映射的本地代理上的目录。",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/VolumeDefinitions.js",
+        29
+      ]
+    ]
+  },
+  "A locally persistent volume based upon the physical disks installed in the agent which has the capabilities of a single disk.": {
+    "translation": "基于安装在代理（具有单个磁盘功能）上的物理磁盘的本地持久卷。",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/VolumeDefinitions.js",
+        14
+      ]
+    ]
+  },
+  "A locally persistent volume pre-created by the operator according to a storage profile.": {
+    "translation": "运算符根据存储配置文件预先创建的本地持久卷。",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/VolumeDefinitions.js",
+        7
+      ]
+    ]
+  },
+  "A service with the same name already exists. Try a different name.": {
+    "translation": "已存在具有相同名称的服务。尝试不同的名称。",
+    "origin": [
+      [
+        "src/js/components/CosmosErrorMessage.js",
+        38
+      ]
+    ]
+  },
+  "A shell command for your container to execute.": {
+    "translation": "容器要执行的 shell 命令。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/ContainerServiceFormSection.js",
+        228
+      ]
+    ]
+  },
+  "A string, integer or regex value.": {
+    "translation": "字符串，整数或 regex 值。",
+    "origin": [
+      [
+        "src/js/components/PlacementConstraintsPartial.js",
+        109
+      ]
+    ]
+  },
+  "Access denied": {
+    "translation": "访问被拒绝",
+    "origin": [
+      [
+        "src/js/components/AccessDeniedPage.js",
+        45
+      ]
+    ]
+  },
+  "Actions (<0>Allow All</0>)": {
+    "translation": "操作（<0>允许全部</0>)",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/PermissionBuilderModal.js",
+        252
+      ]
+    ]
+  },
+  "Active": {
+    "translation": "活动",
+    "origin": [
+      [
+        "plugins/nodes/src/js/pages/nodes/NodeDetailTab.js",
+        76
+      ],
+      [
+        "plugins/services/src/js/components/DeploymentsModal.js",
+        545
+      ],
+      [
+        "plugins/services/src/js/components/dsl/TaskStatusDSLSection.js",
+        45
+      ],
+      [
+        "plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js",
+        142
+      ],
+      [
+        "src/js/components/FrameworkConfigurationReviewScreen.js",
+        67
+      ]
+    ]
+  },
+  "Active deployments will be shown here.": {
+    "translation": "此处将显示活动部署。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/DeploymentsModal.js",
+        386
+      ]
+    ]
+  },
+  "Add": {
+    "translation": "添加",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerAddServiceFormModal.js",
+        86
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/components/modals/LDAPGroupFormModal.js",
+        133
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/users/components/modals/LDAPUserFormModal.js",
+        110
+      ]
+    ]
+  },
+  "Add Artifact": {
+    "translation": "添加工件",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/ArtifactsSection.js",
+        109
+      ]
+    ]
+  },
+  "Add Constraint": {
+    "translation": "添加约束",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/PlacementFormPartial.js",
+        116
+      ]
+    ]
+  },
+  "Add Container": {
+    "translation": "添加容器",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
+        185
+      ]
+    ]
+  },
+  "Add Directory": {
+    "translation": "添加目录",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/components/DirectoryFormModal.js",
+        103
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/components/DirectoryFormModal.js",
+        131
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
+        354
+      ]
+    ]
+  },
+  "Add Environment Variable": {
+    "translation": "添加环境变量",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/EnvironmentFormSection.js",
+        242
+      ]
+    ]
+  },
+  "Add External Load Balancer": {
+    "translation": "添加外部负载均衡器",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancersTab.js",
+        300
+      ]
+    ]
+  },
+  "Add Group": {
+    "translation": "添加组",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/AccountGroupMembershipTab.js",
+        148
+      ]
+    ]
+  },
+  "Add Health Check": {
+    "translation": "添加运行状况检查",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/HealthChecksFormSection.js",
+        548
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js",
+        386
+      ]
+    ]
+  },
+  "Add Identity Provider": {
+    "translation": "添加身份提供商",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/components/AuthProvidersModal.js",
+        151
+      ]
+    ]
+  },
+  "Add Label": {
+    "translation": "添加标签",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/EnvironmentFormSection.js",
+        275
+      ]
+    ]
+  },
+  "Add Local Group": {
+    "translation": "添加本地组",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/pages/GroupsPage.js",
+        145
+      ]
+    ]
+  },
+  "Add Local User": {
+    "translation": "添加本地用户",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/users/pages/UsersPage.js",
+        127
+      ]
+    ]
+  },
+  "Add Package Repository": {
+    "translation": "添加包存储库",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackagesTab.js",
+        64
+      ]
+    ]
+  },
+  "Add Permission": {
+    "translation": "添加权限",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/AdvancedACLsTab.js",
+        320
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/components/PermissionBuilderModal.js",
+        537
+      ]
+    ]
+  },
+  "Add Permissions": {
+    "translation": "添加权限",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/PermissionBuilderModal.js",
+        536
+      ]
+    ]
+  },
+  "Add Placement Constraint": {
+    "translation": "添加布局约束",
+    "origin": [
+      [
+        "src/js/components/PlacementConstraintsPartial.js",
+        234
+      ]
+    ]
+  },
+  "Add Provider": {
+    "translation": "添加提供商",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/components/AuthProvidersModal.js",
+        77
+      ]
+    ]
+  },
+  "Add Repository": {
+    "translation": "添加存储库",
+    "origin": [
+      [
+        "plugins/catalog/src/js/repositories/components/AddRepositoryFormModal.js",
+        89
+      ],
+      [
+        "plugins/catalog/src/js/repositories/components/AddRepositoryFormModal.js",
+        117
+      ],
+      [
+        "plugins/catalog/src/js/repositories/components/RepositoriesTabUI.js",
+        65
+      ]
+    ]
+  },
+  "Add Secret": {
+    "translation": "添加密钥",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/ServiceCreate.js",
+        233
+      ]
+    ]
+  },
+  "Add Service": {
+    "translation": "添加服务",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerDetail.js",
+        297
+      ]
+    ]
+  },
+  "Add Service Endpoint": {
+    "translation": "添加服务端点",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js",
+        515
+      ],
+      [
+        "plugins/services/src/js/components/forms/NetworkingFormSection.js",
+        641
+      ]
+    ]
+  },
+  "Add Service to External Load Balancer": {
+    "translation": "向外部负载均衡器添加服务",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerAddServiceFormModal.js",
+        138
+      ]
+    ]
+  },
+  "Add Service to Load Balancer": {
+    "translation": "向负载均衡器添加服务",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerDetail.js",
+        225
+      ]
+    ]
+  },
+  "Add To Group": {
+    "translation": "添加到组",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/constants/BulkOptions.js",
+        33
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/constants/BulkOptions.js",
+        55
+      ]
+    ]
+  },
+  "Add User": {
+    "translation": "添加用户",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/components/GroupAccountMembershipTab.js",
+        182
+      ],
+      [
+        "src/js/components/modals/UserFormModal.js",
+        78
+      ]
+    ]
+  },
+  "Add User To Group": {
+    "translation": "将用户添加到组",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/constants/BulkOptions.js",
+        10
+      ]
+    ]
+  },
+  "Add User to Cluster": {
+    "translation": "将用户添加到集群",
+    "origin": [
+      [
+        "src/js/components/modals/UserFormModal.js",
+        114
+      ]
+    ]
+  },
+  "Add User to Group": {
+    "translation": "将用户添加到组",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/constants/BulkOptions.js",
+        56
+      ]
+    ]
+  },
+  "Add Volume": {
+    "translation": "添加卷",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js",
+        332
+      ],
+      [
+        "plugins/services/src/js/components/forms/VolumesFormSection.js",
+        452
+      ]
+    ]
+  },
+  "Add a Permission for {0}": {
+    "translation": "为 {0} 添加权限",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/PermissionBuilderModal.js",
+        572
+      ]
+    ]
+  },
+  "Add to Group": {
+    "translation": "添加到组",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/constants/BulkOptions.js",
+        9
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/constants/BulkOptions.js",
+        32
+      ]
+    ]
+  },
+  "Add {title} Identity Provider": {
+    "translation": "添加 {title} 身份提供商",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/components/AuthProvidersModalForm.js",
+        196
+      ]
+    ]
+  },
+  "Adding another container will automatically put multiple containers into a Pod definition. Your containers will be co-located on the same node and scale together. <0>More information</0>.": {
+    "translation": "添加另一个容器将自动使多个容器进入 Pod 定义。您的容器将共同位于同一节点上，并一起进行缩放。<0>更多信息</0>.",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
+        431
+      ]
+    ]
+  },
+  "Address": {
+    "translation": "地址",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-connection/SDKServiceConnectionEndpointList.js",
+        71
+      ]
+    ]
+  },
+  "Advanced Constraints": {
+    "translation": "高级约束",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/PlacementFormPartial.js",
+        83
+      ],
+      [
+        ".dcos-ui-plugins-private/placement/components/PodPlacementConfigSection.js",
+        81
+      ],
+      [
+        ".dcos-ui-plugins-private/placement/components/ServicePlacementConfigSection.js",
+        72
+      ]
+    ]
+  },
+  "Advanced Health Check Settings": {
+    "translation": "高级运行状况检查设置",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/HealthChecksFormSection.js",
+        82
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js",
+        63
+      ]
+    ]
+  },
+  "Advanced Settings": {
+    "translation": "高级设置",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/ContainerServiceFormAdvancedSection.js",
+        230
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerFormAdvancedSection.js",
+        35
+      ]
+    ]
+  },
+  "Advanced settings of the container.": {
+    "translation": "容器的高级设置。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/MultiContainerFormAdvancedSection.js",
+        38
+      ]
+    ]
+  },
+  "Advanced settings related to the runtime you have selected above.": {
+    "translation": "与您在上方选择的运行时间相关的高级设置。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/ContainerServiceFormAdvancedSection.js",
+        233
+      ]
+    ]
+  },
+  "Affected Services": {
+    "translation": "受影响的服务",
+    "origin": [
+      [
+        "plugins/services/src/js/components/DeploymentsModal.js",
+        37
+      ]
+    ]
+  },
+  "Agent Prefix Length": {
+    "translation": "代理前缀长度",
+    "origin": [
+      [
+        "src/js/pages/network/VirtualNetworksTable.js",
+        14
+      ]
+    ]
+  },
+  "Agents": {
+    "translation": "代理",
+    "origin": [
+      [
+        "plugins/nodes/src/js/pages/NodesAgents.js",
+        266
+      ],
+      [
+        "plugins/nodes/src/js/pages/NodesMasters.js",
+        9
+      ]
+    ]
+  },
+  "Alive": {
+    "translation": "有效",
+    "origin": [
+      [
+        "plugins/services/src/js/components/MarathonTaskDetailsList.js",
+        160
+      ]
+    ]
+  },
+  "All": {
+    "translation": "所有",
+    "origin": [
+      [
+        "src/js/pages/system/UnitsHealthTab.js",
+        188
+      ]
+    ]
+  },
+  "All Health Checks": {
+    "translation": "所有运行状况检查",
+    "origin": [
+      [
+        "src/js/components/UnitHealthDropdown.js",
+        12
+      ],
+      [
+        "src/js/components/UnitHealthDropdown.js",
+        13
+      ]
+    ]
+  },
+  "All stats are for the past minute": {
+    "translation": "过去分钟内的所有统计信息",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.js",
+        154
+      ]
+    ]
+  },
+  "Alphanumerical, dashes, underscores and slashes are allowed.": {
+    "translation": "允许字母数字、破折号、下划线和斜杠。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/SecretFormModal.js",
+        141
+      ]
+    ]
+  },
+  "Already Exists": {
+    "translation": "已存在",
+    "origin": [
+      [
+        "src/js/constants/DefaultErrorMessages.js",
+        171
+      ]
+    ]
+  },
+  "Already exists": {
+    "translation": "已存在",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorMessages.js",
+        13
+      ]
+    ]
+  },
+  "An Error Occurred": {
+    "translation": "发生错误",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackagesTab.js",
+        148
+      ]
+    ]
+  },
+  "An error has occurred": {
+    "translation": "发生错误",
+    "origin": [
+      [
+        "src/js/components/ServerErrorModal.js",
+        107
+      ]
+    ]
+  },
+  "An error has occurred.": {
+    "translation": "发生错误。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/SecretFormModal.js",
+        122
+      ],
+      [
+        "plugins/catalog/src/js/repositories/RepositoriesAdd.js",
+        25
+      ],
+      [
+        "plugins/catalog/src/js/repositories/RepositoriesDelete.js",
+        25
+      ],
+      [
+        "src/js/components/ComponentList.js",
+        102
+      ]
+    ]
+  },
+  "An unknown error occurred": {
+    "translation": "发生未知错误",
+    "origin": [
+      [
+        "src/js/components/CosmosErrorMessage.js",
+        24
+      ]
+    ]
+  },
+  "App Reach": {
+    "translation": "应用程序覆盖范围",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPsTable.js",
+        52
+      ]
+    ]
+  },
+  "App Reachability": {
+    "translation": "应用程序可达性",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/NetworkItemChart.js",
+        116
+      ]
+    ]
+  },
+  "Application": {
+    "translation": "应用程序",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/volume-detail/PodVolumeDetail.js",
+        87
+      ],
+      [
+        "plugins/services/src/js/containers/volume-detail/VolumeDetail.js",
+        87
+      ]
+    ]
+  },
+  "Application Availability and Reachability": {
+    "translation": "应用程序可用性和可达性",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPDetailPage.js",
+        130
+      ]
+    ]
+  },
+  "Application Availability and Reachability for all connections to this virtual address in the last hour.": {
+    "translation": "在过去一小时内，此虚拟地址所有连接的应用程序可用性和可达性。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/constants/NetworkingTooltipContent.js",
+        11
+      ]
+    ]
+  },
+  "Application Availability and Reachability per Minute": {
+    "translation": "每分钟的应用程序可用性和可达性",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPDetailPage.js",
+        133
+      ]
+    ]
+  },
+  "Application Reachability": {
+    "translation": "应用程序可达性",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/BackendsTable.js",
+        79
+      ]
+    ]
+  },
+  "Apply": {
+    "translation": "应用",
+    "origin": [
+      [
+        "src/js/components/DSLFormDropdownPanel.js",
+        91
+      ]
+    ]
+  },
+  "Are you sure you want to delete {jobId}? This action is irreversible.": {
+    "translation": "确定要删除 {jobId} 吗？ 此操作不可逆。",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobDeleteModal.js",
+        16
+      ]
+    ]
+  },
+  "Are you sure you want to leave this page? Any data you entered will be lost.": {
+    "translation": "确定要离开此页面吗？ 您输入的任何数据将丢失。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModal.js",
+        938
+      ],
+      [
+        "src/js/components/FrameworkConfiguration.js",
+        363
+      ]
+    ]
+  },
+  "Are you sure you want to stop this?": {
+    "translation": "确定要停止吗？",
+    "origin": [
+      [
+        "src/js/components/modals/JobStopRunModal.js",
+        59
+      ]
+    ]
+  },
+  "Are you sure you want to stop {selectedItemsLength} Job Runs?": {
+    "translation": "确定要停止 {selectedItemsLength} 作业运行吗？",
+    "origin": [
+      [
+        "src/js/components/modals/JobStopRunModal.js",
+        61
+      ]
+    ]
+  },
+  "Are you sure you would like to continue and create a Pod? Any data you have already entered will be lost.": {
+    "translation": "确定要继续并创建 Pod 吗？ 您输入的任何数据将丢失。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
+        442
+      ]
+    ]
+  },
+  "Are you sure?": {
+    "translation": "确定吗？",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/pages/AuthProviderDetailPage.js",
+        281
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerDetail.js",
+        387
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/VHostDetail.js",
+        286
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/components/AccountDetailPage.js",
+        265
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/components/AccountGroupTable.js",
+        172
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/components/GroupDetailPage.js",
+        261
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/components/GroupMemberTable.js",
+        206
+      ],
+      [
+        ".dcos-ui-plugins-private/secrets/components/SecretActionsModal.js",
+        57
+      ],
+      [
+        "plugins/services/src/js/components/DeploymentsModal.js",
+        407
+      ],
+      [
+        "src/js/constants/BulkOptions.js",
+        15
+      ]
+    ]
+  },
+  "Args": {
+    "translation": "Args",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js",
+        226
+      ]
+    ]
+  },
+  "Artifact URI": {
+    "translation": "工件 URI",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/ArtifactsSection.js",
+        37
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodContainerArtifactsConfigSection.js",
+        22
+      ]
+    ]
+  },
+  "Artifact Uri": {
+    "translation": "工件 Uri",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js",
+        255
+      ]
+    ]
+  },
+  "Assign Automatically": {
+    "translation": "自动分配",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/NetworkingFormSection.js",
+        676
+      ]
+    ]
+  },
+  "Assign Host Ports Automatically": {
+    "translation": "自动分配主机端口",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/NetworkingFormSection.js",
+        660
+      ]
+    ]
+  },
+  "At-a-glance overview of the global application or group state. <0>Read more</0>.": {
+    "translation": "全球应用程序或组状态概览。<0>阅读更多</0>.",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/services/ServicesTable.js",
+        493
+      ]
+    ]
+  },
+  "Attach metadata to expose additional information to other services.": {
+    "translation": "附加元数据以向其他服务暴露额外信息。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/EnvironmentFormSection.js",
+        263
+      ]
+    ]
+  },
+  "Attached": {
+    "translation": "已附加",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/VolumeStatus.js",
+        4
+      ]
+    ]
+  },
+  "Attempt StartTLS, abort if it fails": {
+    "translation": "尝试 StartTLS，如果失败，则中止",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        30
+      ]
+    ]
+  },
+  "Attempt StartTLS, proceed unencrypted if it fails": {
+    "translation": "尝试 StartTLS，如果失败，则进行非加密",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        33
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        34
+      ]
+    ]
+  },
+  "Authentication": {
+    "translation": "身份验证",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/components/DirectoryFormModal.js",
+        511
+      ]
+    ]
+  },
+  "Authentication Method": {
+    "translation": "身份验证方法",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        72
+      ]
+    ]
+  },
+  "Auto Assigned": {
+    "translation": "已自动分配",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-connection/ServiceConnectionEndpointList.js",
+        54
+      ],
+      [
+        "plugins/services/src/js/containers/service-connection/ServicePodConnectionEndpointList.js",
+        53
+      ]
+    ]
+  },
+  "Available Agents": {
+    "translation": "可用代理",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/LoadBalancersTable.js",
+        42
+      ]
+    ]
+  },
+  "BACKEND": {
+    "translation": "后端",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/BackendsTable.js",
+        40
+      ]
+    ]
+  },
+  "Back": {
+    "translation": "后",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/components/AuthProvidersModal.js",
+        102
+      ],
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModal.js",
+        876
+      ],
+      [
+        "src/js/components/FrameworkConfiguration.js",
+        142
+      ]
+    ]
+  },
+  "Backends": {
+    "translation": "后端",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/VHostDetail.js",
+        45
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPDetailPage.js",
+        64
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPDetailPage.js",
+        246
+      ]
+    ]
+  },
+  "Backoff": {
+    "translation": "退避",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/PodGeneralConfigSection.js",
+        157
+      ]
+    ]
+  },
+  "Backoff Factor": {
+    "translation": "退避系数",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/PodGeneralConfigSection.js",
+        164
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js",
+        136
+      ]
+    ]
+  },
+  "Backoff Max Launch Delay": {
+    "translation": "退避最大启动延迟",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/PodGeneralConfigSection.js",
+        171
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js",
+        140
+      ]
+    ]
+  },
+  "Backoff Seconds": {
+    "translation": "退避秒数",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js",
+        132
+      ]
+    ]
+  },
+  "Base URI": {
+    "translation": "基准 URI",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/constants/AuthProvidersFormDefinitions.js",
+        94
+      ],
+      [
+        ".dcos-ui-plugins-private/auth-providers/structs/AuthProvider.js",
+        104
+      ]
+    ]
+  },
+  "Bootstrap Config": {
+    "translation": "Bootstrap 配置",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/bootstrap-config/components/BootstrapConfigHashMap.js",
+        77
+      ]
+    ]
+  },
+  "Bridge": {
+    "translation": "桥",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/NetworkingFormSection.js",
+        583
+      ]
+    ]
+  },
+  "Built": {
+    "translation": "已构建",
+    "origin": [
+      [
+        "src/js/pages/system/OverviewDetailTab.js",
+        298
+      ]
+    ]
+  },
+  "By default, containers are “unprivileged” and cannot, for example, run a Docker daemon inside a Docker container.": {
+    "translation": "默认情况下，容器为“无特权”，例如，无法在 Docker 容器内运行 Docker 守护程序。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/ContainerServiceFormAdvancedSection.js",
+        29
+      ]
+    ]
+  },
+  "By running this service you agree to the <0>terms and conditions</0>.": {
+    "translation": "通过运行此服务，您将同意 <0>条款和条件</0>.",
+    "origin": [
+      [
+        "src/js/components/FrameworkConfiguration.js",
+        191
+      ]
+    ]
+  },
+  "By which factor would you like to scale all applications within this group?": {
+    "translation": "您想以哪个系数来缩放在此组中的所有应用程序？",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceScaleFormModal.js",
+        125
+      ]
+    ]
+  },
+  "CA Certificate": {
+    "translation": "CA 证书",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
+        234
+      ]
+    ]
+  },
+  "CA certificate chain": {
+    "translation": "CA 证书链",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        40
+      ]
+    ]
+  },
+  "CLI Only Package": {
+    "translation": "CLI Only Package（只 CLI 包）",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackageDetailTab.js",
+        272
+      ]
+    ]
+  },
+  "CPU": {
+    "translation": "CPU",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/NodesTable.tsx",
+        94
+      ],
+      [
+        "plugins/services/src/js/components/DeclinedOffersTable.js",
+        268
+      ],
+      [
+        "plugins/services/src/js/components/RecentOffersSummary.js",
+        14
+      ],
+      [
+        "plugins/services/src/js/constants/PodTableHeaderLabels.js",
+        10
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceTableHeaderLabels.js",
+        4
+      ],
+      [
+        "plugins/services/src/js/constants/TaskTableHeaderLabels.js",
+        4
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodGeneralConfigSection.js",
+        128
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js",
+        102
+      ]
+    ]
+  },
+  "CPU Allocation": {
+    "translation": "CPU 分配",
+    "origin": [
+      [
+        "src/js/constants/DashboardHeadings.js",
+        4
+      ]
+    ]
+  },
+  "CPU/MEM/DSK": {
+    "translation": "CPU/MEM/DSK",
+    "origin": [
+      [
+        "plugins/services/src/js/components/DeclinedOffersTable.js",
+        241
+      ]
+    ]
+  },
+  "CPUs": {
+    "translation": "CPU",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        32
+      ],
+      [
+        "plugins/nodes/src/js/pages/nodes/NodeDetailTab.js",
+        141
+      ],
+      [
+        "plugins/services/src/js/components/forms/ContainerServiceFormSection.js",
+        187
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        14
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodContainerConfigSection.js",
+        95
+      ]
+    ]
+  },
+  "CRON Schedule": {
+    "translation": "CRON 计划",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        84
+      ]
+    ]
+  },
+  "CSTR": {
+    "translation": "CSTR",
+    "origin": [
+      [
+        "plugins/services/src/js/components/DeclinedOffersTable.js",
+        225
+      ]
+    ]
+  },
+  "Cache": {
+    "translation": "缓存",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/PodContainerArtifactsConfigSection.js",
+        56
+      ]
+    ]
+  },
+  "Caches recent cluster history in-memory so that the {0} web interface can show recent data": {
+    "translation": "缓存最近的集群历史记录内存，以便 {0} Web 界面显示最近数据",
+    "origin": [
+      [
+        "src/js/constants/UnitSummaries.js",
+        70
+      ]
+    ]
+  },
+  "Callback URL": {
+    "translation": "回调 URL",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/components/AuthProviderDetailTab.js",
+        69
+      ]
+    ]
+  },
+  "Can only contain alphanumeric and [-] characters.": {
+    "translation": "只能包含字母数字和 [-] 字符。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerFormModal.js",
+        198
+      ]
+    ]
+  },
+  "Cancel": {
+    "translation": "取消",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/components/AuthProvidersModal.js",
+        87
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerAddServiceFormModal.js",
+        81
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerFormModal.js",
+        149
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/components/DirectoryActionButtons.js",
+        16
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/components/DirectoryFormModal.js",
+        115
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/components/modals/LDAPGroupFormModal.js",
+        168
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/service-accounts/components/ServiceAccountsFormModal.js",
+        125
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/users/components/modals/LDAPUserFormModal.js",
+        140
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/users/components/modals/UserEditFormModal.js",
+        78
+      ],
+      [
+        ".dcos-ui-plugins-private/secrets/components/SecretFormModal.js",
+        178
+      ],
+      [
+        "plugins/catalog/src/js/repositories/components/AddRepositoryFormModal.js",
+        84
+      ],
+      [
+        "plugins/jobs/src/js/components/JobDeleteModal.js",
+        56
+      ],
+      [
+        "plugins/jobs/src/js/components/JobFormModal.tsx",
+        44
+      ],
+      [
+        "plugins/jobs/src/js/components/JobStopRunModal.js",
+        64
+      ],
+      [
+        "plugins/services/src/js/components/DeploymentsModal.js",
+        419
+      ],
+      [
+        "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
+        423
+      ],
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModal.js",
+        882
+      ],
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModal.js",
+        930
+      ],
+      [
+        "plugins/services/src/js/components/modals/KillPodInstanceModal.js",
+        151
+      ],
+      [
+        "plugins/services/src/js/components/modals/KillTaskModal.js",
+        146
+      ],
+      [
+        "plugins/services/src/js/components/modals/ServiceDestroyModal.js",
+        184
+      ],
+      [
+        "plugins/services/src/js/components/modals/ServiceGroupFormModal.js",
+        77
+      ],
+      [
+        "plugins/services/src/js/components/modals/ServiceScaleFormModal.js",
+        140
+      ],
+      [
+        "src/js/components/FormModal.js",
+        156
+      ],
+      [
+        "src/js/components/FrameworkConfiguration.js",
+        142
+      ],
+      [
+        "src/js/components/FrameworkConfiguration.js",
+        356
+      ],
+      [
+        "src/js/components/modals/JobStopRunModal.js",
+        105
+      ],
+      [
+        "src/js/components/modals/LanguagePreferenceFormModal.js",
+        63
+      ],
+      [
+        "src/js/components/modals/UserFormModal.js",
+        73
+      ]
+    ]
+  },
+  "Catalog": {
+    "translation": "目录",
+    "origin": [
+      [
+        "plugins/services/src/js/components/dsl/ServiceOtherDSLSection.js",
+        46
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceOtherLabels.js",
+        4
+      ],
+      [
+        "src/js/pages/CatalogPage.js",
+        13
+      ],
+      [
+        "src/js/pages/catalog/PackageDetailTab.js",
+        36
+      ],
+      [
+        "src/js/pages/catalog/PackagesTab.js",
+        36
+      ]
+    ]
+  },
+  "Certificates": {
+    "translation": "证书",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/pages/CertificatesPage.js",
+        36
+      ],
+      [
+        ".dcos-ui-plugins-private/secrets/pages/CertificatesPage.js",
+        193
+      ]
+    ]
+  },
+  "Certified": {
+    "translation": "已认证",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackageDetailTab.js",
+        257
+      ],
+      [
+        "src/js/pages/catalog/PackagesTab.js",
+        188
+      ],
+      [
+        "src/js/pages/catalog/PackagesTab.js",
+        201
+      ]
+    ]
+  },
+  "Certified packages are verified by Mesosphere for interoperability with DC/OS.": {
+    "translation": "已认证的包经 Mesosphere 验证，可与 DC/OS 互操作。",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackagesTab.js",
+        204
+      ]
+    ]
+  },
+  "Change": {
+    "translation": "更改",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth/components/AuthenticatedUserAccountDropdown.js",
+        45
+      ]
+    ]
+  },
+  "Changing the settings may lead to errors. Please check with your identity provider before making changes. All fields are required.": {
+    "translation": "更改设置可能会导致错误。请在进行更改前与您的身份提供商核实。所有字段均为必填字段。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/components/AuthProvidersModalForm.js",
+        172
+      ]
+    ]
+  },
+  "Choose BRIDGE, HOST, or USER networking. Refer to the <0>ports documentation</0> for more information.": {
+    "translation": "选择 BRIDGE、HOST 或 USER 网络。请参阅 <0>端口文档，</0> 以获取更多信息。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js",
+        573
+      ]
+    ]
+  },
+  "Choose a group": {
+    "translation": "选择组",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/AccountActionsModal.js",
+        106
+      ]
+    ]
+  },
+  "Choose a user": {
+    "translation": "选择用户",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/components/modals/GroupsActionsModal.js",
+        115
+      ]
+    ]
+  },
+  "Choose container/bridge, host, or container networking. Refer to the <0>ports documentation</0> for more information.": {
+    "translation": "选择容器/桥、主机或容器网络。请参阅 <0>端口文档，</0> 以获取更多信息。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/NetworkingFormSection.js",
+        691
+      ]
+    ]
+  },
+  "Choose your operating system and follow the instructions. For any issues or questions, please refer to our <0>documentation</0>.": {
+    "translation": "选择操作系统并遵循说明。如有任何问题或疑问，请参阅我们的 <0>文档</0>.",
+    "origin": [
+      [
+        "src/js/components/modals/CliInstallModal.js",
+        172
+      ]
+    ]
+  },
+  "Click the <0>Services tab</0> to install services.": {
+    "translation": "单击 <0>服务选项卡，</0> 以安装服务。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/ServiceList.js",
+        101
+      ]
+    ]
+  },
+  "Client": {
+    "translation": "客户端",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/ClientsTable.js",
+        54
+      ]
+    ]
+  },
+  "Client ID": {
+    "translation": "客户端 ID",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/constants/AuthProvidersFormDefinitions.js",
+        104
+      ],
+      [
+        ".dcos-ui-plugins-private/auth-providers/structs/AuthProvider.js",
+        105
+      ]
+    ]
+  },
+  "Client Secret": {
+    "translation": "客户端密钥",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/constants/AuthProvidersFormDefinitions.js",
+        114
+      ],
+      [
+        ".dcos-ui-plugins-private/auth-providers/structs/AuthProvider.js",
+        106
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
+        222
+      ]
+    ]
+  },
+  "Client Secret {0}": {
+    "translation": "客户端密钥 {0} ",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/components/AuthProviderDetailTab.js",
+        113
+      ]
+    ]
+  },
+  "Client certificate and private key": {
+    "translation": "客户端证书和私钥",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        46
+      ]
+    ]
+  },
+  "Clients": {
+    "translation": "客户端",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/BackendDetailPage.js",
+        85
+      ]
+    ]
+  },
+  "Close": {
+    "translation": "关闭",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/components/AuthProvidersModal.js",
+        118
+      ],
+      [
+        ".dcos-ui-plugins-private/cluster-linking/components/ClusterLinkingModal.js",
+        23
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/components/PermissionBuilderModal.js",
+        541
+      ],
+      [
+        "plugins/services/src/js/components/DeploymentsModal.js",
+        534
+      ],
+      [
+        "plugins/services/src/js/components/modals/ServiceActionDisabledModal.js",
+        369
+      ],
+      [
+        "src/js/components/Modals.js",
+        149
+      ],
+      [
+        "src/js/components/ServerErrorModal.js",
+        75
+      ]
+    ]
+  },
+  "Cluster": {
+    "translation": "集群",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth/components/AuthenticatedClusterDropdown.js",
+        61
+      ],
+      [
+        "plugins/services/src/js/constants/OperatorTypes.js",
+        21
+      ],
+      [
+        "src/js/components/ClusterHeader.js",
+        60
+      ],
+      [
+        "src/js/pages/SystemOverviewPage.js",
+        13
+      ],
+      [
+        "src/js/pages/system/OverviewDetailTab.js",
+        284
+      ]
+    ]
+  },
+  "Cluster Details": {
+    "translation": "集群详细信息",
+    "origin": [
+      [
+        "src/js/pages/system/OverviewDetailTab.js",
+        343
+      ]
+    ]
+  },
+  "Cluster URL or Public IP": {
+    "translation": "集群 URL 或公用 IP",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/cluster-linking/components/LinkedClustersTable.js",
+        61
+      ]
+    ]
+  },
+  "Code": {
+    "translation": "代码",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/pod-debug/PodContainerTerminationTable.js",
+        49
+      ]
+    ]
+  },
+  "Command": {
+    "translation": "命令",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        50
+      ],
+      [
+        "plugins/services/src/js/components/forms/ContainerServiceFormSection.js",
+        72
+      ],
+      [
+        "plugins/services/src/js/components/forms/HealthChecksFormSection.js",
+        246
+      ],
+      [
+        "plugins/services/src/js/components/forms/HealthChecksFormSection.js",
+        484
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js",
+        229
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js",
+        432
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodContainerConfigSection.js",
+        132
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodHealthChecksConfigSection.js",
+        50
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js",
+        199
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceHealthChecksConfigSection.js",
+        208
+      ]
+    ]
+  },
+  "Command Health Checks": {
+    "translation": "命令运行状况检查",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/PodHealthChecksConfigSection.js",
+        172
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceHealthChecksConfigSection.js",
+        287
+      ]
+    ]
+  },
+  "Community": {
+    "translation": "Community（社区）",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackageDetailTab.js",
+        258
+      ],
+      [
+        "src/js/pages/catalog/PackagesTab.js",
+        188
+      ],
+      [
+        "src/js/pages/catalog/PackagesTab.js",
+        225
+      ]
+    ]
+  },
+  "Community packages are unverified and unreviewed content from the community.": {
+    "translation": "社区包是未经验证和未经审核的社区内容。",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackagesTab.js",
+        220
+      ]
+    ]
+  },
+  "Completed": {
+    "translation": "已完成",
+    "origin": [
+      [
+        "plugins/jobs/src/js/constants/JobStates.ts",
+        34
+      ],
+      [
+        "plugins/services/src/js/components/dsl/TaskStatusDSLSection.js",
+        54
+      ],
+      [
+        "plugins/services/src/js/constants/PodContainerStatus.js",
+        73
+      ],
+      [
+        "plugins/services/src/js/constants/PodInstanceStatus.js",
+        37
+      ]
+    ]
+  },
+  "Component": {
+    "translation": "组件",
+    "origin": [
+      [
+        "src/js/pages/system/UnitsHealthTab.js",
+        211
+      ]
+    ]
+  },
+  "Components": {
+    "translation": "组件",
+    "origin": [
+      [
+        "src/js/pages/ComponentsPage.js",
+        13
+      ],
+      [
+        "src/js/pages/system/ComponentsUnitsHealthNodeDetailPage.js",
+        23
+      ],
+      [
+        "src/js/pages/system/UnitsHealthDetail.js",
+        26
+      ],
+      [
+        "src/js/pages/system/UnitsHealthTab.js",
+        30
+      ],
+      [
+        "src/js/pages/system/UnitsHealthTab.js",
+        257
+      ]
+    ]
+  },
+  "Components Health": {
+    "translation": "组件运行状况",
+    "origin": [
+      [
+        "src/js/constants/DashboardHeadings.js",
+        10
+      ]
+    ]
+  },
+  "Components Not Found": {
+    "translation": "未找到组件",
+    "origin": [
+      [
+        "src/js/components/ComponentList.js",
+        99
+      ]
+    ]
+  },
+  "Configuration": {
+    "translation": "配置",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobDetailPage.js",
+        34
+      ],
+      [
+        "plugins/jobs/src/js/pages/JobDetailPage.js",
+        98
+      ],
+      [
+        "plugins/services/src/js/containers/pod-debug/PodDebugContainer.js",
+        139
+      ],
+      [
+        "plugins/services/src/js/containers/pod-detail/PodDetail.js",
+        41
+      ],
+      [
+        "plugins/services/src/js/containers/pod-detail/PodDetail.js",
+        205
+      ],
+      [
+        "plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js",
+        147
+      ],
+      [
+        "plugins/services/src/js/containers/service-detail/ServiceDetail.js",
+        44
+      ],
+      [
+        "plugins/services/src/js/containers/service-detail/ServiceDetail.js",
+        238
+      ],
+      [
+        "plugins/services/src/js/pages/task-details/TaskDetailsTab.js",
+        119
+      ]
+    ]
+  },
+  "Configuration version": {
+    "translation": "配置版本",
+    "origin": [
+      [
+        "src/js/components/FrameworkConfigurationReviewScreen.js",
+        79
+      ]
+    ]
+  },
+  "Configure any environment values to be attached to each instance that is launched.": {
+    "translation": "配置要连接到每个启动实例的任何环境值。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/EnvironmentFormSection.js",
+        210
+      ]
+    ]
+  },
+  "Configure the networking for your service.": {
+    "translation": "为您的服务配置网络。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js",
+        605
+      ],
+      [
+        "plugins/services/src/js/components/forms/NetworkingFormSection.js",
+        733
+      ]
+    ]
+  },
+  "Configure your container below. Enter a container image or command you want to run.": {
+    "translation": "在下方配置您的容器。输入要运行的容器镜像或命令。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModalForm.js",
+        409
+      ]
+    ]
+  },
+  "Configure your service below. Start by giving your service an ID.": {
+    "translation": "在下方配置您的服务。首先为您的服务赋予 ID。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
+        351
+      ]
+    ]
+  },
+  "Connected Nodes": {
+    "translation": "已连接节点",
+    "origin": [
+      [
+        "src/js/components/charts/HostTimeSeriesChart.js",
+        82
+      ]
+    ]
+  },
+  "Connection": {
+    "translation": "连接",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/components/DirectoryFormModal.js",
+        506
+      ]
+    ]
+  },
+  "Connection Latency": {
+    "translation": "连接延迟",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/BackendDetailPage.js",
+        146
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPDetailPage.js",
+        121
+      ]
+    ]
+  },
+  "Connection Latency <em>(in ms)</em>": {
+    "translation": "连接延迟 <em>（毫秒）</em>",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/NetworkItemChart.js",
+        120
+      ]
+    ]
+  },
+  "Connection Latency per Minute": {
+    "translation": "每分钟连接延迟",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/BackendDetailPage.js",
+        148
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPDetailPage.js",
+        123
+      ]
+    ]
+  },
+  "Connection to node lost": {
+    "translation": "节点连接丢失",
+    "origin": [
+      [
+        "plugins/nodes/src/js/columns/NodesTableIpColumn.tsx",
+        16
+      ],
+      [
+        "plugins/nodes/src/js/components/NodesGridDials.js",
+        132
+      ]
+    ]
+  },
+  "Connection with LDAP server was successful!": {
+    "translation": "与 LDAP 服务器的连接已成功！",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/components/DirectoryActionButtons.js",
+        64
+      ]
+    ]
+  },
+  "Consecutive failures": {
+    "translation": "连续失败",
+    "origin": [
+      [
+        "plugins/services/src/js/components/MarathonTaskDetailsList.js",
+        154
+      ]
+    ]
+  },
+  "Constraint": {
+    "translation": "约束",
+    "origin": [
+      [
+        "plugins/services/src/js/components/DeclinedOffersTable.js",
+        224
+      ]
+    ]
+  },
+  "Constraints": {
+    "translation": "约束",
+    "origin": [
+      [
+        "plugins/services/src/js/components/RecentOffersSummary.js",
+        13
+      ]
+    ]
+  },
+  "Constraints control where apps run to allow optimization for either fault tolerance or locality.": {
+    "translation": "当应用程序运行以允许容错或局部性的优化时，约束则进行控制。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/PlacementSection.js",
+        50
+      ]
+    ]
+  },
+  "Constraints have three parts: a field name, an operator, and an optional parameter. The field can be the hostname of the agent node or any attribute of the agent node.": {
+    "translation": "约束有三个部分：字段名称、运算符和可选参数。该字段可以是代理节点的主机名或代理节点的任何属性。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/PlacementFormPartial.js",
+        86
+      ]
+    ]
+  },
+  "Constraints have three parts: a field name, an operator, and an optional parameter. The field can be the hostname of the agent node or any attribute of the agent node. <0>More information</0>.": {
+    "translation": "约束有三个部分：字段名称、运算符和可选参数。该字段可以是代理节点的主机名或代理节点的任何属性。<0>更多信息</0>.",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/PlacementSection.js",
+        16
+      ]
+    ]
+  },
+  "Container": {
+    "translation": "容器",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModalForm.js",
+        406
+      ],
+      [
+        "plugins/services/src/js/containers/service-connection/ServicePodConnectionEndpointList.js",
+        87
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodEnvironmentVariablesConfigSection.js",
+        30
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodHealthChecksConfigSection.js",
+        41
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodLabelsConfigSection.js",
+        32
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodNetworkConfigSection.js",
+        18
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodNetworkConfigSection.js",
+        72
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodStorageConfigSection.js",
+        67
+      ]
+    ]
+  },
+  "Container Artifacts": {
+    "translation": "容器工件",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/PodContainerArtifactsConfigSection.js",
+        94
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js",
+        247
+      ]
+    ]
+  },
+  "Container Configuration": {
+    "translation": "容器配置",
+    "origin": [
+      [
+        "plugins/services/src/js/pages/task-details/TaskDetailsTab.js",
+        31
+      ]
+    ]
+  },
+  "Container ID": {
+    "translation": "容器 ID",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/pod-debug/PodContainerTerminationTable.js",
+        35
+      ]
+    ]
+  },
+  "Container IP": {
+    "translation": "容器 IP",
+    "origin": [
+      [
+        "src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js",
+        27
+      ]
+    ]
+  },
+  "Container Image": {
+    "translation": "容器镜像",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/ContainerServiceFormSection.js",
+        110
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodContainerConfigSection.js",
+        75
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js",
+        152
+      ]
+    ]
+  },
+  "Container Mount Path": {
+    "translation": "容器安装路径",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/PodStorageConfigSection.js",
+        55
+      ]
+    ]
+  },
+  "Container Name": {
+    "translation": "容器名称",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/ContainerServiceFormSection.js",
+        147
+      ]
+    ]
+  },
+  "Container Path": {
+    "translation": "容器路径",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/dss/components/DSSInput.js",
+        40
+      ],
+      [
+        ".dcos-ui-plugins-private/dss/components/DSSVolumeConfig.js",
+        77
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js",
+        52
+      ],
+      [
+        "plugins/services/src/js/components/forms/VolumesFormSection.js",
+        66
+      ],
+      [
+        "plugins/services/src/js/components/forms/VolumesFormSection.js",
+        152
+      ],
+      [
+        "plugins/services/src/js/components/forms/VolumesFormSection.js",
+        269
+      ],
+      [
+        "plugins/services/src/js/containers/volume-detail/VolumeDetail.js",
+        71
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceStorageConfigSection.js",
+        85
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceStorageConfigSection.js",
+        106
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceStorageConfigSection.js",
+        140
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceStorageConfigSection.js",
+        157
+      ]
+    ]
+  },
+  "Container Port": {
+    "translation": "容器端口",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js",
+        81
+      ],
+      [
+        "plugins/services/src/js/components/forms/NetworkingFormSection.js",
+        408
+      ],
+      [
+        "plugins/services/src/js/containers/service-connection/ServiceConnectionEndpointList.js",
+        126
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js",
+        158
+      ]
+    ]
+  },
+  "Container Runtime": {
+    "translation": "容器运行时间",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
+        215
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js",
+        93
+      ]
+    ]
+  },
+  "Containers": {
+    "translation": "容器",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/dss/components/DSSInput.js",
+        31
+      ],
+      [
+        "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
+        176
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js",
+        43
+      ],
+      [
+        "plugins/services/src/js/containers/pod-debug/PodDebugContainer.js",
+        115
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodContainersConfigSection.js",
+        29
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodContainersConfigSection.js",
+        40
+      ]
+    ]
+  },
+  "Containers: {0}, Executor: {1}": {
+    "translation": "容器：{0}，执行器：{1}",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/pod-instances/PodInstancesTable.js",
+        446
+      ]
+    ]
+  },
+  "Contains extraneous property `||name||`": {
+    "translation": "包含外部属性 `||name||`",
+    "origin": [
+      [
+        "src/js/constants/DefaultErrorMessages.js",
+        100
+      ]
+    ]
+  },
+  "Continue Rollback": {
+    "translation": "继续回滚",
+    "origin": [
+      [
+        "plugins/services/src/js/components/DeploymentsModal.js",
+        423
+      ]
+    ]
+  },
+  "Control where your app runs with advanced rules and constraint attributes": {
+    "translation": "当应用程序使用高级规则和约束属性运行时，则进行控制",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/PlacementFormPartial.js",
+        97
+      ]
+    ]
+  },
+  "Copied!": {
+    "translation": "已复制！",
+    "origin": [
+      [
+        "src/js/components/ClipboardTrigger.js",
+        92
+      ],
+      [
+        "src/js/components/ClusterHeader.js",
+        86
+      ]
+    ]
+  },
+  "Copy": {
+    "translation": "复制",
+    "origin": [
+      [
+        "src/js/components/ClusterHeader.js",
+        86
+      ]
+    ]
+  },
+  "Copy and paste client certificate here.": {
+    "translation": "在此复制并粘贴客户端证书。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        47
+      ]
+    ]
+  },
+  "Copy and paste the code snippet into the terminal:": {
+    "translation": "将代码片段复制并粘贴到终端：",
+    "origin": [
+      [
+        "src/js/components/modals/CliInstallModal.js",
+        94
+      ]
+    ]
+  },
+  "Copy to clipboard": {
+    "translation": "复制到剪贴板",
+    "origin": [
+      [
+        "src/js/components/ClipboardTrigger.js",
+        93
+      ]
+    ]
+  },
+  "Couldn't delete {jobId} as there are currently active job runs. Do you want to stop all runs and delete the job?": {
+    "translation": "无法删除 {jobId}，因为当前有活动的作业运行。是否要停止所有运行并删除作业？",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobDeleteModal.js",
+        22
+      ]
+    ]
+  },
+  "Create": {
+    "translation": "创建",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerFormModal.js",
+        145
+      ],
+      [
+        "src/js/components/FormModal.js",
+        161
+      ]
+    ]
+  },
+  "Create Account": {
+    "translation": "创建账户",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/service-accounts/components/ServiceAccountsFormModal.js",
+        117
+      ]
+    ]
+  },
+  "Create External Load Balancer": {
+    "translation": "创建外部负载均衡器",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerFormModal.js",
+        232
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancersTab.js",
+        134
+      ]
+    ]
+  },
+  "Create Group": {
+    "translation": "创建组",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceGroupFormModal.js",
+        82
+      ],
+      [
+        "plugins/services/src/js/components/modals/ServiceGroupFormModal.js",
+        96
+      ],
+      [
+        "plugins/services/src/js/containers/services/ServiceTreeView.js",
+        107
+      ]
+    ]
+  },
+  "Create Job": {
+    "translation": "创建作业",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobFormModal.tsx",
+        254
+      ]
+    ]
+  },
+  "Create New Group": {
+    "translation": "创建新组",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/components/GroupFormModal.js",
+        88
+      ]
+    ]
+  },
+  "Create New Secret": {
+    "translation": "创建新密钥",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/SecretFormModal.js",
+        193
+      ]
+    ]
+  },
+  "Create New User": {
+    "translation": "创建新用户",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/users/hooks.js",
+        134
+      ]
+    ]
+  },
+  "Create Service Account": {
+    "translation": "创建服务帐户",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/service-accounts/components/ServiceAccountsFormModal.js",
+        206
+      ]
+    ]
+  },
+  "Create a Group": {
+    "translation": "创建组",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/services/EmptyServiceTree.js",
+        11
+      ]
+    ]
+  },
+  "Create a Job": {
+    "translation": "创建作业",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobsOverviewEmpty.tsx",
+        35
+      ]
+    ]
+  },
+  "Create a job": {
+    "translation": "创建作业",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobsOverviewList.tsx",
+        40
+      ]
+    ]
+  },
+  "Create a stateful service by configuring a persistent volume. Persistent volumes enable instances to be restarted without data loss.": {
+    "translation": "通过配置持久卷来创建有状态服务。持久卷允许重启实例，而不会丢失数据。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js",
+        321
+      ],
+      [
+        "plugins/services/src/js/components/forms/VolumesFormSection.js",
+        441
+      ]
+    ]
+  },
+  "Create an external load balancer for your services.": {
+    "translation": "为您的服务创建外部负载均衡器。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancersTab.js",
+        147
+      ]
+    ]
+  },
+  "Create both one-off or scheduled jobs to perform tasks at a predefined interval.": {
+    "translation": "创建一次性或计划性作业，以按照预定义的间隔执行任务。",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobsOverviewEmpty.tsx",
+        29
+      ]
+    ]
+  },
+  "Created": {
+    "translation": "已创建",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/pages/SecretDetail.js",
+        233
+      ],
+      [
+        "plugins/services/src/js/constants/PodContainerStatus.js",
+        7
+      ],
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        6
+      ]
+    ]
+  },
+  "Cryptographic Cluster ID": {
+    "translation": "密码集群 ID",
+    "origin": [
+      [
+        "src/js/pages/system/OverviewDetailTab.js",
+        171
+      ]
+    ]
+  },
+  "Current Version ({localeVersion})": {
+    "translation": "当前版本（{localeVersion}）",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/pod-configuration/PodConfigurationContainer.js",
+        16
+      ]
+    ]
+  },
+  "Currently Deploying Package": {
+    "translation": "当前部署包",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancersTab.js",
+        164
+      ]
+    ]
+  },
+  "DC/OS Storage Volume": {
+    "translation": "DC/OS 存储卷",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/VolumeDefinitions.js",
+        5
+      ]
+    ]
+  },
+  "DC/OS UI cannot retrieve the requested information at this moment.": {
+    "translation": "DC/OS UI 目前无法检索请求的信息。",
+    "origin": [
+      [
+        "src/js/components/RequestErrorMsg.js",
+        50
+      ]
+    ]
+  },
+  "DC/OS also exposes environment variables for host ports and metdata. <0>More information</0>.": {
+    "translation": "DC/OS 还暴露主机端口和元数据的环境变量。<0>更多信息</0>.",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/EnvironmentFormSection.js",
+        176
+      ]
+    ]
+  },
+  "DC/OS can automatically generate a Service Address to connect to each of your load balanced endpoints": {
+    "translation": "DC/OS 可自动生成服务地址，以连接到每个负载均衡端点",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js",
+        652
+      ]
+    ]
+  },
+  "DC/OS can automatically generate a Service Address to connect to each of your load balanced endpoints.": {
+    "translation": "DC/OS 可自动生成服务地址，以连接到每个负载均衡端点。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/NetworkingFormSection.js",
+        628
+      ]
+    ]
+  },
+  "DC/OS has been unable to complete this deployment for {0}.": {
+    "translation": "DC/OS 无法完成 {0} 的该部署。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/ServiceStatusIcon.js",
+        109
+      ]
+    ]
+  },
+  "DC/OS has been waiting for resources and is unable to complete this deployment for": {
+    "translation": "DC/OS 一直在等待资源，无法完成 的该部署",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js",
+        289
+      ]
+    ]
+  },
+  "DC/OS has been waiting for resources and is unable to complete this deployment for {0} .": {
+    "translation": "DC/OS 一直在等待资源，无法完成 {0} 的该部署。",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/pod-debug/PodDebugContainer.js",
+        213
+      ]
+    ]
+  },
+  "DC/OS has been waiting for resources and is unable to complete this deployment for {0}.": {
+    "translation": "DC/OS 一直在等待资源，无法完成 {0} 的该部署。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/ServiceStatusIcon.js",
+        44
+      ]
+    ]
+  },
+  "DC/OS has been waiting for resources and is unable to complete this deployment for {0}. See more information in the debug tab.": {
+    "translation": "DC/OS 一直在等待资源，无法完成 {0} 的该部署。在调试选项卡中查看更多信息。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/ServiceStatusWarningWithDebugInstruction.js",
+        11
+      ]
+    ]
+  },
+  "DC/OS is waiting for resources and is unable to complete the deployment of {appsWithWarningsCount} {0} in this group.": {
+    "translation": "DC/OS 正在等待资源，无法在该组中完成 {appsWithWarningsCount} {0} 的部署。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/ServiceStatusIcon.js",
+        72
+      ]
+    ]
+  },
+  "DC/OS offers several storage options. <0>More information</0>.": {
+    "translation": "DC/OS 提供多种存储选项。<0>更多信息</0>.",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js",
+        268
+      ],
+      [
+        "plugins/services/src/js/components/forms/VolumesFormSection.js",
+        414
+      ]
+    ]
+  },
+  "DNS": {
+    "translation": "DNS",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-connection/SDKServiceConnectionEndpointList.js",
+        77
+      ]
+    ]
+  },
+  "DSK": {
+    "translation": "DSK",
+    "origin": [
+      [
+        "plugins/services/src/js/components/DeclinedOffersTable.js",
+        298
+      ]
+    ]
+  },
+  "Dashboard": {
+    "translation": "仪表板",
+    "origin": [
+      [
+        "src/js/pages/DashboardPage.js",
+        48
+      ],
+      [
+        "src/js/pages/DashboardPage.js",
+        64
+      ]
+    ]
+  },
+  "Debug": {
+    "translation": "调试",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/pod-detail/PodDetail.js",
+        42
+      ],
+      [
+        "plugins/services/src/js/containers/pod-detail/PodDetail.js",
+        208
+      ],
+      [
+        "plugins/services/src/js/containers/service-detail/ServiceDetail.js",
+        45
+      ],
+      [
+        "plugins/services/src/js/containers/service-detail/ServiceDetail.js",
+        241
+      ]
+    ]
+  },
+  "Debug information": {
+    "translation": "调试信息",
+    "origin": [
+      [
+        "plugins/services/src/js/components/ServiceStatusIcon.js",
+        30
+      ]
+    ]
+  },
+  "Declined": {
+    "translation": "已拒绝",
+    "origin": [
+      [
+        "plugins/services/src/js/components/RecentOffersSummary.js",
+        250
+      ]
+    ]
+  },
+  "Define the permission in a string format. If the permission also includes an action, specify the action that should be allowed. Refer to <0>the documentation</0> for more details.": {
+    "translation": "以字符串格式定义权限。如果权限还包括操作，则指定应允许的操作。请参阅 <0>文档，</0> 以了解更多详情。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/PermissionBuilderModal.js",
+        439
+      ]
+    ]
+  },
+  "Delayed": {
+    "translation": "已延迟",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceStatusLabels.js",
+        8
+      ]
+    ]
+  },
+  "Delete": {
+    "translation": "删除",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerDetail.js",
+        186
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/VHostDetail.js",
+        138
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/components/AdvancedACLsTab.js",
+        185
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/constants/BulkOptions.js",
+        22
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/constants/BulkOptions.js",
+        45
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/constants/BulkOptions.js",
+        68
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/components/DirectoryActionButtons.js",
+        143
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/components/GroupDetailPage.js",
+        296
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/components/GroupDetailPage.js",
+        315
+      ],
+      [
+        ".dcos-ui-plugins-private/secrets/components/SecretsTable.js",
+        47
+      ],
+      [
+        "plugins/jobs/src/js/jobsMenu.js",
+        16
+      ],
+      [
+        "plugins/services/src/js/components/modals/ServiceDestroyModal.js",
+        176
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceActionLabels.js",
+        5
+      ],
+      [
+        "plugins/services/src/js/containers/pod-detail/PodDetail.js",
+        183
+      ],
+      [
+        "plugins/services/src/js/containers/service-detail/ServiceDetail.js",
+        222
+      ],
+      [
+        "src/js/components/form/DeleteRowButton.js",
+        10
+      ],
+      [
+        "src/js/components/form/FormGroupContainer.js",
+        15
+      ],
+      [
+        "src/js/constants/BulkOptions.js",
+        11
+      ]
+    ]
+  },
+  "Delete Action": {
+    "translation": "删除操作",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/AdvancedACLsTab.js",
+        230
+      ]
+    ]
+  },
+  "Delete Group": {
+    "translation": "删除组",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/constants/BulkOptions.js",
+        26
+      ],
+      [
+        "plugins/services/src/js/components/modals/DisabledGroupDestroyModal.js",
+        18
+      ]
+    ]
+  },
+  "Delete Job": {
+    "translation": "删除作业",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobDeleteModal.js",
+        7
+      ],
+      [
+        "plugins/jobs/src/js/components/JobDeleteModal.js",
+        30
+      ]
+    ]
+  },
+  "Delete Repository": {
+    "translation": "删除存储库",
+    "origin": [
+      [
+        "plugins/catalog/src/js/repositories/components/RepositoriesDeleteConfirm.js",
+        37
+      ],
+      [
+        "plugins/catalog/src/js/repositories/components/RepositoriesDeleteConfirm.js",
+        40
+      ]
+    ]
+  },
+  "Delete Service Account": {
+    "translation": "删除服务帐户",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/constants/BulkOptions.js",
+        49
+      ]
+    ]
+  },
+  "Delete User": {
+    "translation": "删除用户",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/constants/BulkOptions.js",
+        72
+      ]
+    ]
+  },
+  "Delete {serviceLabel}": {
+    "translation": "删除 {serviceLabel}",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceDestroyModal.js",
+        205
+      ]
+    ]
+  },
+  "Deleting": {
+    "translation": "正在删除",
+    "origin": [
+      [
+        "plugins/services/src/js/components/dsl/ServiceStatusDSLSection.js",
+        88
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceStatusLabels.js",
+        10
+      ]
+    ]
+  },
+  "Dependencies": {
+    "translation": "依赖性",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js",
+        211
+      ]
+    ]
+  },
+  "Deploying": {
+    "translation": "正在部署",
+    "origin": [
+      [
+        "plugins/services/src/js/components/dsl/ServiceStatusDSLSection.js",
+        57
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceStatusLabels.js",
+        5
+      ]
+    ]
+  },
+  "Deployment": {
+    "translation": "部署",
+    "origin": [
+      [
+        "plugins/services/src/js/components/DeploymentsModal.js",
+        542
+      ]
+    ]
+  },
+  "Deployments": {
+    "translation": "部署",
+    "origin": [
+      [
+        "plugins/services/src/js/components/DeploymentsModal.js",
+        542
+      ]
+    ]
+  },
+  "Description": {
+    "translation": "描述",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/constants/AuthProvidersFormDefinitions.js",
+        26
+      ],
+      [
+        ".dcos-ui-plugins-private/auth-providers/constants/AuthProvidersFormDefinitions.js",
+        73
+      ],
+      [
+        ".dcos-ui-plugins-private/auth-providers/structs/AuthProvider.js",
+        102
+      ],
+      [
+        ".dcos-ui-plugins-private/auth-providers/structs/AuthProvider.js",
+        113
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/components/OrganizationTab.js",
+        350
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/service-accounts/components/ServiceAccountsFormModal.js",
+        151
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/service-accounts/components/ServiceAccountsFormModal.js",
+        164
+      ],
+      [
+        ".dcos-ui-plugins-private/secrets/pages/SecretDetail.js",
+        211
+      ],
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        26
+      ]
+    ]
+  },
+  "Destination Path": {
+    "translation": "目标路径",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/PodContainerArtifactsConfigSection.js",
+        70
+      ]
+    ]
+  },
+  "Detached": {
+    "translation": "已分离",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/VolumeStatus.js",
+        5
+      ]
+    ]
+  },
+  "Details": {
+    "translation": "详细信息",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerDetail.js",
+        59
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/VHostDetail.js",
+        46
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/BackendDetailPage.js",
+        255
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPDetailPage.js",
+        258
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/components/AccountDetailPage.js",
+        49
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/components/AccountDetailPage.js",
+        286
+      ],
+      [
+        "plugins/jobs/src/js/pages/JobTaskDetailPage.js",
+        25
+      ],
+      [
+        "plugins/nodes/src/js/pages/nodes/NodeDetailPage.js",
+        38
+      ],
+      [
+        "plugins/nodes/src/js/pages/nodes/NodeDetailPage.js",
+        188
+      ],
+      [
+        "plugins/nodes/src/js/pages/nodes/NodesTaskDetailPage.js",
+        38
+      ],
+      [
+        "plugins/services/src/js/containers/pod-debug/PodDebugContainer.js",
+        52
+      ],
+      [
+        "plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js",
+        53
+      ],
+      [
+        "plugins/services/src/js/pages/task-details/ServiceTaskDetailPage.js",
+        22
+      ],
+      [
+        "src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.js",
+        65
+      ],
+      [
+        "src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.js",
+        156
+      ],
+      [
+        "src/js/pages/network/virtual-network-detail/VirtualNetworkTaskPage.js",
+        78
+      ]
+    ]
+  },
+  "Did not find a node by the id \"{nodeID}\"": {
+    "translation": "使用 id \"{nodeID}\"，未找到节点",
+    "origin": [
+      [
+        "plugins/nodes/src/js/pages/nodes/NodeDetailPage.js",
+        131
+      ]
+    ]
+  },
+  "Did not find a {item} with id \"{itemID}\"": {
+    "translation": "使用 id \"{itemID}\"，未找到 {item}",
+    "origin": [
+      [
+        "plugins/services/src/js/pages/task-details/TaskDetail.js",
+        286
+      ]
+    ]
+  },
+  "Disable Schedule": {
+    "translation": "禁用计划",
+    "origin": [
+      [
+        "plugins/jobs/src/js/jobsToggleSchedule.js",
+        20
+      ]
+    ]
+  },
+  "Disabled": {
+    "translation": "已禁用",
+    "origin": [
+      [
+        "plugins/services/src/js/components/ConfigurationMapBooleanValue.js",
+        38
+      ]
+    ]
+  },
+  "Discard": {
+    "translation": "已丢弃",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModal.js",
+        933
+      ],
+      [
+        "src/js/components/FrameworkConfiguration.js",
+        358
+      ]
+    ]
+  },
+  "Discard Changes?": {
+    "translation": "要丢弃更改？",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModal.js",
+        925
+      ],
+      [
+        "src/js/components/FrameworkConfiguration.js",
+        351
+      ]
+    ]
+  },
+  "Disk": {
+    "translation": "磁盘",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/NodesTable.tsx",
+        98
+      ],
+      [
+        "plugins/nodes/src/js/pages/nodes/NodeDetailTab.js",
+        125
+      ],
+      [
+        "plugins/services/src/js/components/DeclinedOffersTable.js",
+        298
+      ],
+      [
+        "plugins/services/src/js/components/RecentOffersSummary.js",
+        17
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceTableHeaderLabels.js",
+        5
+      ],
+      [
+        "plugins/services/src/js/constants/TaskTableHeaderLabels.js",
+        6
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodContainerConfigSection.js",
+        109
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js",
+        117
+      ]
+    ]
+  },
+  "Disk (MiB)": {
+    "translation": "磁盘 (Mib)",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/ContainerServiceFormAdvancedSection.js",
+        242
+      ]
+    ]
+  },
+  "Disk Allocation": {
+    "translation": "磁盘分配",
+    "origin": [
+      [
+        "src/js/constants/DashboardHeadings.js",
+        7
+      ]
+    ]
+  },
+  "Disk Space (Mib)": {
+    "translation": "磁盘空间 (Mib)",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        44
+      ]
+    ]
+  },
+  "Docker Container": {
+    "translation": "Docker 容器",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        106
+      ]
+    ]
+  },
+  "Docker Engine": {
+    "translation": "Docker 引擎",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ContainerConstants.js",
+        9
+      ]
+    ]
+  },
+  "Docker Engine does not support GPU resources, please select Universal Container Runtime (UCR) if you want to use GPU resources.": {
+    "translation": "Docker 引擎不支持 GPU 资源，如果您想使用 GPU 资源，请选择通用容器运行时 (UCR)。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/ContainerServiceFormAdvancedSection.js",
+        117
+      ],
+      [
+        "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
+        255
+      ]
+    ]
+  },
+  "Docker Runtime only supports the default size for implicit volumes, please select Universal Container Runtime (UCR) if you want to modify the size.": {
+    "translation": "Docker 运行时仅支持隐式卷的默认大小，如果要修改大小，请选择通用容器运行时 (UCR)。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/VolumesFormSection.js",
+        214
+      ]
+    ]
+  },
+  "Docker’s container runtime. No support for multiple containers (Pods) or GPU resources.": {
+    "translation": "Docker 的容器运行时。不支持多个容器（Pod）或 GPU 资源。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
+        49
+      ]
+    ]
+  },
+  "Documentation": {
+    "translation": "文档",
+    "origin": [
+      [
+        "src/js/components/ClusterHeader.js",
+        142
+      ]
+    ]
+  },
+  "Don't run app tasks on a particular set of attribute IDs": {
+    "translation": "不要在特定的属性 ID 集合上运行应用程序任务",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/OperatorTypes.js",
+        60
+      ]
+    ]
+  },
+  "Download": {
+    "translation": "下载",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/components/AuthProviderDetailTab.js",
+        80
+      ]
+    ]
+  },
+  "Download Config": {
+    "translation": "下载配置",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js",
+        241
+      ],
+      [
+        "src/js/components/FrameworkConfigurationReviewScreen.js",
+        162
+      ]
+    ]
+  },
+  "Download Snapshot": {
+    "translation": "下载快照",
+    "origin": [
+      [
+        "src/js/pages/system/UnitsHealthTab.js",
+        234
+      ]
+    ]
+  },
+  "Download and install: <0><1/> Download dcos.exe</0>.": {
+    "translation": "下载和安装：<0><1/> 下载 dcos.exe</0>.",
+    "origin": [
+      [
+        "src/js/components/modals/CliInstallModal.js",
+        137
+      ]
+    ]
+  },
+  "Download log file": {
+    "translation": "下载日志文件",
+    "origin": [
+      [
+        "plugins/services/src/js/pages/task-details/TaskFileViewer.js",
+        193
+      ]
+    ]
+  },
+  "Downloads and extracts the {0} bootstrap tarball into /opt/mesosphere on your nodes.": {
+    "translation": "下载并将{0} bootstrap tarball 提取到节点上的 /opt/mesosphere。",
+    "origin": [
+      [
+        "src/js/constants/UnitSummaries.js",
+        103
+      ]
+    ]
+  },
+  "Dropped": {
+    "translation": "已错位",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        71
+      ]
+    ]
+  },
+  "E.g hostname.": {
+    "translation": "例如，主机名。",
+    "origin": [
+      [
+        "src/js/components/PlacementConstraintsPartial.js",
+        106
+      ]
+    ]
+  },
+  "Edit": {
+    "translation": "编辑",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerDetail.js",
+        175
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/components/DirectoryActionButtons.js",
+        133
+      ],
+      [
+        ".dcos-ui-plugins-private/placement/components/RegionConstraintsSection.js",
+        14
+      ],
+      [
+        ".dcos-ui-plugins-private/placement/components/ZoneConstraintsSection.js",
+        14
+      ],
+      [
+        ".dcos-ui-plugins-private/secrets/components/ServiceConfigSecretsSectionDisplay.js",
+        86
+      ],
+      [
+        "plugins/jobs/src/js/jobsMenu.js",
+        8
+      ],
+      [
+        "plugins/services/src/js/components/ConfigurationMapTable.js",
+        144
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceActionLabels.js",
+        4
+      ],
+      [
+        "plugins/services/src/js/containers/pod-detail/PodDetail.js",
+        156
+      ],
+      [
+        "plugins/services/src/js/containers/pod-detail/PodHeader.js",
+        67
+      ],
+      [
+        "plugins/services/src/js/containers/service-detail/ServiceDetail.js",
+        189
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodNetworkConfigSection.js",
+        122
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceConfigBaseSectionDisplay.js",
+        71
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceEnvironmentVariablesConfigSection.js",
+        93
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js",
+        282
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceHealthChecksConfigSection.js",
+        168
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceHealthChecksConfigSection.js",
+        275
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceLabelsConfigSection.js",
+        82
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js",
+        207
+      ],
+      [
+        "src/js/pages/settings/UISettingsPage.js",
+        72
+      ]
+    ]
+  },
+  "Edit Config": {
+    "translation": "编辑配置",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js",
+        224
+      ],
+      [
+        "src/js/components/FrameworkConfigurationReviewScreen.js",
+        145
+      ]
+    ]
+  },
+  "Edit Configuration": {
+    "translation": "编辑配置",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-connection/ServiceNoEndpointsPanel.js",
+        18
+      ],
+      [
+        "src/js/components/FrameworkConfiguration.js",
+        271
+      ]
+    ]
+  },
+  "Edit Directory": {
+    "translation": "编辑目录",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/components/DirectoryFormModal.js",
+        129
+      ]
+    ]
+  },
+  "Edit External Load Balancer": {
+    "translation": "编辑外部负载均衡器",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerFormModal.js",
+        231
+      ]
+    ]
+  },
+  "Edit Job ({0})": {
+    "translation": "编辑作业（{0}）",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobFormModal.tsx",
+        254
+      ]
+    ]
+  },
+  "Edit Secret": {
+    "translation": "编辑密钥",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/SecretFormModal.js",
+        192
+      ]
+    ]
+  },
+  "Edit Service": {
+    "translation": "编辑服务",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModal.js",
+        587
+      ]
+    ]
+  },
+  "Edit Service Account": {
+    "translation": "编辑服务帐户",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/service-accounts/components/ServiceAccountsFormModal.js",
+        204
+      ]
+    ]
+  },
+  "Edit User": {
+    "translation": "编辑用户",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/users/components/modals/UserEditFormModal.js",
+        127
+      ]
+    ]
+  },
+  "Edit {0}": {
+    "translation": "编辑 {0}",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModal.js",
+        585
+      ]
+    ]
+  },
+  "Editing this service is only available on <0>Mesosphere Enterprise DC/OS</0>.": {
+    "translation": "编辑此服务仅适用于 <0>Mesosphere 企业 DC/OS</0>.",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceActionDisabledModal.js",
+        162
+      ]
+    ]
+  },
+  "Elected": {
+    "translation": "已选中",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/LeaderGrid.js",
+        66
+      ],
+      [
+        "src/js/pages/system/OverviewDetailTab.js",
+        308
+      ]
+    ]
+  },
+  "Enable Load Balanced Service Address": {
+    "translation": "启用负载均衡服务地址",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js",
+        230
+      ],
+      [
+        "plugins/services/src/js/components/forms/NetworkingFormSection.js",
+        185
+      ]
+    ]
+  },
+  "Enable Schedule": {
+    "translation": "启用计划",
+    "origin": [
+      [
+        "plugins/jobs/src/js/jobsToggleSchedule.js",
+        21
+      ]
+    ]
+  },
+  "Enabled": {
+    "translation": "已启用。",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        78
+      ],
+      [
+        "plugins/services/src/js/components/ConfigurationMapBooleanValue.js",
+        37
+      ]
+    ]
+  },
+  "Endpoints": {
+    "translation": "端点",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/pod-detail/PodDetail.js",
+        209
+      ],
+      [
+        "plugins/services/src/js/containers/service-detail/ServiceDetail.js",
+        242
+      ]
+    ]
+  },
+  "Endpoints for {0} will appear here once it is fully deployed and running.": {
+    "translation": "{0} 的端点将在完全部署和运行后出现于此。",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-connection/SDKServiceConnectionEndpointList.js",
+        159
+      ]
+    ]
+  },
+  "Enforce StartTLS for all connections": {
+    "translation": "为所有连接执行 StartTLS",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        29
+      ]
+    ]
+  },
+  "Enter": {
+    "translation": "输入",
+    "origin": [
+      [
+        "src/js/components/modals/CliInstallModal.js",
+        119
+      ]
+    ]
+  },
+  "Enter a Docker image or browse <0>Docker Hub</0> to find more. You can also enter an image from your private registry. <1>More information</1>.": {
+    "translation": "输入 Docker 镜像或浏览 <0>Docker Hub</0> 以了解更多信息。您也可以从私有注册中心输入镜像。<1>更多信息</1>.",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/ContainerServiceFormSection.js",
+        91
+      ]
+    ]
+  },
+  "Enter a Docker image you want to run, e.g. nginx.": {
+    "translation": "输入您要运行的 Docker 镜像，例如，nginx。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/ContainerServiceFormSection.js",
+        176
+      ]
+    ]
+  },
+  "Enter a name for the new group under <0>{parentGroupId}</0>": {
+    "translation": "为 下的新组输入名称 <0>{parentGroupId}</0>",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceGroupFormModal.js",
+        107
+      ]
+    ]
+  },
+  "Enter a path that is reachable in your service and where you expect a response code between 200 and 399.": {
+    "translation": "输入您服务中可访问、预期响应代码在 200 到 399 之间的路径。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/HealthChecksFormSection.js",
+        320
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js",
+        271
+      ]
+    ]
+  },
+  "Enter words found in name": {
+    "translation": "输入在名称中找到的字词",
+    "origin": [
+      [
+        "plugins/services/src/js/components/dsl/FuzzyTextDSLSection.js",
+        106
+      ]
+    ]
+  },
+  "EntityID": {
+    "translation": "EntityID",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/components/AuthProviderDetailTab.js",
+        89
+      ]
+    ]
+  },
+  "Environment": {
+    "translation": "环境",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/EnvironmentFormSection.js",
+        206
+      ],
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModalForm.js",
+        498
+      ],
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModalForm.js",
+        514
+      ]
+    ]
+  },
+  "Environment Variables": {
+    "translation": "环境变量",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/EnvironmentFormSection.js",
+        217
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodEnvironmentVariablesConfigSection.js",
+        77
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceEnvironmentVariablesConfigSection.js",
+        43
+      ]
+    ]
+  },
+  "Environment variables": {
+    "translation": "环境变量",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        22
+      ]
+    ]
+  },
+  "Ephemeral Storage": {
+    "translation": "临时存储",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/VolumeDefinitions.js",
+        34
+      ]
+    ]
+  },
+  "Error": {
+    "translation": "错误",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/PodContainerStatus.js",
+        49
+      ],
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        56
+      ]
+    ]
+  },
+  "Error finding node": {
+    "translation": "查找节点错误",
+    "origin": [
+      [
+        "plugins/nodes/src/js/pages/nodes/NodeDetailPage.js",
+        128
+      ]
+    ]
+  },
+  "Error finding {item}": {
+    "translation": "查找 {item} 错误",
+    "origin": [
+      [
+        "plugins/services/src/js/pages/task-details/TaskDetail.js",
+        283
+      ]
+    ]
+  },
+  "Exceeded licensed node count on ${numberBreaches} occasions.": {
+    "translation": "超过许可节点数 ${numberBreaches} 次。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/licensing/components/LicensingNodeCapacityRow.js",
+        61
+      ]
+    ]
+  },
+  "Exceeded licensed node count on one occasion.": {
+    "translation": "超过许可节点数 1 次。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/licensing/components/LicensingNodeCapacityRow.js",
+        57
+      ]
+    ]
+  },
+  "Executable": {
+    "translation": "可执行",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/PodContainerArtifactsConfigSection.js",
+        28
+      ]
+    ]
+  },
+  "Executor": {
+    "translation": "执行器",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js",
+        218
+      ]
+    ]
+  },
+  "Expires": {
+    "translation": "到期",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/CertificatesTable.js",
+        55
+      ]
+    ]
+  },
+  "Extended Runtime Priv.": {
+    "translation": "延长运行时权限",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js",
+        165
+      ]
+    ]
+  },
+  "External": {
+    "translation": "外部",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/OrganizationTab.js",
+        163
+      ]
+    ]
+  },
+  "External LDAP Configuration": {
+    "translation": "外部 LDAP 配置",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
+        329
+      ]
+    ]
+  },
+  "External Persistent Volume": {
+    "translation": "外部持久卷",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/VolumeDefinitions.js",
+        20
+      ]
+    ]
+  },
+  "Extract": {
+    "translation": "提取",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/PodContainerArtifactsConfigSection.js",
+        42
+      ]
+    ]
+  },
+  "FAILURE %": {
+    "translation": "失败 %",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/BackendsTable.js",
+        44
+      ]
+    ]
+  },
+  "FAILURES": {
+    "translation": "失败",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/BackendsTable.js",
+        43
+      ]
+    ]
+  },
+  "FALSE": {
+    "translation": "错误",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/PodContainerArtifactsConfigSection.js",
+        14
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodStorageConfigSection.js",
+        16
+      ]
+    ]
+  },
+  "Failed": {
+    "translation": "已失败",
+    "origin": [
+      [
+        "plugins/jobs/src/js/constants/JobStates.ts",
+        24
+      ],
+      [
+        "plugins/services/src/js/constants/PodContainerStatus.js",
+        55
+      ],
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        46
+      ]
+    ]
+  },
+  "Failure %": {
+    "translation": "失败 %",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/LoadBalancersTable.js",
+        45
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPsTable.js",
+        51
+      ]
+    ]
+  },
+  "Failures": {
+    "translation": "失败",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/LoadBalancersTable.js",
+        44
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/VHostsTable.js",
+        43
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/BackendsTable.js",
+        77
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/NetworkItemChart.js",
+        98
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPsTable.js",
+        50
+      ]
+    ]
+  },
+  "Failure %": {
+    "translation": "失败 %",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/VHostsTable.js",
+        44
+      ]
+    ]
+  },
+  "Field": {
+    "translation": "字段",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/PlacementConstraintsFields.js",
+        86
+      ],
+      [
+        "src/js/components/PlacementConstraintsPartial.js",
+        86
+      ]
+    ]
+  },
+  "Field Name": {
+    "translation": "字段名称",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/AdvancedConstraintsSection.js",
+        17
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodPlacementConstraintsConfigSection.js",
+        24
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServicePlacementConstraintsConfigSection.js",
+        23
+      ]
+    ]
+  },
+  "Files": {
+    "translation": "文件",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobTaskDetailPage.js",
+        26
+      ],
+      [
+        "plugins/nodes/src/js/pages/nodes/NodesTaskDetailPage.js",
+        39
+      ],
+      [
+        "plugins/services/src/js/containers/service-connection/SDKServiceConnectionEndpointList.js",
+        149
+      ],
+      [
+        "plugins/services/src/js/pages/task-details/ServiceTaskDetailPage.js",
+        23
+      ],
+      [
+        "src/js/pages/network/virtual-network-detail/VirtualNetworkTaskPage.js",
+        82
+      ]
+    ]
+  },
+  "Filter": {
+    "translation": "筛选器",
+    "origin": [
+      [
+        "src/js/components/DSLInputField.js",
+        285
+      ]
+    ]
+  },
+  "Filter by Service": {
+    "translation": "按服务筛选",
+    "origin": [
+      [
+        "plugins/services/src/js/components/FilterByService.js",
+        77
+      ]
+    ]
+  },
+  "Finished": {
+    "translation": "已完成",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobRunHistoryTable.js",
+        105
+      ],
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        36
+      ]
+    ]
+  },
+  "First success": {
+    "translation": "首次成功",
+    "origin": [
+      [
+        "plugins/services/src/js/components/MarathonTaskDetailsList.js",
+        130
+      ]
+    ]
+  },
+  "For example, you could label services “staging” and “production” to mark them by their position in the pipeline. <0>More information</0>.": {
+    "translation": "例如，您可以为服务打上“模拟”和“生产”标签，以通过它们在流水线中的位置进行标记。<0>更多信息</0>.",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/EnvironmentFormSection.js",
+        189
+      ]
+    ]
+  },
+  "For information and instructions on how to create virtual IPs see <0>networking documentation</0>.": {
+    "translation": "有关如何创建虚拟 IP 的信息和说明，请参阅 <0>网络文档</0>.",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.js",
+        89
+      ]
+    ]
+  },
+  "For {otherServicesList}: Copy the JSON below into a file called <0>options.json</0>. <1>More information</1>": {
+    "translation": "对于 {otherServicesList}：将以下 JSON 复制到名为 <0>options.json</0>. <1>更多信息</1>",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceActionDisabledModal.js",
+        252
+      ]
+    ]
+  },
+  "For {sdkServicesList} : Create <0><package-name>-options.json</0> files for each service. Here is a sample options file . <1>More information</1>": {
+    "translation": "对于 {sdkServicesList}：为每个服务创建 <0><package-name>-options.json</0> 文件。这是一个样本选项文件。<1>更多信息</1>",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceActionDisabledModal.js",
+        280
+      ]
+    ]
+  },
+  "Force": {
+    "translation": "强制",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/KillPodInstanceModal.js",
+        124
+      ],
+      [
+        "plugins/services/src/js/components/modals/KillTaskModal.js",
+        125
+      ]
+    ]
+  },
+  "Force Docker to pull the image before launching each instance.": {
+    "translation": "在启动每个实例之前，强制 Docker 拉取镜像。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/ContainerServiceFormAdvancedSection.js",
+        39
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerFormAdvancedSection.js",
+        24
+      ]
+    ]
+  },
+  "Force Pull Image On Launch": {
+    "translation": "启动时强制拉取图像",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/ContainerServiceFormAdvancedSection.js",
+        38
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerFormAdvancedSection.js",
+        22
+      ]
+    ]
+  },
+  "Force Pull on Launch": {
+    "translation": "启动时强制拉取",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js",
+        182
+      ]
+    ]
+  },
+  "Force Run Service": {
+    "translation": "强制运行服务",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModal.js",
+        769
+      ]
+    ]
+  },
+  "Force pull image on launch option isn't supported by selected runtime.": {
+    "translation": "选中的运行时不支持“启动时强制拉取镜像”选项。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/ContainerServiceFormAdvancedSection.js",
+        42
+      ]
+    ]
+  },
+  "Force pull on launch": {
+    "translation": "启动时强制拉取",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/PodContainerConfigSection.js",
+        82
+      ]
+    ]
+  },
+  "Full Name": {
+    "translation": "全名",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/OrganizationTab.js",
+        349
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/users/components/modals/UserEditFormModal.js",
+        98
+      ]
+    ]
+  },
+  "GPU": {
+    "translation": "GPU",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/NodesTable.tsx",
+        100
+      ],
+      [
+        "plugins/services/src/js/components/DeclinedOffersTable.js",
+        315
+      ],
+      [
+        "plugins/services/src/js/components/RecentOffersSummary.js",
+        15
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceTableHeaderLabels.js",
+        6
+      ],
+      [
+        "plugins/services/src/js/constants/TaskTableHeaderLabels.js",
+        5
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodGeneralConfigSection.js",
+        149
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js",
+        128
+      ]
+    ]
+  },
+  "GPU Allocation": {
+    "translation": "GPU 分配",
+    "origin": [
+      [
+        "src/js/constants/DashboardHeadings.js",
+        5
+      ]
+    ]
+  },
+  "GPUs": {
+    "translation": "GPU",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/ContainerServiceFormAdvancedSection.js",
+        140
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodContainerConfigSection.js",
+        116
+      ]
+    ]
+  },
+  "General": {
+    "translation": "通用",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        16
+      ],
+      [
+        "src/js/pages/system/OverviewDetailTab.js",
+        346
+      ]
+    ]
+  },
+  "Give your service a unique name within the cluster, e.g. my-service.": {
+    "translation": "在集群中为您的服务赋予唯一名称，例如，my-service。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
+        383
+      ]
+    ]
+  },
+  "Go to bottom": {
+    "translation": "返回底部",
+    "origin": [
+      [
+        "plugins/services/src/js/components/LogView.js",
+        301
+      ]
+    ]
+  },
+  "Gone": {
+    "translation": "已返回",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        61
+      ]
+    ]
+  },
+  "Gone by operator": {
+    "translation": "由运算符返回",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        66
+      ]
+    ]
+  },
+  "Grace Period": {
+    "translation": "宽限期",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/PodHealthChecksConfigSection.js",
+        16
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceHealthChecksConfigSection.js",
+        120
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceHealthChecksConfigSection.js",
+        227
+      ]
+    ]
+  },
+  "Grace Period (s)": {
+    "translation": "宽限期",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/HealthChecksFormSection.js",
+        93
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js",
+        74
+      ]
+    ]
+  },
+  "Grant Runtime Privileges": {
+    "translation": "授予运行时权限",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/ContainerServiceFormAdvancedSection.js",
+        28
+      ]
+    ]
+  },
+  "Grant runtime privileges option isn't supported by selected runtime.": {
+    "translation": "选中的运行时不支持“授予运行时权限”选项。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/ContainerServiceFormAdvancedSection.js",
+        32
+      ]
+    ]
+  },
+  "Grid": {
+    "translation": "网格",
+    "origin": [
+      [
+        "plugins/nodes/src/js/pages/NodesAgents.js",
+        235
+      ]
+    ]
+  },
+  "Group": {
+    "translation": "组",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceActionDisabledModal.js",
+        348
+      ],
+      [
+        "plugins/services/src/js/components/modals/ServiceRestartModal.js",
+        94
+      ],
+      [
+        "plugins/services/src/js/components/modals/ServiceStopModal.js",
+        94
+      ]
+    ]
+  },
+  "Group By": {
+    "translation": "按 分组",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/OperatorTypes.js",
+        31
+      ]
+    ]
+  },
+  "Group ID": {
+    "translation": "组 ID",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/AccountGroupTable.js",
+        87
+      ]
+    ]
+  },
+  "Group Import (Optional)": {
+    "translation": "组导入（可选）",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/components/DirectoryFormModal.js",
+        516
+      ]
+    ]
+  },
+  "Group Membership": {
+    "translation": "组成员",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/AccountDetailPage.js",
+        48
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/components/AccountDetailPage.js",
+        279
+      ]
+    ]
+  },
+  "Group Name": {
+    "translation": "组名称",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/components/modals/LDAPGroupFormModal.js",
+        118
+      ]
+    ]
+  },
+  "Group Search": {
+    "translation": "组搜索",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        61
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
+        187
+      ]
+    ]
+  },
+  "Group Search Base": {
+    "translation": "组搜索基准",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        64
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        65
+      ]
+    ]
+  },
+  "Group Search Filter Template": {
+    "translation": "组搜索筛选模板",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        68
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        69
+      ]
+    ]
+  },
+  "Group name": {
+    "translation": "组名称",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/components/GroupFormModal.js",
+        65
+      ],
+      [
+        "plugins/services/src/js/components/modals/ServiceGroupFormModal.js",
+        60
+      ]
+    ]
+  },
+  "Group name must be at least 1 character and may only contain digits (0-9), dashes (-), dots (.), and lowercase letters (a-z). The name may not begin or end with a dash.": {
+    "translation": "组名称必须至少为 1 个字符，且只能包含数字 (0-9)、破折号 (-)、圆点 (.) 和小写字母 (a-z)。名称不得以破折号开始或结束。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceGroupFormModal.js",
+        66
+      ]
+    ]
+  },
+  "Group {successMsg} added.": {
+    "translation": "组 {successMsg} 已添加。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/components/modals/LDAPGroupFormModal.js",
+        153
+      ]
+    ]
+  },
+  "Groups": {
+    "translation": "组",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/components/GroupDetailPage.js",
+        34
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/pages/GroupsPage.js",
+        40
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/pages/GroupsPage.js",
+        202
+      ]
+    ]
+  },
+  "HEALTHY": {
+    "translation": "运行状况",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-debug/TaskStatsTable.js",
+        23
+      ]
+    ]
+  },
+  "HTTP": {
+    "translation": "HTTP",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/HealthChecksFormSection.js",
+        485
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js",
+        433
+      ]
+    ]
+  },
+  "Has the words": {
+    "translation": "含有词语",
+    "origin": [
+      [
+        "plugins/services/src/js/components/dsl/FuzzyTextDSLSection.js",
+        100
+      ]
+    ]
+  },
+  "Health": {
+    "translation": "运行状况",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/HealthTab.js",
+        60
+      ],
+      [
+        "plugins/nodes/src/js/components/NodesTable.tsx",
+        84
+      ],
+      [
+        "plugins/nodes/src/js/components/dsl/NodesHealthDSLSection.js",
+        34
+      ],
+      [
+        "plugins/nodes/src/js/pages/nodes/NodeDetailPage.js",
+        37
+      ],
+      [
+        "plugins/nodes/src/js/pages/nodes/NodeDetailPage.js",
+        181
+      ],
+      [
+        "plugins/services/src/js/components/dsl/ServiceHealthDSLSection.js",
+        35
+      ],
+      [
+        "plugins/services/src/js/constants/PodTableHeaderLabels.js",
+        9
+      ],
+      [
+        "plugins/services/src/js/constants/TaskTableHeaderLabels.js",
+        14
+      ],
+      [
+        "src/js/components/UnitHealthNodesTable.js",
+        36
+      ],
+      [
+        "src/js/pages/system/UnitsHealthTab.js",
+        149
+      ]
+    ]
+  },
+  "Health Check": {
+    "translation": "运行状况检查",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/HealthTab.js",
+        61
+      ],
+      [
+        "plugins/nodes/src/js/components/HealthTab.js",
+        145
+      ],
+      [
+        "src/js/pages/system/UnitsHealthDetail.js",
+        190
+      ]
+    ]
+  },
+  "Health Check Result {healthCheckResultNum}": {
+    "translation": "运行状况检查结果 {healthCheckResultNum}",
+    "origin": [
+      [
+        "plugins/services/src/js/components/MarathonTaskDetailsList.js",
+        124
+      ]
+    ]
+  },
+  "Health Checks": {
+    "translation": "运行状况检查",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/HealthChecksFormSection.js",
+        521
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js",
+        488
+      ],
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModalForm.js",
+        493
+      ],
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModalForm.js",
+        509
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodHealthChecksConfigSection.js",
+        143
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceHealthChecksConfigSection.js",
+        70
+      ]
+    ]
+  },
+  "Health check grace periods": {
+    "translation": "运行状况检查宽限期",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        82
+      ]
+    ]
+  },
+  "Health check intervals": {
+    "translation": "运行状况检查间隔",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        86
+      ]
+    ]
+  },
+  "Health check max failures": {
+    "translation": "运行状况检查最大失败数",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        94
+      ]
+    ]
+  },
+  "Health check timeouts": {
+    "translation": "运行状况检查超时",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        90
+      ]
+    ]
+  },
+  "Health checks may be specified per application to be run against the application's instances.": {
+    "translation": "可按每个应用程序指定运行状况检查，已针对应用程序的实例运行。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/HealthChecksFormSection.js",
+        536
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js",
+        525
+      ]
+    ]
+  },
+  "Healthy": {
+    "translation": "运行状况",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/dsl/NodesHealthDSLSection.js",
+        45
+      ],
+      [
+        "plugins/services/src/js/components/dsl/ServiceHealthDSLSection.js",
+        46
+      ],
+      [
+        "plugins/services/src/js/constants/TaskHealthStates.js",
+        4
+      ],
+      [
+        "plugins/services/src/js/containers/pod-instances/PodInstancesTable.js",
+        413
+      ],
+      [
+        "src/js/constants/UnitHealthStatus.js",
+        18
+      ],
+      [
+        "src/js/pages/system/UnitsHealthTab.js",
+        192
+      ]
+    ]
+  },
+  "Host": {
+    "translation": "主机",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/VHostsTable.js",
+        40
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        5
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        6
+      ],
+      [
+        "plugins/nodes/src/js/components/NodesTable.tsx",
+        82
+      ],
+      [
+        "plugins/services/src/js/components/DeclinedOffersTable.js",
+        194
+      ],
+      [
+        "plugins/services/src/js/components/MarathonTaskDetailsList.js",
+        58
+      ],
+      [
+        "plugins/services/src/js/components/PodVolumeTable.js",
+        67
+      ],
+      [
+        "plugins/services/src/js/components/VolumeTable.js",
+        66
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js",
+        560
+      ],
+      [
+        "plugins/services/src/js/components/forms/NetworkingFormSection.js",
+        582
+      ],
+      [
+        "plugins/services/src/js/constants/TaskTableHeaderLabels.js",
+        7
+      ],
+      [
+        "plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js",
+        99
+      ],
+      [
+        "plugins/services/src/js/containers/volume-detail/PodVolumeDetail.js",
+        103
+      ],
+      [
+        "plugins/services/src/js/containers/volume-detail/VolumeDetail.js",
+        97
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodNetworkConfigSection.js",
+        19
+      ]
+    ]
+  },
+  "Host Name": {
+    "translation": "主机名",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/VHostDetail.js",
+        242
+      ]
+    ]
+  },
+  "Host Path": {
+    "translation": "主机路径",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js",
+        222
+      ],
+      [
+        "plugins/services/src/js/components/forms/VolumesFormSection.js",
+        136
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodStorageConfigSection.js",
+        61
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceStorageConfigSection.js",
+        153
+      ]
+    ]
+  },
+  "Host Port": {
+    "translation": "主机端口",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js",
+        141
+      ],
+      [
+        "plugins/services/src/js/components/forms/NetworkingFormSection.js",
+        112
+      ],
+      [
+        "plugins/services/src/js/containers/service-connection/ServiceConnectionEndpointList.js",
+        132
+      ],
+      [
+        "plugins/services/src/js/containers/service-connection/ServicePodConnectionEndpointList.js",
+        81
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js",
+        119
+      ]
+    ]
+  },
+  "Host Volume": {
+    "translation": "主机卷",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/VolumeDefinitions.js",
+        27
+      ]
+    ]
+  },
+  "Host/Port": {
+    "translation": "主机/端口",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/PodTableHeaderLabels.js",
+        5
+      ]
+    ]
+  },
+  "How many instances?": {
+    "translation": "有多少例实例？",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceScaleFormModal.js",
+        132
+      ]
+    ]
+  },
+  "ID": {
+    "translation": "ID",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/service-accounts/components/ServiceAccountsFormModal.js",
+        174
+      ],
+      [
+        ".dcos-ui-plugins-private/secrets/components/SecretFormModal.js",
+        210
+      ],
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        20
+      ],
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        72
+      ],
+      [
+        "plugins/nodes/src/js/pages/nodes/NodeDetailTab.js",
+        70
+      ],
+      [
+        "plugins/services/src/js/components/PodVolumeTable.js",
+        66
+      ],
+      [
+        "plugins/services/src/js/components/VolumeTable.js",
+        65
+      ],
+      [
+        "plugins/services/src/js/constants/TaskTableHeaderLabels.js",
+        11
+      ]
+    ]
+  },
+  "IP": {
+    "translation": "IP",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/VHostDetail.js",
+        248
+      ]
+    ]
+  },
+  "IP Addresses": {
+    "translation": "IP 地址",
+    "origin": [
+      [
+        "plugins/services/src/js/pages/task-details/TaskIpAddressesRow.js",
+        41
+      ]
+    ]
+  },
+  "IP Reach": {
+    "translation": "IP 覆盖范围",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPsTable.js",
+        53
+      ]
+    ]
+  },
+  "IP Reachability": {
+    "translation": "IP 可达性",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/BackendsTable.js",
+        80
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/NetworkItemChart.js",
+        118
+      ]
+    ]
+  },
+  "IP Subnet": {
+    "translation": "IP 子网",
+    "origin": [
+      [
+        "src/js/pages/network/VirtualNetworksTable.js",
+        13
+      ],
+      [
+        "src/js/pages/network/virtual-network-detail/VirtualNetworkDetailsTab.js",
+        28
+      ]
+    ]
+  },
+  "IP and Port": {
+    "translation": "IP 和端口",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/LeaderGrid.js",
+        37
+      ]
+    ]
+  },
+  "IPs": {
+    "translation": "IP",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerDetail.js",
+        359
+      ]
+    ]
+  },
+  "IPv6": {
+    "translation": "IPv6",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/HealthChecksFormSection.js",
+        295
+      ]
+    ]
+  },
+  "IdP Metadata": {
+    "translation": "IdP 元数据",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/constants/AuthProvidersFormDefinitions.js",
+        38
+      ],
+      [
+        ".dcos-ui-plugins-private/auth-providers/structs/AuthProvider.js",
+        115
+      ]
+    ]
+  },
+  "Identity Provider Settings": {
+    "translation": "身份提供商设置",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/components/AuthProvidersModalForm.js",
+        191
+      ]
+    ]
+  },
+  "Identity Providers": {
+    "translation": "身份提供商",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/pages/AuthProviderDetailPage.js",
+        41
+      ],
+      [
+        ".dcos-ui-plugins-private/auth-providers/pages/AuthProvidersTab.js",
+        35
+      ],
+      [
+        ".dcos-ui-plugins-private/auth-providers/pages/AuthProvidersTab.js",
+        181
+      ]
+    ]
+  },
+  "If a client certificate is added, a CA certificate chain is required.": {
+    "translation": "如果添加了客户端证书，则需要 CA 证书链。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        41
+      ]
+    ]
+  },
+  "If left undefined this will run in your local region.": {
+    "translation": "如果未定义，则会在本地区域运行。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/RegionSelection.js",
+        101
+      ]
+    ]
+  },
+  "If you are using the Mesos containerizer, this must be a single-level path relative to the container. <0>More information</0>.": {
+    "translation": "如果是使用 Mesos containerizer，那么这必须是相对于容器的单层路径。<0>更多信息</0>.",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/VolumesFormSection.js",
+        119
+      ]
+    ]
+  },
+  "If your service requires additional files and/or archives of files, enter their URIs to download and, if necessary, extract these resources. <0>More information</0>.": {
+    "translation": "如果您的服务需要其他文件和/或文件存档，则输入它们的 URL，以下载和提取这些资源（如有必要）。<0>更多信息</0>.",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/ArtifactsSection.js",
+        21
+      ]
+    ]
+  },
+  "Image": {
+    "translation": "镜像",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        110
+      ]
+    ]
+  },
+  "Import LDAP Group": {
+    "translation": "导入 LDAP 组",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/pages/GroupsPage.js",
+        149
+      ]
+    ]
+  },
+  "Import LDAP Groups": {
+    "translation": "导入 LDAP 组",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/components/modals/LDAPGroupFormModal.js",
+        182
+      ]
+    ]
+  },
+  "Import LDAP User": {
+    "translation": "导入 LDAP 用户",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/users/pages/UsersPage.js",
+        131
+      ]
+    ]
+  },
+  "Import LDAP Users": {
+    "translation": "导入 LDAP 用户",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/users/components/modals/LDAPUserFormModal.js",
+        154
+      ]
+    ]
+  },
+  "In Command Prompt, enter": {
+    "translation": "在命令提示符中，输入",
+    "origin": [
+      [
+        "src/js/components/modals/CliInstallModal.js",
+        118
+      ]
+    ]
+  },
+  "Include the path to your service, if applicable. E.g. /dev/tools/my-service <0>More information</0>.": {
+    "translation": "包括服务路径（如适用）。例如，/dev/tools/my-service <0>更多信息</0>.",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
+        332
+      ]
+    ]
+  },
+  "Insert Permission String": {
+    "translation": "插入权限字符串",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/PermissionBuilderModal.js",
+        577
+      ]
+    ]
+  },
+  "Install CLI": {
+    "translation": "安装 CLI",
+    "origin": [
+      [
+        "src/js/components/ClusterHeader.js",
+        149
+      ]
+    ]
+  },
+  "Install DC/OS CLI": {
+    "translation": "安装 DC/OS CLI",
+    "origin": [
+      [
+        "src/js/components/Modals.js",
+        143
+      ]
+    ]
+  },
+  "Install a Package": {
+    "translation": "安装包",
+    "origin": [
+      [
+        "src/js/components/CreateServiceModalCatalogPanelOption.js",
+        24
+      ]
+    ]
+  },
+  "Install {dcosLBPackageName}": {
+    "translation": "安装 {dcosLBPackageName}",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancersTab.js",
+        178
+      ]
+    ]
+  },
+  "Install {dcosLBPackageName} to enable this capability.": {
+    "translation": "安装 {dcosLBPackageName} ，以启用此功能。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancersTab.js",
+        197
+      ]
+    ]
+  },
+  "Instance": {
+    "translation": "实例",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/pod-instances/PodInstancesView.js",
+        158
+      ]
+    ]
+  },
+  "Instance ID": {
+    "translation": "实例 ID",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/pod-debug/PodDebugContainer.js",
+        99
+      ]
+    ]
+  },
+  "Instances": {
+    "translation": "实例",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
+        395
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        10
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceTableHeaderLabels.js",
+        11
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodGeneralConfigSection.js",
+        123
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js",
+        89
+      ]
+    ]
+  },
+  "Interval": {
+    "translation": "间隔",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/PodHealthChecksConfigSection.js",
+        23
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceHealthChecksConfigSection.js",
+        127
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceHealthChecksConfigSection.js",
+        234
+      ]
+    ]
+  },
+  "Interval (s)": {
+    "translation": "间隔",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/HealthChecksFormSection.js",
+        129
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js",
+        108
+      ]
+    ]
+  },
+  "Invalid JSON syntax": {
+    "translation": "无效 JSON syntax",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobFormModal.tsx",
+        149
+      ]
+    ]
+  },
+  "Invalid base64 encoding detected.": {
+    "translation": "检测到无效的 base64 编码。",
+    "origin": [
+      [
+        "src/js/components/YamlEditorSchemaField.js",
+        22
+      ]
+    ]
+  },
+  "Is": {
+    "translation": "Is",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/OperatorTypes.js",
+        41
+      ]
+    ]
+  },
+  "Issuer": {
+    "translation": "Issuer",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/constants/AuthProvidersFormDefinitions.js",
+        83
+      ],
+      [
+        ".dcos-ui-plugins-private/auth-providers/structs/AuthProvider.js",
+        103
+      ]
+    ]
+  },
+  "JSON Configuration": {
+    "translation": "JSON 配置",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/CreateServiceJsonOnly.js",
+        102
+      ],
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModalServicePicker.js",
+        51
+      ]
+    ]
+  },
+  "JSON Editor": {
+    "translation": "JSON 编辑器",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModal.js",
+        802
+      ],
+      [
+        "src/js/components/FrameworkConfiguration.js",
+        172
+      ]
+    ]
+  },
+  "JSON mode": {
+    "translation": "JSON 模式",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobFormModal.tsx",
+        61
+      ]
+    ]
+  },
+  "Job ID": {
+    "translation": "作业 ID",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobRunHistoryTable.js",
+        102
+      ]
+    ]
+  },
+  "Jobs": {
+    "translation": "作业",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/Breadcrumbs.js",
+        14
+      ],
+      [
+        "plugins/jobs/src/js/components/JobsOverviewList.tsx",
+        38
+      ],
+      [
+        "src/js/pages/JobsPage.js",
+        19
+      ]
+    ]
+  },
+  "Key": {
+    "translation": "键",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/EnvironmentFormSection.js",
+        38
+      ],
+      [
+        "plugins/services/src/js/components/forms/EnvironmentFormSection.js",
+        112
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodEnvironmentVariablesConfigSection.js",
+        18
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodLabelsConfigSection.js",
+        20
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceEnvironmentVariablesConfigSection.js",
+        52
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceLabelsConfigSection.js",
+        46
+      ]
+    ]
+  },
+  "Killed": {
+    "translation": "已杀死",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/PodContainerStatus.js",
+        67
+      ],
+      [
+        "plugins/services/src/js/constants/PodInstanceStatus.js",
+        31
+      ],
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        41
+      ]
+    ]
+  },
+  "Killing": {
+    "translation": "正在杀死",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/PodContainerStatus.js",
+        61
+      ],
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        31
+      ]
+    ]
+  },
+  "LDAP Directory": {
+    "translation": "LDAP 目录",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
+        39
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
+        382
+      ]
+    ]
+  },
+  "LDAP Password": {
+    "translation": "LDAP 密码",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/components/DirectoryActionButtons.js",
+        115
+      ]
+    ]
+  },
+  "LDAP Username": {
+    "translation": "LDAP 用户名",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/components/DirectoryActionButtons.js",
+        103
+      ]
+    ]
+  },
+  "Labels": {
+    "translation": "标签",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        123
+      ],
+      [
+        "plugins/services/src/js/components/forms/EnvironmentFormSection.js",
+        249
+      ],
+      [
+        "plugins/services/src/js/pages/task-details/TaskDetailsTab.js",
+        173
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodLabelsConfigSection.js",
+        81
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceLabelsConfigSection.js",
+        37
+      ]
+    ]
+  },
+  "Language": {
+    "translation": "语言",
+    "origin": [
+      [
+        "src/js/pages/settings/UISettingsPage.js",
+        65
+      ]
+    ]
+  },
+  "Language Preference": {
+    "translation": "语言偏好",
+    "origin": [
+      [
+        "src/js/components/modals/LanguagePreferenceFormModal.js",
+        78
+      ]
+    ]
+  },
+  "Last Changes": {
+    "translation": "上次更改",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/pod-debug/PodDebugContainer.js",
+        137
+      ],
+      [
+        "plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js",
+        346
+      ]
+    ]
+  },
+  "Last Failure:": {
+    "translation": "上次失败：",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobsOverviewTable.js",
+        260
+      ]
+    ]
+  },
+  "Last Run": {
+    "translation": "上次运行",
+    "origin": [
+      [
+        "plugins/jobs/src/js/constants/JobTableHeaderLabels.js",
+        6
+      ]
+    ]
+  },
+  "Last State": {
+    "translation": "上次状态",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/pod-debug/PodContainerTerminationTable.js",
+        42
+      ]
+    ]
+  },
+  "Last Success:": {
+    "translation": "上次成功：",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobsOverviewTable.js",
+        249
+      ]
+    ]
+  },
+  "Last Task Failure": {
+    "translation": "上次任务失败",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js",
+        350
+      ]
+    ]
+  },
+  "Last Termination (<0/>)": {
+    "translation": "上次终止（<0/>)",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/pod-debug/PodDebugContainer.js",
+        80
+      ]
+    ]
+  },
+  "Last Terminations": {
+    "translation": "上次终止",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/pod-debug/PodDebugContainer.js",
+        67
+      ]
+    ]
+  },
+  "Last failure": {
+    "translation": "上次失败",
+    "origin": [
+      [
+        "plugins/services/src/js/components/MarathonTaskDetailsList.js",
+        146
+      ]
+    ]
+  },
+  "Last success": {
+    "translation": "上次成功",
+    "origin": [
+      [
+        "plugins/services/src/js/components/MarathonTaskDetailsList.js",
+        138
+      ]
+    ]
+  },
+  "Latency distribution (in milliseconds) for all connections to this virtual address in the last hour.": {
+    "translation": "上一个小时内，此虚拟地址所有连接的延迟分布（以毫秒为单位）。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/constants/NetworkingTooltipContent.js",
+        8
+      ]
+    ]
+  },
+  "Latency distribution (in milliseconds) for all connections to virtual addresses redirected to this backend in the last hour.": {
+    "translation": "上一个小时内，重定向至此后端的虚拟地址所有连接的延迟分布（以毫秒为单位）。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/constants/NetworkingTooltipContent.js",
+        22
+      ]
+    ]
+  },
+  "Leader": {
+    "translation": "簇头",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/LeaderGrid.js",
+        32
+      ],
+      [
+        "src/js/pages/system/OverviewDetailTab.js",
+        288
+      ]
+    ]
+  },
+  "Learn more": {
+    "translation": "了解更多",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/LearnMoreTooltip.js",
+        12
+      ],
+      [
+        "plugins/services/src/js/components/RecentOffersSummary.js",
+        208
+      ]
+    ]
+  },
+  "License Expiration": {
+    "translation": "许可证过期",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/licensing/components/LicensingExpirationRow.js",
+        69
+      ]
+    ]
+  },
+  "Like": {
+    "translation": "Like",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/OperatorTypes.js",
+        51
+      ]
+    ]
+  },
+  "Link a cluster to switch between clusters.": {
+    "translation": "链接集群，以在集群之间切换。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/cluster-linking/pages/LinkedClustersPage.js",
+        58
+      ]
+    ]
+  },
+  "Linked Clusters": {
+    "translation": "链接集群",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/cluster-linking/components/ClusterLinkingModal.js",
+        12
+      ],
+      [
+        ".dcos-ui-plugins-private/cluster-linking/pages/LinkedClustersPage.js",
+        26
+      ],
+      [
+        ".dcos-ui-plugins-private/cluster-linking/pages/LinkedClustersPage.js",
+        128
+      ]
+    ]
+  },
+  "List": {
+    "translation": "列表",
+    "origin": [
+      [
+        "plugins/nodes/src/js/pages/NodesAgents.js",
+        225
+      ]
+    ]
+  },
+  "Load Balanced Address": {
+    "translation": "负载均衡地址",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-connection/ServiceConnectionEndpointList.js",
+        144
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodNetworkConfigSection.js",
+        65
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js",
+        130
+      ]
+    ]
+  },
+  "Load Balanced Port": {
+    "translation": "负载均衡器端口",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js",
+        324
+      ],
+      [
+        "plugins/services/src/js/components/forms/NetworkingFormSection.js",
+        279
+      ]
+    ]
+  },
+  "Load balance the service internally (layer 4), and create a service address. For external (layer 7) load balancing, create an external load balancer and attach this service. <0>More Information</0>.": {
+    "translation": "内部负载均衡服务（层 4），并创建服务地址。对于外部（层 7）负载均衡，创建外部负载均衡器并连接此服务。<0>更多信息</0>.",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js",
+        209
+      ],
+      [
+        "plugins/services/src/js/components/forms/NetworkingFormSection.js",
+        161
+      ]
+    ]
+  },
+  "Load balance this service internally at {hostName}": {
+    "translation": "在 {hostName} 内部负载均衡此服务",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js",
+        312
+      ],
+      [
+        "plugins/services/src/js/components/forms/NetworkingFormSection.js",
+        267
+      ]
+    ]
+  },
+  "Loading selected version": {
+    "translation": "正在加载所选版本",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackageDetailTab.js",
+        293
+      ]
+    ]
+  },
+  "Local Persistent Volume": {
+    "translation": "本地持久卷",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/VolumeDefinitions.js",
+        12
+      ]
+    ]
+  },
+  "Log In": {
+    "translation": "登录",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth/components/LoginModal.js",
+        114
+      ]
+    ]
+  },
+  "Log out": {
+    "translation": "注销",
+    "origin": [
+      [
+        "src/js/components/AccessDeniedPage.js",
+        32
+      ]
+    ]
+  },
+  "Logging In...": {
+    "translation": "正在登录……",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth/components/LoginModal.js",
+        116
+      ]
+    ]
+  },
+  "Login to your account": {
+    "translation": "登录您的帐户",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth/components/LoginModal.js",
+        162
+      ]
+    ]
+  },
+  "Login with": {
+    "translation": "使用 登录",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/components/LoginModalProviders.js",
+        57
+      ]
+    ]
+  },
+  "Logrotate allows for the automatic rotation compression, removal, and mailing of log files.": {
+    "translation": "Logrotate 允许自动旋转压缩、移除和发送日志文件。",
+    "origin": [
+      [
+        "src/js/constants/UnitSummaries.js",
+        81
+      ]
+    ]
+  },
+  "Logs": {
+    "translation": "日志",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobTaskDetailPage.js",
+        27
+      ],
+      [
+        "plugins/nodes/src/js/pages/nodes/NodesTaskDetailPage.js",
+        40
+      ],
+      [
+        "plugins/services/src/js/pages/task-details/ServiceTaskDetailPage.js",
+        24
+      ],
+      [
+        "src/js/pages/network/virtual-network-detail/VirtualNetworkTaskPage.js",
+        86
+      ]
+    ]
+  },
+  "Looks Like Something is Wrong": {
+    "translation": "好像发生了错误",
+    "origin": [
+      [
+        "src/js/components/modals/ErrorModal.js",
+        24
+      ]
+    ]
+  },
+  "Lookup DN": {
+    "translation": "查找 DN",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        17
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        18
+      ]
+    ]
+  },
+  "Lookup Password": {
+    "translation": "查找密码",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        21
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        22
+      ]
+    ]
+  },
+  "Lost": {
+    "translation": "丢失",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/PodContainerStatus.js",
+        79
+      ],
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        51
+      ]
+    ]
+  },
+  "MEDIAN LIFETIME": {
+    "translation": "MEDIAN LIFETIME（中位寿命）",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-debug/TaskStatsTable.js",
+        26
+      ]
+    ]
+  },
+  "Machine Availability and Reachability": {
+    "translation": "机器可用性和可达性",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPDetailPage.js",
+        140
+      ]
+    ]
+  },
+  "Machine Availability and Reachability for all connections to this virtual address in the last hour.": {
+    "translation": "在过去一小时内，此虚拟地址所有连接的机器可用性和可达性。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/constants/NetworkingTooltipContent.js",
+        14
+      ]
+    ]
+  },
+  "Machine Availability and Reachability per Minute": {
+    "translation": "每分钟的机器可用性和可达性",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPDetailPage.js",
+        143
+      ]
+    ]
+  },
+  "Makes vendored {0} binaries, such as the mesos-master, mesos-slave, available at the command line when SSHing to a host.": {
+    "translation": "当 SSH 到主机时，使 vendored {0} 二进制文件，如 mesos-master、mesos-slave，在命令行中可用。",
+    "origin": [
+      [
+        "src/js/constants/UnitSummaries.js",
+        92
+      ]
+    ]
+  },
+  "Manages {0} in-cluster Zookeeper, used by Mesos as well as {1} Marathon.": {
+    "translation": "管理 Mesos 以及 {1} Marathon 所使用的 {0} 集群内 Zookeeper。",
+    "origin": [
+      [
+        "src/js/constants/UnitSummaries.js",
+        59
+      ]
+    ]
+  },
+  "Marathon Task Configuration": {
+    "translation": "Marathon 任务配置",
+    "origin": [
+      [
+        "plugins/services/src/js/components/MarathonTaskDetailsList.js",
+        54
+      ]
+    ]
+  },
+  "Master Version": {
+    "translation": "管理节点版本",
+    "origin": [
+      [
+        "plugins/nodes/src/js/pages/nodes/NodeDetailTab.js",
+        92
+      ]
+    ]
+  },
+  "Masters": {
+    "translation": "管理节点",
+    "origin": [
+      [
+        "plugins/nodes/src/js/pages/NodesAgents.js",
+        267
+      ],
+      [
+        "plugins/nodes/src/js/pages/NodesMasters.js",
+        10
+      ]
+    ]
+  },
+  "Matched": {
+    "translation": "已匹配",
+    "origin": [
+      [
+        "plugins/services/src/js/components/RecentOffersSummary.js",
+        246
+      ]
+    ]
+  },
+  "Max Failures": {
+    "translation": "最大失败次数",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/HealthChecksFormSection.js",
+        197
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js",
+        176
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodHealthChecksConfigSection.js",
+        37
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceHealthChecksConfigSection.js",
+        142
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceHealthChecksConfigSection.js",
+        249
+      ]
+    ]
+  },
+  "Max Per": {
+    "translation": "Max Per（每 最大）",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/OperatorTypes.js",
+        69
+      ]
+    ]
+  },
+  "May only contain digits (0-9), dashes (-) and lowercase letters (a-z) e.g. web-server": {
+    "translation": "只能包含数字 (0-9)、破折号 (-) 和小写字母 (a-z)，例如，web-server",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorMessages.js",
+        32
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceErrorMessages.js",
+        39
+      ]
+    ]
+  },
+  "May only contain digits (0-9), dashes (-), dots (.),lowercase letters (a-z), and slashes (/) e.g. /group/my-service": {
+    "translation": "只能包含数字 (0-9)、破折号 (-)、圆点 (.)、小写字母 (a-z) 和斜杠 (/)，例如， /group/my-service",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorMessages.js",
+        18
+      ]
+    ]
+  },
+  "Media": {
+    "translation": "媒介",
+    "origin": [
+      [
+        "src/js/components/ImageViewer.js",
+        71
+      ]
+    ]
+  },
+  "Mem": {
+    "translation": "Mem（内存）",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/NodesTable.tsx",
+        96
+      ],
+      [
+        "plugins/nodes/src/js/pages/nodes/NodeDetailTab.js",
+        133
+      ],
+      [
+        "plugins/services/src/js/components/DeclinedOffersTable.js",
+        283
+      ],
+      [
+        "plugins/services/src/js/constants/PodTableHeaderLabels.js",
+        11
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceTableHeaderLabels.js",
+        7
+      ],
+      [
+        "plugins/services/src/js/constants/TaskTableHeaderLabels.js",
+        10
+      ]
+    ]
+  },
+  "Memory": {
+    "translation": "内存",
+    "origin": [
+      [
+        "plugins/services/src/js/components/RecentOffersSummary.js",
+        16
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        18
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodContainerConfigSection.js",
+        102
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodGeneralConfigSection.js",
+        135
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js",
+        106
+      ]
+    ]
+  },
+  "Memory (MiB)": {
+    "translation": "内存 (Mib)",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        38
+      ],
+      [
+        "plugins/services/src/js/components/forms/ContainerServiceFormSection.js",
+        205
+      ]
+    ]
+  },
+  "Memory Allocation": {
+    "translation": "内存分配",
+    "origin": [
+      [
+        "src/js/constants/DashboardHeadings.js",
+        6
+      ]
+    ]
+  },
+  "Mesos DNS provides service discovery within the cluster.": {
+    "translation": "Mesos DNS 在集群内提供 service discovery（服务发现）。",
+    "origin": [
+      [
+        "src/js/constants/UnitSummaries.js",
+        23
+      ]
+    ]
+  },
+  "Mesos Details": {
+    "translation": "Mesos 详细信息",
+    "origin": [
+      [
+        "src/js/pages/system/OverviewDetailTab.js",
+        350
+      ]
+    ]
+  },
+  "Mesos default for allocating temporary disk space to a service. Enough for many stateless or semi-stateless 12-factor and cloud native applications.": {
+    "translation": "为服务分配临时磁盘空间的 Mesos 默认值。对于许多无状态或半无状态的 12-因数和云本地应用来说，这已足够。",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/VolumeDefinitions.js",
+        36
+      ]
+    ]
+  },
+  "Message": {
+    "translation": "消息",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/pod-debug/PodContainerTerminationTable.js",
+        56
+      ],
+      [
+        "plugins/services/src/js/containers/pod-debug/PodDebugContainer.js",
+        103
+      ],
+      [
+        "plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js",
+        93
+      ]
+    ]
+  },
+  "Minutes ago": {
+    "translation": "分钟前",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/NetworkItemChart.js",
+        96
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/NetworkItemChart.js",
+        105
+      ]
+    ]
+  },
+  "Mode": {
+    "translation": "模式",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/VolumesFormSection.js",
+        177
+      ],
+      [
+        "plugins/services/src/js/containers/volume-detail/VolumeDetail.js",
+        77
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceStorageConfigSection.js",
+        161
+      ]
+    ]
+  },
+  "Modified": {
+    "translation": "已修改",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/TaskDirectoryHeaderLabels.js",
+        8
+      ]
+    ]
+  },
+  "More Information": {
+    "translation": "更多信息",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/licensing/components/LicensingBanner.js",
+        110
+      ]
+    ]
+  },
+  "More Settings": {
+    "translation": "更多设置",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
+        97
+      ],
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModalForm.js",
+        424
+      ]
+    ]
+  },
+  "More actions": {
+    "translation": "更多操作",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/cluster-linking/components/LinkedClustersTable.js",
+        101
+      ],
+      [
+        "plugins/services/src/js/components/DeploymentsModal.js",
+        313
+      ],
+      [
+        "plugins/services/src/js/containers/services/ServicesTable.js",
+        350
+      ]
+    ]
+  },
+  "Most services will use TCP. <0>More information</0>.": {
+    "translation": "大多数服务将使用 TCP。<0>更多信息</0>.",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js",
+        374
+      ],
+      [
+        "plugins/services/src/js/components/forms/NetworkingFormSection.js",
+        331
+      ]
+    ]
+  },
+  "Multi-container (Pod)": {
+    "translation": "多容器 (Pod)",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModalServicePicker.js",
+        37
+      ]
+    ]
+  },
+  "Must be a boolean value": {
+    "translation": "必须为布尔值",
+    "origin": [
+      [
+        "src/js/constants/DefaultErrorMessages.js",
+        130
+      ]
+    ]
+  },
+  "Must be a certain shape: ||shape||": {
+    "translation": "必须为特定形状：||shape||",
+    "origin": [
+      [
+        "src/js/constants/DefaultErrorMessages.js",
+        184
+      ]
+    ]
+  },
+  "Must be a date/time string": {
+    "translation": "必须为日期/时间字符串",
+    "origin": [
+      [
+        "src/js/constants/DefaultErrorMessages.js",
+        135
+      ]
+    ]
+  },
+  "Must be a number": {
+    "translation": "必须为数字",
+    "origin": [
+      [
+        "src/js/constants/DefaultErrorMessages.js",
+        150
+      ]
+    ]
+  },
+  "Must be a positive integer between 0 and {numberOfRepositories} representing its priority. 0 is the highest and {numberOfRepositories} denotes the lowest priority.": {
+    "translation": "必须为 0 到 {numberOfRepositories} 之间的正整数（代表其优先级）。0 是最高优先级，而 {numberOfRepositories} 表示最低优先级。",
+    "origin": [
+      [
+        "plugins/catalog/src/js/repositories/components/AddRepositoryFormModal.js",
+        66
+      ]
+    ]
+  },
+  "Must be a string": {
+    "translation": "必须是字符串",
+    "origin": [
+      [
+        "src/js/constants/DefaultErrorMessages.js",
+        160
+      ]
+    ]
+  },
+  "Must be an array": {
+    "translation": "必须是阵列",
+    "origin": [
+      [
+        "src/js/constants/DefaultErrorMessages.js",
+        125
+      ]
+    ]
+  },
+  "Must be an integer number": {
+    "translation": "必须为整数",
+    "origin": [
+      [
+        "src/js/constants/DefaultErrorMessages.js",
+        140
+      ]
+    ]
+  },
+  "Must be an object": {
+    "translation": "必须是对象",
+    "origin": [
+      [
+        "src/js/constants/DefaultErrorMessages.js",
+        155
+      ]
+    ]
+  },
+  "Must be at least ||value|| characters long": {
+    "translation": "必须最少为 ||value|| 字符长度",
+    "origin": [
+      [
+        "src/js/constants/DefaultErrorMessages.js",
+        65
+      ]
+    ]
+  },
+  "Must be at most ||value|| characters long": {
+    "translation": "必须最多为 ||value|| 字符长度",
+    "origin": [
+      [
+        "src/js/constants/DefaultErrorMessages.js",
+        60
+      ]
+    ]
+  },
+  "Must be bigger than or equal to ||value||": {
+    "translation": "必须大于或等于 ||value||",
+    "origin": [
+      [
+        "src/js/constants/DefaultErrorMessages.js",
+        75
+      ]
+    ]
+  },
+  "Must be defined": {
+    "translation": "必须被定义",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/validators/SecretsValidators.js",
+        21
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceErrorMessages.js",
+        8
+      ],
+      [
+        "src/js/constants/DefaultErrorMessages.js",
+        105
+      ]
+    ]
+  },
+  "Must be multiple of ||value||": {
+    "translation": "必须是 ||value|| 的倍数",
+    "origin": [
+      [
+        "src/js/constants/DefaultErrorMessages.js",
+        80
+      ]
+    ]
+  },
+  "Must be null": {
+    "translation": "必须为空",
+    "origin": [
+      [
+        "src/js/constants/DefaultErrorMessages.js",
+        145
+      ]
+    ]
+  },
+  "Must be of type `||type||`": {
+    "translation": "必须为类 `||type||`",
+    "origin": [
+      [
+        "src/js/constants/DefaultErrorMessages.js",
+        85
+      ]
+    ]
+  },
+  "Must be one of ||values||": {
+    "translation": "必须是 ||values|| 的其中一个",
+    "origin": [
+      [
+        "src/js/constants/DefaultErrorMessages.js",
+        40
+      ]
+    ]
+  },
+  "Must be smaller than or equal to ||value||": {
+    "translation": "必须小于或等于 ||value||",
+    "origin": [
+      [
+        "src/js/constants/DefaultErrorMessages.js",
+        70
+      ]
+    ]
+  },
+  "Must contain a property that matches `||pattern||`": {
+    "translation": "必须包含匹配 `||pattern||` 的属性",
+    "origin": [
+      [
+        "src/js/constants/DefaultErrorMessages.js",
+        115
+      ]
+    ]
+  },
+  "Must contain at least ||value|| items in the array": {
+    "translation": "必须至少包含阵列中的 ||value|| 项",
+    "origin": [
+      [
+        "src/js/constants/DefaultErrorMessages.js",
+        50
+      ]
+    ]
+  },
+  "Must contain at least ||value|| properties": {
+    "translation": "必须至少包含 ||value|| 属性",
+    "origin": [
+      [
+        "src/js/constants/DefaultErrorMessages.js",
+        95
+      ]
+    ]
+  },
+  "Must contain at most ||value|| items in the array": {
+    "translation": "必须至多包含阵列中的 ||value|| 项",
+    "origin": [
+      [
+        "src/js/constants/DefaultErrorMessages.js",
+        45
+      ]
+    ]
+  },
+  "Must contain at most ||value|| properties": {
+    "translation": "必须至多包含 ||value|| 属性",
+    "origin": [
+      [
+        "src/js/constants/DefaultErrorMessages.js",
+        90
+      ]
+    ]
+  },
+  "Must contain only unique items": {
+    "translation": "必须只包含唯一项",
+    "origin": [
+      [
+        "src/js/constants/DefaultErrorMessages.js",
+        55
+      ]
+    ]
+  },
+  "Must define property `||name||`": {
+    "translation": "必须定义属性 `||name||`",
+    "origin": [
+      [
+        "src/js/constants/DefaultErrorMessages.js",
+        110
+      ]
+    ]
+  },
+  "Must match the pattern `||pattern||`": {
+    "translation": "必须匹配模式 `||pattern||`",
+    "origin": [
+      [
+        "src/js/constants/DefaultErrorMessages.js",
+        120
+      ]
+    ]
+  },
+  "N/A": {
+    "translation": "N/A（不适用）",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/VHostDetail.js",
+        251
+      ],
+      [
+        "plugins/jobs/src/js/pages/JobRunHistoryTable.js",
+        332
+      ],
+      [
+        "plugins/services/src/js/components/dsl/ServiceHealthDSLSection.js",
+        55
+      ],
+      [
+        "plugins/services/src/js/constants/PodContainerStatus.js",
+        85
+      ],
+      [
+        "plugins/services/src/js/constants/PodInstanceStatus.js",
+        43
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceStatusLabels.js",
+        7
+      ],
+      [
+        "src/js/constants/UnitHealthStatus.js",
+        39
+      ]
+    ]
+  },
+  "Name": {
+    "translation": "名称",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/components/AuthProvidersTable.js",
+        35
+      ],
+      [
+        ".dcos-ui-plugins-private/cluster-linking/components/LinkedClustersTable.js",
+        60
+      ],
+      [
+        ".dcos-ui-plugins-private/dss/components/DSSInput.js",
+        106
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerDetail.js",
+        342
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerFormModal.js",
+        195
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/LoadBalancersTable.js",
+        41
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/BackendsTable.js",
+        75
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPsTable.js",
+        48
+      ],
+      [
+        ".dcos-ui-plugins-private/secrets/components/CertificatesTable.js",
+        53
+      ],
+      [
+        ".dcos-ui-plugins-private/secrets/components/SecretStoresTable.js",
+        79
+      ],
+      [
+        "plugins/jobs/src/js/constants/JobTableHeaderLabels.js",
+        4
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js",
+        194
+      ],
+      [
+        "plugins/services/src/js/components/forms/VolumesFormSection.js",
+        252
+      ],
+      [
+        "plugins/services/src/js/constants/PodTableHeaderLabels.js",
+        4
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceTableHeaderLabels.js",
+        8
+      ],
+      [
+        "plugins/services/src/js/constants/TaskDirectoryHeaderLabels.js",
+        4
+      ],
+      [
+        "plugins/services/src/js/constants/TaskTableHeaderLabels.js",
+        12
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodNetworkConfigSection.js",
+        47
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js",
+        98
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceStorageConfigSection.js",
+        136
+      ],
+      [
+        "src/js/constants/RepositoriesTableHeaderLabels.js",
+        4
+      ],
+      [
+        "src/js/pages/network/VirtualNetworksTable.js",
+        12
+      ],
+      [
+        "src/js/pages/network/virtual-network-detail/VirtualNetworkDetailsTab.js",
+        22
+      ],
+      [
+        "src/js/pages/system/UnitsHealthTab.js",
+        139
+      ]
+    ]
+  },
+  "Name your endpoint to search for it by a meaningful name, rather than the port number.": {
+    "translation": "命名您的端点，从而以有意义的名称（而不是端口号）来搜索该端点。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/NetworkingFormSection.js",
+        471
+      ]
+    ]
+  },
+  "Need to run a service with multiple containers? <0>Add another container</0>.": {
+    "translation": "需要使用多个容器来运行服务？ <0>添加另一个容器</0>.",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
+        142
+      ]
+    ]
+  },
+  "Network": {
+    "translation": "网络",
+    "origin": [
+      [
+        "src/js/pages/network/VirtualNetworksTab.js",
+        149
+      ]
+    ]
+  },
+  "Network Mode": {
+    "translation": "网络模式",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js",
+        56
+      ]
+    ]
+  },
+  "Network Name": {
+    "translation": "网络名称",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/PodNetworkConfigSection.js",
+        145
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js",
+        60
+      ]
+    ]
+  },
+  "Network Type": {
+    "translation": "网络类型",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js",
+        611
+      ],
+      [
+        "plugins/services/src/js/components/forms/NetworkingFormSection.js",
+        739
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodNetworkConfigSection.js",
+        138
+      ]
+    ]
+  },
+  "Networking": {
+    "translation": "网络",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js",
+        603
+      ],
+      [
+        "plugins/services/src/js/components/forms/NetworkingFormSection.js",
+        715
+      ],
+      [
+        "plugins/services/src/js/components/forms/NetworkingFormSection.js",
+        730
+      ],
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModalForm.js",
+        487
+      ],
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModalForm.js",
+        504
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodNetworkConfigSection.js",
+        129
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js",
+        51
+      ],
+      [
+        "src/js/pages/NetworkPage.js",
+        75
+      ]
+    ]
+  },
+  "Networks": {
+    "translation": "网络",
+    "origin": [
+      [
+        "src/js/pages/NetworkPage.js",
+        23
+      ],
+      [
+        "src/js/pages/network/VirtualNetworksTab.js",
+        27
+      ],
+      [
+        "src/js/pages/network/VirtualNetworksTab.js",
+        176
+      ],
+      [
+        "src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.js",
+        23
+      ],
+      [
+        "src/js/pages/network/virtual-network-detail/VirtualNetworkTaskPage.js",
+        25
+      ]
+    ]
+  },
+  "Never": {
+    "translation": "从不",
+    "origin": [
+      [
+        "plugins/services/src/js/components/MarathonTaskDetailsList.js",
+        33
+      ]
+    ]
+  },
+  "New Group": {
+    "translation": "新组",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/pages/GroupsPage.js",
+        138
+      ]
+    ]
+  },
+  "New Job": {
+    "translation": "新作业",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobFormModal.tsx",
+        254
+      ]
+    ]
+  },
+  "New Secret": {
+    "translation": "新密钥",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/SecretsError.js",
+        26
+      ],
+      [
+        ".dcos-ui-plugins-private/secrets/pages/SecretsPage.js",
+        314
+      ]
+    ]
+  },
+  "New Service Account": {
+    "translation": "新服务帐户",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/service-accounts/pages/ServiceAccountsPage.js",
+        128
+      ]
+    ]
+  },
+  "New User": {
+    "translation": "新用户",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/users/pages/UsersPage.js",
+        120
+      ]
+    ]
+  },
+  "No": {
+    "translation": "无",
+    "origin": [
+      [
+        "plugins/services/src/js/components/MarathonTaskDetailsList.js",
+        118
+      ]
+    ]
+  },
+  "No Endpoints": {
+    "translation": "无端点",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-connection/ServiceNoEndpointsPanel.js",
+        12
+      ]
+    ]
+  },
+  "No External Load Balancers": {
+    "translation": "无外部负载均衡器",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancersTab.js",
+        145
+      ]
+    ]
+  },
+  "No Services Running": {
+    "translation": "无服务运行",
+    "origin": [
+      [
+        "plugins/services/src/js/components/ServiceList.js",
+        98
+      ]
+    ]
+  },
+  "No active deployments": {
+    "translation": "无活动部署",
+    "origin": [
+      [
+        "plugins/services/src/js/components/DeploymentsModal.js",
+        384
+      ]
+    ]
+  },
+  "No active jobs": {
+    "translation": "无活动作业",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobsOverviewEmpty.tsx",
+        27
+      ]
+    ]
+  },
+  "No containers specified! Please specify at least one container when creating a multi-container definition!": {
+    "translation": "未指定容器！创建多容器定义时，请至少指定一个容器！",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/PodContainersConfigSection.js",
+        30
+      ]
+    ]
+  },
+  "No directory configured": {
+    "translation": "未配置目录",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
+        343
+      ]
+    ]
+  },
+  "No groups to add": {
+    "translation": "没有要添加的组",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/AccountGroupMembershipTab.js",
+        143
+      ]
+    ]
+  },
+  "No health checks available": {
+    "translation": "无可用的运行状况检查",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/pod-instances/PodInstancesTable.js",
+        420
+      ],
+      [
+        "plugins/services/src/js/containers/tasks/TaskTable.js",
+        388
+      ]
+    ]
+  },
+  "No linked clusters": {
+    "translation": "无链接集群",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/cluster-linking/pages/LinkedClustersPage.js",
+        56
+      ]
+    ]
+  },
+  "No networks detected": {
+    "translation": "未检测到网络",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.js",
+        87
+      ]
+    ]
+  },
+  "No nodes detected": {
+    "translation": "未检测到节点",
+    "origin": [
+      [
+        "plugins/nodes/src/js/pages/NodesAgents.js",
+        302
+      ]
+    ]
+  },
+  "No package repositories": {
+    "translation": "无包存储库",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackagesTab.js",
+        49
+      ]
+    ]
+  },
+  "No results were found for your search: \"{0}\" (<0>view all</0>)": {
+    "translation": "未找到搜索结果：\"{0}\" (<0>查看全部</0>)",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackagesTab.js",
+        235
+      ]
+    ]
+  },
+  "No running services": {
+    "translation": "无运行服务",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/services/EmptyServiceTree.js",
+        33
+      ]
+    ]
+  },
+  "No services found": {
+    "translation": "未找到服务",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerDetail.js",
+        235
+      ]
+    ]
+  },
+  "No users to add": {
+    "translation": "没有要添加的用户",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/components/GroupAccountMembershipTab.js",
+        177
+      ]
+    ]
+  },
+  "No virtual networks detected": {
+    "translation": "未检测到虚拟网络",
+    "origin": [
+      [
+        "src/js/pages/network/VirtualNetworksTab.js",
+        90
+      ]
+    ]
+  },
+  "Node": {
+    "translation": "节点",
+    "origin": [
+      [
+        "plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.js",
+        202
+      ],
+      [
+        "plugins/services/src/js/pages/task-details/TaskDetailsTab.js",
+        96
+      ],
+      [
+        "src/js/components/UnitHealthNodesTable.js",
+        37
+      ]
+    ]
+  },
+  "Node Capacity": {
+    "translation": "节点容量",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/licensing/components/LicensingNodeCapacityRow.js",
+        103
+      ]
+    ]
+  },
+  "Nodes": {
+    "translation": "节点",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/NodeBreadcrumbs.js",
+        17
+      ],
+      [
+        "plugins/nodes/src/js/pages/NodesAgents.js",
+        69
+      ],
+      [
+        "plugins/nodes/src/js/pages/NodesPage.js",
+        13
+      ],
+      [
+        "src/js/constants/DashboardHeadings.js",
+        11
+      ]
+    ]
+  },
+  "Non-Leaders": {
+    "translation": "非簇头",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/NonLeadersGrid.js",
+        70
+      ]
+    ]
+  },
+  "None": {
+    "translation": "非",
+    "origin": [
+      [
+        "plugins/services/src/js/components/MarathonTaskDetailsList.js",
+        18
+      ],
+      [
+        "plugins/services/src/js/components/MarathonTaskDetailsList.js",
+        114
+      ]
+    ]
+  },
+  "Not Applicable": {
+    "translation": "不适用",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/PodPlacementConfigSection.js",
+        51
+      ],
+      [
+        ".dcos-ui-plugins-private/placement/components/ServicePlacementConfigSection.js",
+        28
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodPlacementConstraintsConfigSection.js",
+        46
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServicePlacementConstraintsConfigSection.js",
+        41
+      ]
+    ]
+  },
+  "Not Available": {
+    "translation": "不可用",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/VolumeProfile.js",
+        4
+      ]
+    ]
+  },
+  "Not Enabled": {
+    "translation": "未启用",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-connection/ServiceConnectionEndpointList.js",
+        87
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodNetworkConfigSection.js",
+        68
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js",
+        144
+      ]
+    ]
+  },
+  "Not Found.": {
+    "translation": "未找到。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/ServiceItemNotFound.js",
+        30
+      ]
+    ]
+  },
+  "Number of Agents": {
+    "translation": "代理数量",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerDetail.js",
+        348
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerFormModal.js",
+        180
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerFormModal.js",
+        219
+      ]
+    ]
+  },
+  "Number of Zones": {
+    "translation": "区数量",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/ZoneConstraintsSection.js",
+        37
+      ],
+      [
+        ".dcos-ui-plugins-private/placement/components/ZoneSelection.js",
+        24
+      ]
+    ]
+  },
+  "Number of zones to evenly distribute instances across.": {
+    "translation": "将实例均匀分配的区数量。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/ZoneSelection.js",
+        36
+      ]
+    ]
+  },
+  "OK": {
+    "translation": "OK",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/DisabledGroupDestroyModal.js",
+        11
+      ]
+    ]
+  },
+  "Offers will appear here when your service is deploying or waiting for resources.": {
+    "translation": "当您的服务正在部署或等待资源时，此处将显示 offer。",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/pod-debug/PodDebugContainer.js",
+        152
+      ],
+      [
+        "plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js",
+        220
+      ]
+    ]
+  },
+  "Open Service": {
+    "translation": "开源服务",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceActionLabels.js",
+        8
+      ],
+      [
+        "src/js/pages/catalog/PackageDetailTab.js",
+        423
+      ]
+    ]
+  },
+  "OpenID Connect": {
+    "translation": "OpenID Connect",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/constants/ProviderTypes.js",
+        7
+      ],
+      [
+        ".dcos-ui-plugins-private/auth-providers/constants/ProviderTypes.js",
+        9
+      ]
+    ]
+  },
+  "Operator": {
+    "translation": "运算符",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/AdvancedConstraintsSection.js",
+        13
+      ],
+      [
+        ".dcos-ui-plugins-private/placement/components/PlacementConstraintsFields.js",
+        87
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodPlacementConstraintsConfigSection.js",
+        18
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServicePlacementConstraintsConfigSection.js",
+        17
+      ],
+      [
+        "src/js/components/PlacementConstraintsPartial.js",
+        87
+      ]
+    ]
+  },
+  "Optional": {
+    "translation": "可选",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/components/DirectoryFormModal.js",
+        178
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/components/DirectoryFormModal.js",
+        441
+      ]
+    ]
+  },
+  "Organization": {
+    "translation": "组织",
+    "origin": [
+      [
+        "src/js/pages/OrganizationPage.js",
+        13
+      ]
+    ]
+  },
+  "Other": {
+    "translation": "其他",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/NodesGridView.js",
+        94
+      ],
+      [
+        "plugins/services/src/js/components/dsl/ServiceOtherDSLSection.js",
+        35
+      ]
+    ]
+  },
+  "Output": {
+    "translation": "输出",
+    "origin": [
+      [
+        "src/js/pages/system/units-health-node-detail/NodeInfoPanel.js",
+        36
+      ]
+    ]
+  },
+  "Overview": {
+    "translation": "概述",
+    "origin": [
+      [
+        "src/js/components/ClusterHeader.js",
+        120
+      ],
+      [
+        "src/js/pages/system/OverviewDetailTab.js",
+        43
+      ],
+      [
+        "src/js/pages/system/OverviewDetailTab.js",
+        365
+      ]
+    ]
+  },
+  "Owner": {
+    "translation": "所有者",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/TaskDirectoryHeaderLabels.js",
+        6
+      ]
+    ]
+  },
+  "P99 LATENCY": {
+    "translation": "P99 延迟",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/BackendsTable.js",
+        45
+      ]
+    ]
+  },
+  "P99 Latency": {
+    "translation": "P99 延迟",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/LoadBalancersTable.js",
+        47
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/BackendsTable.js",
+        78
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/ClientsTable.js",
+        55
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPsTable.js",
+        54
+      ]
+    ]
+  },
+  "P99 Latency": {
+    "translation": "P99 延迟",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/VHostsTable.js",
+        45
+      ]
+    ]
+  },
+  "PRT": {
+    "translation": "PRT",
+    "origin": [
+      [
+        "plugins/services/src/js/components/DeclinedOffersTable.js",
+        328
+      ]
+    ]
+  },
+  "Package Repositories": {
+    "translation": "包存储库",
+    "origin": [
+      [
+        "plugins/catalog/src/js/repositories/RepositoriesList.js",
+        89
+      ],
+      [
+        "plugins/catalog/src/js/repositories/components/RepositoriesPage.js",
+        13
+      ]
+    ]
+  },
+  "Package not installed": {
+    "translation": "未安装包",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancersTab.js",
+        195
+      ]
+    ]
+  },
+  "Page not found": {
+    "translation": "未找到页面",
+    "origin": [
+      [
+        "src/js/pages/NotFoundPage.js",
+        28
+      ]
+    ]
+  },
+  "Password": {
+    "translation": "密码",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth/components/LoginModal.js",
+        100
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/users/components/modals/UserEditFormModal.js",
+        111
+      ]
+    ]
+  },
+  "Path": {
+    "translation": "路径",
+    "origin": [
+      [
+        "plugins/services/src/js/components/VolumeTable.js",
+        69
+      ],
+      [
+        "plugins/services/src/js/components/forms/HealthChecksFormSection.js",
+        359
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js",
+        310
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodHealthChecksConfigSection.js",
+        84
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceHealthChecksConfigSection.js",
+        107
+      ]
+    ]
+  },
+  "Periodically writes /etc/resolv.conf so that only currently active Mesos masters with working Mesos DNS are in it.": {
+    "translation": "定期写入 /etc/resolv.conf，以便只有当前活动的 Mesos 管理节点以及正在工作的 Mesos DNS 在其中。",
+    "origin": [
+      [
+        "src/js/constants/UnitSummaries.js",
+        205
+      ]
+    ]
+  },
+  "Permission denied": {
+    "translation": "权限被拒绝",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/pages/SecretDetail.js",
+        63
+      ]
+    ]
+  },
+  "Permission inherited from the <0>{0}</0> group.": {
+    "translation": "权限继承自 <0>{0}</0> 组。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/AdvancedACLsTab.js",
+        212
+      ]
+    ]
+  },
+  "Permissions": {
+    "translation": "权限",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/AccountDetailPage.js",
+        47
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/components/AccountDetailPage.js",
+        272
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/components/GroupDetailPage.js",
+        52
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/components/GroupDetailPage.js",
+        268
+      ],
+      [
+        "plugins/services/src/js/constants/TaskDirectoryHeaderLabels.js",
+        5
+      ]
+    ]
+  },
+  "Permissions Strings": {
+    "translation": "权限字符串",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/PermissionBuilderModal.js",
+        456
+      ]
+    ]
+  },
+  "Placement": {
+    "translation": "布局",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/PlacementSchemaField.js",
+        146
+      ],
+      [
+        ".dcos-ui-plugins-private/placement/components/PlacementSection.js",
+        20
+      ],
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModalForm.js",
+        483
+      ],
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModalForm.js",
+        503
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodPlacementConstraintsConfigSection.js",
+        64
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServicePlacementConstraintsConfigSection.js",
+        60
+      ]
+    ]
+  },
+  "Placement Constraints": {
+    "translation": "布局约束",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/PlacementSection.js",
+        36
+      ],
+      [
+        "src/js/components/PlacementConstraintsSchemaField.js",
+        132
+      ]
+    ]
+  },
+  "Placement constraints control where apps run to allow optimization for either fault tolerance or locality.": {
+    "translation": "当应用程序运行以允许容错或局部性的优化时，布局约束则进行控制。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/PlacementSection.js",
+        38
+      ]
+    ]
+  },
+  "Please <0>add a container</0> before configuring Volumes.": {
+    "translation": "在配置运行状况检查 <0>之前，请</0> 添加容器。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js",
+        304
+      ]
+    ]
+  },
+  "Please <0>add a container</0> before configuring health checks.": {
+    "translation": "在配置运行状况检查 <0>之前，请</0> 添加容器。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js",
+        508
+      ]
+    ]
+  },
+  "Please contact your system administrator or see the <0>documentation</0>.": {
+    "translation": "请联系您的系统管理员或查看 <0>文档</0>.",
+    "origin": [
+      [
+        "plugins/oauth/components/LoginPage.js",
+        118
+      ]
+    ]
+  },
+  "Please fix all the errors first": {
+    "translation": "请先修复所有错误",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobFormModal.tsx",
+        205
+      ]
+    ]
+  },
+  "Please make sure you have the required information from your provider. All fields are required.": {
+    "translation": "请确保已从您的提供商获取了所需信息。所有字段均为必填字段。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/components/AuthProvidersModalForm.js",
+        180
+      ]
+    ]
+  },
+  "Please select at least one option.": {
+    "translation": "请至少选择一个选项。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/PermissionBuilderModal.js",
+        279
+      ]
+    ]
+  },
+  "Please try again later.": {
+    "translation": "请稍后重试。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/EmptyLogScreen.js",
+        14
+      ]
+    ]
+  },
+  "Please try again.": {
+    "translation": "请重试。",
+    "origin": [
+      [
+        "src/js/components/CosmosErrorMessage.js",
+        124
+      ]
+    ]
+  },
+  "Pod": {
+    "translation": "Pod",
+    "origin": [
+      [
+        "plugins/services/src/js/components/dsl/ServiceOtherDSLSection.js",
+        55
+      ],
+      [
+        "plugins/services/src/js/components/modals/ServiceActionDisabledModal.js",
+        344
+      ],
+      [
+        "plugins/services/src/js/components/modals/ServiceRestartModal.js",
+        90
+      ],
+      [
+        "plugins/services/src/js/components/modals/ServiceStopModal.js",
+        90
+      ]
+    ]
+  },
+  "Pods": {
+    "translation": "Pod",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceOtherLabels.js",
+        6
+      ]
+    ]
+  },
+  "Port": {
+    "translation": "端口",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerFormModal.js",
+        207
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        9
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        10
+      ],
+      [
+        "plugins/services/src/js/components/DeclinedOffersTable.js",
+        328
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodNetworkConfigSection.js",
+        59
+      ]
+    ]
+  },
+  "Port Mapping": {
+    "translation": "端口映射",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/NetworkingFormSection.js",
+        443
+      ]
+    ]
+  },
+  "Port Mappings": {
+    "translation": "端口映射",
+    "origin": [
+      [
+        "src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js",
+        28
+      ]
+    ]
+  },
+  "Ports": {
+    "translation": "端口",
+    "origin": [
+      [
+        "plugins/services/src/js/components/MarathonTaskDetailsList.js",
+        64
+      ],
+      [
+        "plugins/services/src/js/components/RecentOffersSummary.js",
+        18
+      ]
+    ]
+  },
+  "Preinstall Notes:": {
+    "translation": "预安装备注：",
+    "origin": [
+      [
+        "src/js/components/FrameworkConfiguration.js",
+        209
+      ]
+    ]
+  },
+  "Priority": {
+    "translation": "优先级",
+    "origin": [
+      [
+        "plugins/catalog/src/js/repositories/components/AddRepositoryFormModal.js",
+        60
+      ],
+      [
+        "src/js/constants/RepositoriesTableHeaderLabels.js",
+        5
+      ]
+    ]
+  },
+  "Private": {
+    "translation": "专用",
+    "origin": [
+      [
+        "plugins/nodes/src/js/columns/NodesTableTypeColumn.tsx",
+        6
+      ]
+    ]
+  },
+  "Processes login requests from users, as well as checking if an authorization token is valid.": {
+    "translation": "处理来自用户的登录请求，以及检查认证令牌是否有效。",
+    "origin": [
+      [
+        "src/js/constants/UnitSummaries.js",
+        133
+      ]
+    ]
+  },
+  "Profile Name": {
+    "translation": "配置文件名称",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/dss/components/DSSInput.js",
+        123
+      ],
+      [
+        ".dcos-ui-plugins-private/dss/components/DSSVolumeConfig.js",
+        60
+      ],
+      [
+        "plugins/services/src/js/containers/volume-detail/PodVolumeDetail.js",
+        91
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceStorageConfigSection.js",
+        81
+      ]
+    ]
+  },
+  "Proto": {
+    "translation": "Proto（协议）",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/PodHealthChecksConfigSection.js",
+        78
+      ]
+    ]
+  },
+  "Protocol": {
+    "translation": "协议",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/HealthChecksFormSection.js",
+        457
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js",
+        415
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js",
+        392
+      ],
+      [
+        "plugins/services/src/js/components/forms/NetworkingFormSection.js",
+        349
+      ],
+      [
+        "plugins/services/src/js/containers/service-connection/ServiceConnectionEndpointList.js",
+        120
+      ],
+      [
+        "plugins/services/src/js/containers/service-connection/ServicePodConnectionEndpointList.js",
+        75
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodNetworkConfigSection.js",
+        53
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceHealthChecksConfigSection.js",
+        94
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js",
+        107
+      ]
+    ]
+  },
+  "Provider ID": {
+    "translation": "提供商 ID",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/constants/AuthProvidersFormDefinitions.js",
+        15
+      ],
+      [
+        ".dcos-ui-plugins-private/auth-providers/constants/AuthProvidersFormDefinitions.js",
+        62
+      ],
+      [
+        ".dcos-ui-plugins-private/auth-providers/structs/AuthProvider.js",
+        101
+      ],
+      [
+        ".dcos-ui-plugins-private/auth-providers/structs/AuthProvider.js",
+        112
+      ]
+    ]
+  },
+  "Public": {
+    "translation": "公用",
+    "origin": [
+      [
+        "plugins/nodes/src/js/columns/NodesTableTypeColumn.tsx",
+        6
+      ]
+    ]
+  },
+  "Public IP": {
+    "translation": "公用 IP",
+    "origin": [
+      [
+        "src/js/pages/system/OverviewDetailTab.js",
+        177
+      ]
+    ]
+  },
+  "Public Key": {
+    "translation": "公钥",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/service-accounts/components/ServiceAccountsFormModal.js",
+        184
+      ]
+    ]
+  },
+  "RLE": {
+    "translation": "RLE（游程编码）",
+    "origin": [
+      [
+        "plugins/services/src/js/components/DeclinedOffersTable.js",
+        210
+      ]
+    ]
+  },
+  "RUNNING": {
+    "translation": "正在运行",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-debug/TaskStatsTable.js",
+        22
+      ]
+    ]
+  },
+  "Read Only": {
+    "translation": "只读",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/VolumesFormSection.js",
+        184
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodStorageConfigSection.js",
+        42
+      ]
+    ]
+  },
+  "Read and Write": {
+    "translation": "读取和写入",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/VolumesFormSection.js",
+        183
+      ]
+    ]
+  },
+  "Received": {
+    "translation": "已接收",
+    "origin": [
+      [
+        "plugins/services/src/js/components/DeclinedOffersTable.js",
+        157
+      ],
+      [
+        "plugins/services/src/js/components/DeclinedOffersTable.js",
+        343
+      ]
+    ]
+  },
+  "Recent Resource Offers{offerCount}": {
+    "translation": "最近的 Resource Offer{offerCount}",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/pod-debug/PodDebugContainer.js",
+        186
+      ],
+      [
+        "plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js",
+        238
+      ]
+    ]
+  },
+  "Recommended": {
+    "translation": "已推荐",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/dss/components/VolumeMountTypesSelect.js",
+        18
+      ],
+      [
+        ".dcos-ui-plugins-private/dss/components/VolumeTypeSelect.js",
+        17
+      ],
+      [
+        "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
+        278
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js",
+        171
+      ],
+      [
+        "plugins/services/src/js/components/forms/VolumesFormSection.js",
+        382
+      ]
+    ]
+  },
+  "Recovering": {
+    "translation": "正在恢复",
+    "origin": [
+      [
+        "plugins/services/src/js/components/dsl/ServiceStatusDSLSection.js",
+        66
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceStatusLabels.js",
+        11
+      ]
+    ]
+  },
+  "Region": {
+    "translation": "区域",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/RegionConstraintsSection.js",
+        37
+      ],
+      [
+        ".dcos-ui-plugins-private/placement/components/RegionSelection.js",
+        88
+      ],
+      [
+        "plugins/nodes/src/js/components/LeaderGrid.js",
+        43
+      ],
+      [
+        "plugins/nodes/src/js/components/NodesTable.tsx",
+        88
+      ],
+      [
+        "plugins/nodes/src/js/pages/nodes/NodeDetailTab.js",
+        100
+      ],
+      [
+        "plugins/services/src/js/constants/PodTableHeaderLabels.js",
+        7
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceTableHeaderLabels.js",
+        12
+      ],
+      [
+        "plugins/services/src/js/constants/TaskTableHeaderLabels.js",
+        9
+      ],
+      [
+        "plugins/services/src/js/pages/task-details/TaskDetailsTab.js",
+        142
+      ]
+    ]
+  },
+  "Regions": {
+    "translation": "区域",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/dsl/NodesRegionDSLFilter.js",
+        47
+      ],
+      [
+        "plugins/services/src/js/components/dsl/TaskRegionDSLSection.js",
+        47
+      ]
+    ]
+  },
+  "Registered": {
+    "translation": "已注册",
+    "origin": [
+      [
+        "plugins/nodes/src/js/pages/nodes/NodeDetailTab.js",
+        84
+      ]
+    ]
+  },
+  "Rejected offer analysis is not currently supported for {frameworkName}.": {
+    "translation": "目前不支持已拒绝 offer 分析 {frameworkName}。",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js",
+        193
+      ]
+    ]
+  },
+  "Rejected offer analysis is not currently supported.": {
+    "translation": "目前不支持已拒绝 offer 分析 。",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js",
+        200
+      ]
+    ]
+  },
+  "Remove": {
+    "translation": "移除",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/AccountGroupTable.js",
+        158
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/components/GroupMemberTable.js",
+        186
+      ]
+    ]
+  },
+  "Remove From Group": {
+    "translation": "从组中移除",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/constants/BulkOptions.js",
+        39
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/constants/BulkOptions.js",
+        61
+      ]
+    ]
+  },
+  "Remove User From Group": {
+    "translation": "从组中移除用户",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/constants/BulkOptions.js",
+        16
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/constants/BulkOptions.js",
+        62
+      ]
+    ]
+  },
+  "Remove from Group": {
+    "translation": "从组中移除",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/constants/BulkOptions.js",
+        15
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/constants/BulkOptions.js",
+        38
+      ]
+    ]
+  },
+  "Repository ({label}) will be deleted from {0}. You will not be able to install any packages belonging to that repository anymore.": {
+    "translation": "存储库 ({label}) 将从 {0} 删除。您将无法再安装属于该存储库的任何包。",
+    "origin": [
+      [
+        "plugins/catalog/src/js/repositories/components/RepositoriesDeleteConfirm.js",
+        16
+      ]
+    ]
+  },
+  "Repository Name": {
+    "translation": "存储库名称",
+    "origin": [
+      [
+        "plugins/catalog/src/js/repositories/components/AddRepositoryFormModal.js",
+        34
+      ]
+    ]
+  },
+  "Request successes and failures for all connections to this virtual address in the last hour.": {
+    "translation": "请求在过去一小时内与此虚拟地址所有连接的成功次数和失败次数。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/constants/NetworkingTooltipContent.js",
+        5
+      ]
+    ]
+  },
+  "Request successes and failures for all connections to virtual addresses redirected to this backend in the last hour.": {
+    "translation": "请求在过去一小时内重定向到此后端的虚拟地址所有连接的成功次数和失败次数。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/constants/NetworkingTooltipContent.js",
+        19
+      ]
+    ]
+  },
+  "Requested": {
+    "translation": "已请求",
+    "origin": [
+      [
+        "plugins/services/src/js/components/DeclinedOffersTable.js",
+        152
+      ]
+    ]
+  },
+  "Requests": {
+    "translation": "请求",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/NetworkItemChart.js",
+        114
+      ]
+    ]
+  },
+  "Resource": {
+    "translation": "资源",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/AdvancedACLsTab.js",
+        263
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/components/PermissionBuilderModal.js",
+        486
+      ]
+    ]
+  },
+  "Resource Roles": {
+    "translation": "资源角色",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js",
+        204
+      ]
+    ]
+  },
+  "Resources": {
+    "translation": "资源",
+    "origin": [
+      [
+        "plugins/nodes/src/js/pages/nodes/NodeDetailTab.js",
+        121
+      ]
+    ]
+  },
+  "Restart": {
+    "translation": "重启",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/KillPodInstanceModal.js",
+        15
+      ],
+      [
+        "plugins/services/src/js/components/modals/KillTaskModal.js",
+        14
+      ],
+      [
+        "plugins/services/src/js/components/modals/ServiceRestartModal.js",
+        131
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceActionLabels.js",
+        6
+      ],
+      [
+        "plugins/services/src/js/containers/pod-instances/PodInstancesView.js",
+        51
+      ],
+      [
+        "plugins/services/src/js/containers/service-detail/ServiceDetail.js",
+        195
+      ],
+      [
+        "plugins/services/src/js/containers/tasks/TasksView.js",
+        184
+      ]
+    ]
+  },
+  "Restart the Admin Router Nginx server so that it picks up new DNS resolutions, for example master.mesos, leader.mesos.": {
+    "translation": "重启 Admin Router Nginx 服务器，以便其选取新的 DNS 分辨率，例如，master.mesos、leader.mesos。",
+    "origin": [
+      [
+        "src/js/constants/UnitSummaries.js",
+        144
+      ]
+    ]
+  },
+  "Restart your service from the DC/OS CLI. <0>More information</0>": {
+    "translation": "从 DC/OS CLI 重启服务。<0>更多信息</0>",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceActionDisabledModal.js",
+        71
+      ]
+    ]
+  },
+  "Restart {0}": {
+    "translation": "重启 {0}",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceRestartModal.js",
+        106
+      ]
+    ]
+  },
+  "Restarting tasks is not supported while the service is deploying.": {
+    "translation": "服务部署期间不支持重启任务。",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/tasks/TasksView.js",
+        173
+      ]
+    ]
+  },
+  "Restarting the <0>{serviceName}</0> {0} will remove all currently running instances of the {1} and then attempt to create new instances identical to those removed.": {
+    "translation": "重启 <0>{serviceName}</0> {0} 将移除 {1} 的所有当前运行实例，然后尝试创建与移除的实例相同的新实例。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceRestartModal.js",
+        138
+      ]
+    ]
+  },
+  "Resume": {
+    "translation": "恢复",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceActionLabels.js",
+        7
+      ],
+      [
+        "plugins/services/src/js/containers/pod-detail/PodDetail.js",
+        176
+      ],
+      [
+        "plugins/services/src/js/containers/service-detail/ServiceDetail.js",
+        215
+      ]
+    ]
+  },
+  "Resume Service": {
+    "translation": "恢复服务",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceResumeModal.js",
+        153
+      ],
+      [
+        "plugins/services/src/js/components/modals/ServiceResumeModal.js",
+        165
+      ]
+    ]
+  },
+  "Resume your service by scaling to 1 or more instances from the DC/OS CLI using an `options.json` file. <0>More information</0>": {
+    "translation": "通过使用 `options.json` 文件，从 DC/OS CLI 缩放到 1 个或多个实例，从而恢复服务。<0>更多信息</0>",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceActionDisabledModal.js",
+        114
+      ]
+    ]
+  },
+  "Review & Run": {
+    "translation": "审查和运行",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModal.js",
+        809
+      ],
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModal.js",
+        819
+      ],
+      [
+        "src/js/components/FrameworkConfiguration.js",
+        157
+      ],
+      [
+        "src/js/pages/catalog/PackageDetailTab.js",
+        329
+      ]
+    ]
+  },
+  "Review & Run Service": {
+    "translation": "审查和运行服务",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModal.js",
+        569
+      ]
+    ]
+  },
+  "Review Configuration": {
+    "translation": "审核配置",
+    "origin": [
+      [
+        "src/js/components/FrameworkConfiguration.js",
+        270
+      ]
+    ]
+  },
+  "Role": {
+    "translation": "角色",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/HealthTab.js",
+        62
+      ],
+      [
+        "plugins/services/src/js/components/DeclinedOffersTable.js",
+        210
+      ],
+      [
+        "plugins/services/src/js/components/RecentOffersSummary.js",
+        12
+      ],
+      [
+        "src/js/components/UnitHealthNodesTable.js",
+        38
+      ]
+    ]
+  },
+  "Rollback": {
+    "translation": "回滚",
+    "origin": [
+      [
+        "plugins/services/src/js/components/DeploymentsModal.js",
+        282
+      ]
+    ]
+  },
+  "Rollback & Delete": {
+    "translation": "回滚和删除",
+    "origin": [
+      [
+        "plugins/services/src/js/components/DeploymentsModal.js",
+        284
+      ]
+    ]
+  },
+  "Rotates the Mesos master and agent log files to prevent filling the disk.": {
+    "translation": "旋转 Mesos 管理节点和代理日志文件，以防止填充磁盘。",
+    "origin": [
+      [
+        "src/js/constants/UnitSummaries.js",
+        114
+      ]
+    ]
+  },
+  "Run": {
+    "translation": "运行",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobRunHistoryTable.js",
+        374
+      ]
+    ]
+  },
+  "Run History": {
+    "translation": "运行历史",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobDetailPage.js",
+        33
+      ],
+      [
+        "plugins/jobs/src/js/pages/JobDetailPage.js",
+        91
+      ]
+    ]
+  },
+  "Run Now": {
+    "translation": "立即运行",
+    "origin": [
+      [
+        "plugins/jobs/src/js/jobsRunNow.js",
+        19
+      ]
+    ]
+  },
+  "Run Service": {
+    "translation": "运行服务",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModal.js",
+        770
+      ],
+      [
+        "src/js/components/FrameworkConfiguration.js",
+        156
+      ]
+    ]
+  },
+  "Run Time": {
+    "translation": "运行时间",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobRunHistoryTable.js",
+        106
+      ]
+    ]
+  },
+  "Run a Service": {
+    "translation": "运行服务",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModal.js",
+        579
+      ],
+      [
+        "plugins/services/src/js/containers/services/EmptyServiceTree.js",
+        21
+      ],
+      [
+        "plugins/services/src/js/containers/services/ServiceTreeView.js",
+        112
+      ]
+    ]
+  },
+  "Run a new service or create a new group to help organize your services.": {
+    "translation": "运行新服务或创建新组来帮助组织服务。",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/services/EmptyServiceTree.js",
+        34
+      ]
+    ]
+  },
+  "Run app tasks evenly distributed across a certain attribute": {
+    "translation": "运行在特定属性上均匀分布的应用程序任务",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/OperatorTypes.js",
+        32
+      ]
+    ]
+  },
+  "Run app tasks on a particular set of attribute IDs": {
+    "translation": "在特定 ID 集合上运行应用程序任务",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/OperatorTypes.js",
+        52
+      ]
+    ]
+  },
+  "Run app tasks on nodes having attribute ID with a specific value": {
+    "translation": "在节点（具有属性 ID 以及特定值）上运行应用程序任务",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/OperatorTypes.js",
+        42
+      ]
+    ]
+  },
+  "Run app tasks on nodes that share a certain attribute ID": {
+    "translation": "在节点（共享一个特定属性 ID）上运行应用程序任务",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/OperatorTypes.js",
+        22
+      ]
+    ]
+  },
+  "Run as User": {
+    "translation": "作为用户进行运行",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/PodContainerConfigSection.js",
+        125
+      ]
+    ]
+  },
+  "Run each app task on a unique attribute ID": {
+    "translation": "在唯一属性 ID 上运行每个应用程序任务",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/OperatorTypes.js",
+        14
+      ]
+    ]
+  },
+  "Run max number of app tasks on each attribute ID": {
+    "translation": "在每个属性 ID 上运行最大数量的应用程序任务",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/OperatorTypes.js",
+        70
+      ]
+    ]
+  },
+  "Running": {
+    "translation": "正在运行",
+    "origin": [
+      [
+        "plugins/jobs/src/js/constants/JobStates.ts",
+        19
+      ],
+      [
+        "plugins/services/src/js/components/dsl/ServiceStatusDSLSection.js",
+        48
+      ],
+      [
+        "plugins/services/src/js/constants/PodContainerStatus.js",
+        31
+      ],
+      [
+        "plugins/services/src/js/constants/PodContainerStatus.js",
+        43
+      ],
+      [
+        "plugins/services/src/js/constants/PodInstanceStatus.js",
+        7
+      ],
+      [
+        "plugins/services/src/js/constants/PodInstanceStatus.js",
+        19
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceStatusLabels.js",
+        4
+      ],
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        26
+      ]
+    ]
+  },
+  "Runs a Mesos agent on the node.": {
+    "translation": "在节点上运行 Mesos 代理节点。",
+    "origin": [
+      [
+        "src/js/constants/UnitSummaries.js",
+        175
+      ]
+    ]
+  },
+  "Runs a publicly accessible Mesos agent on the node.": {
+    "translation": "在节点上运行可公开访问的 Mesos 代理节点。",
+    "origin": [
+      [
+        "src/js/constants/UnitSummaries.js",
+        215
+      ]
+    ]
+  },
+  "Runs keepalived to make a VRRP load balancer that can be used to access the masters.": {
+    "translation": "运行 keepalived，以启用 VRRP 负载均衡器，从而可以使用该负载均衡器访问管理节点。",
+    "origin": [
+      [
+        "src/js/constants/UnitSummaries.js",
+        182
+      ]
+    ]
+  },
+  "Runs the {0} web interface, as well as a reverse proxy so that administrative interfaces of {1} Service can be accessed from outside the cluster.": {
+    "translation": "运行 {0} 网络界面以及反向代理，以便从集群外部访问 {1} 服务的管理界面。",
+    "origin": [
+      [
+        "src/js/constants/UnitSummaries.js",
+        193
+      ]
+    ]
+  },
+  "SAML": {
+    "translation": "SAML",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/constants/ProviderTypes.js",
+        14
+      ]
+    ]
+  },
+  "SAML 2.0": {
+    "translation": "SAML 2.0",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/constants/ProviderTypes.js",
+        12
+      ]
+    ]
+  },
+  "SIZE (GiB)": {
+    "translation": "大小 (GiB)",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/VolumesFormSection.js",
+        284
+      ]
+    ]
+  },
+  "SIZE (MiB)": {
+    "translation": "大小 (MiB)",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/dss/components/DSSVolumeConfig.js",
+        92
+      ],
+      [
+        "plugins/services/src/js/components/forms/VolumesFormSection.js",
+        91
+      ]
+    ]
+  },
+  "SP Metadata": {
+    "translation": "SP 元数据",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/components/AuthProviderDetailTab.js",
+        77
+      ]
+    ]
+  },
+  "SSL/TLS Setting": {
+    "translation": "SSL/TLS 设置",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
+        258
+      ]
+    ]
+  },
+  "STAGED": {
+    "translation": "已暂存",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-debug/TaskStatsTable.js",
+        25
+      ]
+    ]
+  },
+  "SUCCESSES": {
+    "translation": "成功次数",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/BackendsTable.js",
+        42
+      ]
+    ]
+  },
+  "Sandbox Path": {
+    "translation": "沙盒路径",
+    "origin": [
+      [
+        "plugins/services/src/js/pages/task-details/TaskDetailsTab.js",
+        109
+      ]
+    ]
+  },
+  "Save": {
+    "translation": "保存",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerFormModal.js",
+        145
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/service-accounts/components/ServiceAccountsFormModal.js",
+        120
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/users/components/modals/UserEditFormModal.js",
+        83
+      ],
+      [
+        "src/js/components/modals/LanguagePreferenceFormModal.js",
+        68
+      ]
+    ]
+  },
+  "Save Configuration": {
+    "translation": "保存配置",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/components/DirectoryFormModal.js",
+        106
+      ]
+    ]
+  },
+  "Save Job": {
+    "translation": "保存作业",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobFormModal.tsx",
+        254
+      ]
+    ]
+  },
+  "Scale": {
+    "translation": "缩放",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceActionLabels.js",
+        9
+      ],
+      [
+        "plugins/services/src/js/containers/pod-detail/PodDetail.js",
+        162
+      ],
+      [
+        "plugins/services/src/js/containers/pod-detail/PodHeader.js",
+        56
+      ],
+      [
+        "plugins/services/src/js/containers/service-detail/ServiceDetail.js",
+        201
+      ]
+    ]
+  },
+  "Scale By": {
+    "translation": "按 缩放",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceActionLabels.js",
+        10
+      ]
+    ]
+  },
+  "Scale Group": {
+    "translation": "缩放组",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceScaleFormModal.js",
+        116
+      ]
+    ]
+  },
+  "Scale Pod": {
+    "translation": "缩放 Pod",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceScaleFormModal.js",
+        112
+      ]
+    ]
+  },
+  "Scale Service": {
+    "translation": "缩放服务",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceScaleFormModal.js",
+        109
+      ],
+      [
+        "plugins/services/src/js/components/modals/ServiceScaleFormModal.js",
+        145
+      ]
+    ]
+  },
+  "Scale or Restart": {
+    "translation": "缩放或重启",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js",
+        143
+      ]
+    ]
+  },
+  "Schedule": {
+    "translation": "计划",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        68
+      ]
+    ]
+  },
+  "Scheduled": {
+    "translation": "已计划",
+    "origin": [
+      [
+        "plugins/jobs/src/js/constants/JobStates.ts",
+        39
+      ]
+    ]
+  },
+  "Search": {
+    "translation": "搜索",
+    "origin": [
+      [
+        "plugins/catalog/src/js/repositories/components/RepositoriesTabUI.js",
+        45
+      ],
+      [
+        "plugins/jobs/src/js/components/JobsOverviewList.tsx",
+        46
+      ],
+      [
+        "plugins/services/src/js/components/SearchLog.js",
+        162
+      ]
+    ]
+  },
+  "Search Results": {
+    "translation": "搜索结果",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/services/ServiceTreeView.js",
+        56
+      ]
+    ]
+  },
+  "Search/bind": {
+    "translation": "搜索/绑定",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        78
+      ]
+    ]
+  },
+  "Secret": {
+    "translation": "密钥",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/ServiceCreate.js",
+        98
+      ]
+    ]
+  },
+  "Secret Stores": {
+    "translation": "密钥存储库",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/pages/SecretStorePage.js",
+        24
+      ],
+      [
+        ".dcos-ui-plugins-private/secrets/pages/SecretStorePage.js",
+        101
+      ]
+    ]
+  },
+  "Secret store sealed": {
+    "translation": "密钥存储库已密封",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/SealedStoreAlert.js",
+        17
+      ]
+    ]
+  },
+  "Secrets": {
+    "translation": "密钥",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/ServiceCreate.js",
+        204
+      ],
+      [
+        ".dcos-ui-plugins-private/secrets/pages/SecretDetail.js",
+        35
+      ],
+      [
+        ".dcos-ui-plugins-private/secrets/pages/SecretsPage.js",
+        56
+      ],
+      [
+        ".dcos-ui-plugins-private/secrets/pages/SecretsPage.js",
+        363
+      ],
+      [
+        ".dcos-ui-plugins-private/secrets/pages/SecurityPage.js",
+        13
+      ]
+    ]
+  },
+  "Security Mode": {
+    "translation": "安全模式",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/bootstrap-config/components/BootstrapConfigHashMap.js",
+        79
+      ]
+    ]
+  },
+  "See recent resource offers": {
+    "translation": "查看最近的 resource offer",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/pod-debug/PodDebugContainer.js",
+        218
+      ],
+      [
+        "plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js",
+        295
+      ]
+    ]
+  },
+  "Select ...": {
+    "translation": "选择……",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/dss/components/VolumeMountTypesSelect.js",
+        40
+      ],
+      [
+        ".dcos-ui-plugins-private/dss/components/VolumeTypeSelect.js",
+        39
+      ],
+      [
+        "src/js/components/PlacementConstraintsPartial.js",
+        102
+      ]
+    ]
+  },
+  "Select Endpoint": {
+    "translation": "选择端点",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/HealthChecksFormSection.js",
+        351
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js",
+        302
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js",
+        367
+      ]
+    ]
+  },
+  "Select Protocol": {
+    "translation": "选择协议",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/HealthChecksFormSection.js",
+        483
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js",
+        431
+      ]
+    ]
+  },
+  "Select SSL/TLS setting": {
+    "translation": "选择 SSL/TLS 设置",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        37
+      ]
+    ]
+  },
+  "Select a number of agents to allocate": {
+    "translation": "选择要分配的代理数",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerFormModal.js",
+        117
+      ]
+    ]
+  },
+  "Select a service endpoint that you configured in Networking.": {
+    "translation": "选择您在网络中配置的服务端点。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/HealthChecksFormSection.js",
+        315
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js",
+        266
+      ]
+    ]
+  },
+  "Select an identity provider to easily allow access to users.": {
+    "translation": "选择身份提供商，以便于允许访问用户。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/components/AuthProvidersModalButtonContents.js",
+        37
+      ]
+    ]
+  },
+  "Select your language": {
+    "translation": "选择您的语言",
+    "origin": [
+      [
+        "src/js/components/modals/LanguagePreferenceFormModal.js",
+        49
+      ]
+    ]
+  },
+  "Select...": {
+    "translation": "选择……",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/RegionSelection.js",
+        95
+      ]
+    ]
+  },
+  "Selected Group is": {
+    "translation": "所选组为",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/constants/BulkOptions.js",
+        11
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/constants/BulkOptions.js",
+        17
+      ]
+    ]
+  },
+  "Selected Service is": {
+    "translation": "所选服务是",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/constants/BulkOptions.js",
+        34
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/constants/BulkOptions.js",
+        40
+      ]
+    ]
+  },
+  "Selected User is": {
+    "translation": "选定用户是",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/constants/BulkOptions.js",
+        57
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/constants/BulkOptions.js",
+        63
+      ]
+    ]
+  },
+  "Sends a periodic ping back to Mesosphere with high-level cluster information to help improve {0}, and provides advance monitoring of cluster issues.": {
+    "translation": "使用高级别集群信息向 Mesosphere 发回周期性 ping，以帮助改进 {0}，并提供集群问题的预先监控。",
+    "origin": [
+      [
+        "src/js/constants/UnitSummaries.js",
+        37
+      ]
+    ]
+  },
+  "Service": {
+    "translation": "服务",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/VHostDetail.js",
+        256
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/VHostsTable.js",
+        41
+      ],
+      [
+        "plugins/services/src/js/components/modals/ServiceActionDisabledModal.js",
+        341
+      ],
+      [
+        "plugins/services/src/js/components/modals/ServiceRestartModal.js",
+        97
+      ],
+      [
+        "plugins/services/src/js/components/modals/ServiceStopModal.js",
+        97
+      ],
+      [
+        "plugins/services/src/js/pages/task-details/TaskDetailsTab.js",
+        83
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodGeneralConfigSection.js",
+        110
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js",
+        80
+      ]
+    ]
+  },
+  "Service Accounts": {
+    "translation": "服务账户",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/components/GroupDetailPage.js",
+        54
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/components/GroupDetailPage.js",
+        282
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/service-accounts/components/ServiceAccountDetailPage.js",
+        116
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/service-accounts/pages/ServiceAccountsPage.js",
+        33
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/service-accounts/pages/ServiceAccountsPage.js",
+        147
+      ]
+    ]
+  },
+  "Service Addresses": {
+    "translation": "服务地址",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/BackendDetailPage.js",
+        41
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/LoadBalancingPage.js",
+        11
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.js",
+        32
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPDetailPage.js",
+        33
+      ]
+    ]
+  },
+  "Service Endpoint": {
+    "translation": "服务端点",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/HealthChecksFormSection.js",
+        332
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js",
+        283
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js",
+        359
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodHealthChecksConfigSection.js",
+        72
+      ]
+    ]
+  },
+  "Service Endpoint Health Checks": {
+    "translation": "服务端点运行状况检查",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/PodHealthChecksConfigSection.js",
+        149
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceHealthChecksConfigSection.js",
+        180
+      ]
+    ]
+  },
+  "Service Endpoint Name": {
+    "translation": "服务端点名称",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js",
+        470
+      ],
+      [
+        "plugins/services/src/js/components/forms/NetworkingFormSection.js",
+        510
+      ]
+    ]
+  },
+  "Service Endpoints": {
+    "translation": "服务端点",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js",
+        637
+      ],
+      [
+        "plugins/services/src/js/components/forms/NetworkingFormSection.js",
+        607
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodNetworkConfigSection.js",
+        158
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js",
+        219
+      ]
+    ]
+  },
+  "Service ID": {
+    "translation": "服务 ID",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
+        360
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        6
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodGeneralConfigSection.js",
+        118
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js",
+        85
+      ]
+    ]
+  },
+  "Service Port": {
+    "translation": "服务端口",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-connection/ServiceConnectionEndpointList.js",
+        138
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js",
+        184
+      ]
+    ]
+  },
+  "Service Provider Base URL": {
+    "translation": "服务提供商基准 URL",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/constants/AuthProvidersFormDefinitions.js",
+        49
+      ],
+      [
+        ".dcos-ui-plugins-private/auth-providers/structs/AuthProvider.js",
+        114
+      ]
+    ]
+  },
+  "Service endpoint container ports": {
+    "translation": "服务端点容器端口",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        70
+      ]
+    ]
+  },
+  "Service endpoint host ports": {
+    "translation": "服务端点主机端口",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        54
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        58
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        74
+      ]
+    ]
+  },
+  "Service endpoint names": {
+    "translation": "服务端点名称",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        50
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        66
+      ]
+    ]
+  },
+  "Service endpoints map traffic from a single VIP to multiple IP addresses and ports. <0>More Information</0>.": {
+    "translation": "服务端点将来自单个 VIP 的流量映射到多个 IP 地址和端口。<0>更多信息</0>.",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js",
+        591
+      ],
+      [
+        "plugins/services/src/js/components/forms/NetworkingFormSection.js",
+        596
+      ]
+    ]
+  },
+  "Service not found": {
+    "translation": "未找到服务",
+    "origin": [
+      [
+        "plugins/services/src/js/components/ServiceItemNotFound.js",
+        21
+      ]
+    ]
+  },
+  "Services": {
+    "translation": "服务",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerDetail.js",
+        58
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/LoadBalancersTable.js",
+        46
+      ],
+      [
+        "plugins/services/src/js/components/ServiceBreadcrumbs.js",
+        204
+      ],
+      [
+        "plugins/services/src/js/containers/services/ServicesContainer.js",
+        653
+      ],
+      [
+        "plugins/services/src/js/pages/ServicesPage.js",
+        23
+      ],
+      [
+        "plugins/services/src/js/pages/ServicesPage.js",
+        40
+      ],
+      [
+        "src/js/components/NestedServiceLinks.js",
+        111
+      ]
+    ]
+  },
+  "Services Status": {
+    "translation": "服务状态",
+    "origin": [
+      [
+        "src/js/constants/DashboardHeadings.js",
+        8
+      ]
+    ]
+  },
+  "Set up an LDAP connection to avoid having to recreate your user accounts within DC/OS.": {
+    "translation": "设置 LDAP 连接，以避免在 DC/OS 内重新创建用户帐户。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
+        345
+      ]
+    ]
+  },
+  "Set up environment variables for each instance your service launches.": {
+    "translation": "为服务启动的每个实例设置环境变量。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/EnvironmentFormSection.js",
+        231
+      ]
+    ]
+  },
+  "Set variables for each task your service launches. You can also use variables to expose Secrets. <0>Manage secrets here</0>. <1>Learn more about variables</1>.": {
+    "translation": "为服务启动的每项任务设置变量。您也可以使用变量来暴露密钥。<0>在此处管理密钥</0>. <1>了解有关变量的更多信息</1>.",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/hooks.js",
+        364
+      ]
+    ]
+  },
+  "Sets the dcos-adminrouter-reload.service interval at once an hour.": {
+    "translation": "将 dcos-adminrouter-reload.service 间隔设置为每小时一次。",
+    "origin": [
+      [
+        "src/js/constants/UnitSummaries.js",
+        155
+      ]
+    ]
+  },
+  "Sets the dcos-gen-resolvconf.service to be run once a minute.": {
+    "translation": "将 dcos-gen-resolvconf.service 设置为每 运行一次。",
+    "origin": [
+      [
+        "src/js/constants/UnitSummaries.js",
+        49
+      ]
+    ]
+  },
+  "Sets the dcos-signal.service interval at once an hour.": {
+    "translation": "将 dcos-signal.service 间隔设置为每小时一次。",
+    "origin": [
+      [
+        "src/js/constants/UnitSummaries.js",
+        125
+      ]
+    ]
+  },
+  "Settings": {
+    "translation": "设置",
+    "origin": [
+      [
+        "src/js/pages/SettingsPage.js",
+        13
+      ]
+    ]
+  },
+  "Showing {currentLength} of {totalLength} {name}": {
+    "translation": "显示 {totalLength} {name} 的 {currentLength} ",
+    "origin": [
+      [
+        "src/js/components/FilterHeadline.js",
+        65
+      ]
+    ]
+  },
+  "Sign Out": {
+    "translation": "退出",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth/components/AuthenticatedUserAccountDropdown.js",
+        50
+      ],
+      [
+        "plugins/oauth/components/AuthenticatedUserAccountDropdown.js",
+        40
+      ]
+    ]
+  },
+  "Simple bind": {
+    "translation": "简单绑定",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        75
+      ]
+    ]
+  },
+  "Single Container": {
+    "translation": "单个容器",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModalServicePicker.js",
+        23
+      ]
+    ]
+  },
+  "Size": {
+    "translation": "大小",
+    "origin": [
+      [
+        "plugins/services/src/js/components/PodVolumeTable.js",
+        71
+      ],
+      [
+        "plugins/services/src/js/components/VolumeTable.js",
+        70
+      ],
+      [
+        "plugins/services/src/js/constants/TaskDirectoryHeaderLabels.js",
+        7
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceStorageConfigSection.js",
+        89
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceStorageConfigSection.js",
+        110
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceStorageConfigSection.js",
+        121
+      ]
+    ]
+  },
+  "Size (GiB)": {
+    "translation": "大小 (GiB)",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/volume-detail/PodVolumeDetail.js",
+        22
+      ],
+      [
+        "plugins/services/src/js/containers/volume-detail/VolumeDetail.js",
+        22
+      ]
+    ]
+  },
+  "Size (MiB)": {
+    "translation": "大小 (MiB)",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/dss/components/DSSInput.js",
+        139
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js",
+        250
+      ],
+      [
+        "plugins/services/src/js/containers/volume-detail/PodVolumeDetail.js",
+        25
+      ],
+      [
+        "plugins/services/src/js/containers/volume-detail/VolumeDetail.js",
+        25
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodStorageConfigSection.js",
+        36
+      ]
+    ]
+  },
+  "Specializes the {0} bootstrap tarball for the particular cluster, as well as its cluster role.": {
+    "translation": "针对特定集群及其集群角色，专门化 {0} bootstrap tarball。",
+    "origin": [
+      [
+        "src/js/constants/UnitSummaries.js",
+        165
+      ]
+    ]
+  },
+  "Specify where your app will run.": {
+    "translation": "指定应用程序运行的位置。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/PlacementConstraintsFields.js",
+        142
+      ],
+      [
+        "src/js/components/PlacementConstraintsPartial.js",
+        104
+      ]
+    ]
+  },
+  "Staged at": {
+    "translation": "已缓存于",
+    "origin": [
+      [
+        "plugins/services/src/js/components/MarathonTaskDetailsList.js",
+        80
+      ]
+    ]
+  },
+  "Staging": {
+    "translation": "正在缓存",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/PodContainerStatus.js",
+        13
+      ],
+      [
+        "plugins/services/src/js/constants/PodInstanceStatus.js",
+        25
+      ],
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        11
+      ]
+    ]
+  },
+  "Started": {
+    "translation": "已开始",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobRunHistoryTable.js",
+        104
+      ],
+      [
+        "plugins/nodes/src/js/components/LeaderGrid.js",
+        55
+      ],
+      [
+        "plugins/services/src/js/components/DeploymentsModal.js",
+        38
+      ],
+      [
+        "plugins/services/src/js/constants/PodContainerStatus.js",
+        25
+      ],
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        21
+      ],
+      [
+        "src/js/pages/system/OverviewDetailTab.js",
+        304
+      ]
+    ]
+  },
+  "Started After Last Scaling": {
+    "translation": "上次缩放后已开始",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-debug/TaskStatsTable.js",
+        16
+      ]
+    ]
+  },
+  "Started At": {
+    "translation": "已开始于",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/pod-debug/PodDebugContainer.js",
+        107
+      ]
+    ]
+  },
+  "Started at": {
+    "translation": "已开始于",
+    "origin": [
+      [
+        "plugins/services/src/js/components/MarathonTaskDetailsList.js",
+        88
+      ]
+    ]
+  },
+  "Starting": {
+    "translation": "正在开始",
+    "origin": [
+      [
+        "plugins/jobs/src/js/constants/JobStates.ts",
+        9
+      ],
+      [
+        "plugins/jobs/src/js/constants/JobStates.ts",
+        14
+      ],
+      [
+        "plugins/services/src/js/constants/PodContainerStatus.js",
+        19
+      ],
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        16
+      ]
+    ]
+  },
+  "Starting Deadline": {
+    "translation": "开始截止期",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        96
+      ]
+    ]
+  },
+  "State": {
+    "translation": "状态",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js",
+        87
+      ]
+    ]
+  },
+  "Status": {
+    "translation": "状态",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/CertificatesTable.js",
+        54
+      ],
+      [
+        "plugins/jobs/src/js/constants/JobTableHeaderLabels.js",
+        5
+      ],
+      [
+        "plugins/jobs/src/js/pages/JobRunHistoryTable.js",
+        103
+      ],
+      [
+        "plugins/services/src/js/components/DeploymentsModal.js",
+        39
+      ],
+      [
+        "plugins/services/src/js/components/MarathonTaskDetailsList.js",
+        72
+      ],
+      [
+        "plugins/services/src/js/components/PodVolumeTable.js",
+        72
+      ],
+      [
+        "plugins/services/src/js/components/VolumeTable.js",
+        71
+      ],
+      [
+        "plugins/services/src/js/components/dsl/ServiceStatusDSLSection.js",
+        37
+      ],
+      [
+        "plugins/services/src/js/components/dsl/TaskStatusDSLSection.js",
+        34
+      ],
+      [
+        "plugins/services/src/js/constants/PodTableHeaderLabels.js",
+        8
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceTableHeaderLabels.js",
+        9
+      ],
+      [
+        "plugins/services/src/js/constants/TaskTableHeaderLabels.js",
+        13
+      ]
+    ]
+  },
+  "Stop": {
+    "translation": "停止",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobRunHistoryTable.js",
+        220
+      ],
+      [
+        "plugins/services/src/js/components/modals/KillPodInstanceModal.js",
+        16
+      ],
+      [
+        "plugins/services/src/js/components/modals/KillTaskModal.js",
+        15
+      ],
+      [
+        "plugins/services/src/js/components/modals/ServiceStopModal.js",
+        123
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceActionLabels.js",
+        11
+      ],
+      [
+        "plugins/services/src/js/containers/pod-detail/PodDetail.js",
+        169
+      ],
+      [
+        "plugins/services/src/js/containers/service-detail/ServiceDetail.js",
+        208
+      ],
+      [
+        "plugins/services/src/js/containers/tasks/TasksView.js",
+        200
+      ]
+    ]
+  },
+  "Stop Current Runs and Delete Job": {
+    "translation": "停止当前运行和删除作业",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobDeleteModal.js",
+        9
+      ]
+    ]
+  },
+  "Stop Job Run": {
+    "translation": "停止作业运行",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobStopRunModal.js",
+        50
+      ]
+    ]
+  },
+  "Stop Job Runs": {
+    "translation": "停止作业运行",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobStopRunModal.js",
+        54
+      ]
+    ]
+  },
+  "Stop your service by scaling to 0 instances from the DC/OS CLI using an `options.json` file. <0>More information</0>": {
+    "translation": "通过使用 `options.json` 文件，从 DC/OS CLI 缩放到 0 个实例，从而停止服务。<0>更多信息</0>",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceActionDisabledModal.js",
+        92
+      ]
+    ]
+  },
+  "Stop {serviceLabel}": {
+    "translation": "停止 {serviceLabel} ",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceStopModal.js",
+        105
+      ]
+    ]
+  },
+  "Stopped": {
+    "translation": "已停止",
+    "origin": [
+      [
+        "plugins/services/src/js/components/dsl/ServiceStatusDSLSection.js",
+        79
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceStatusLabels.js",
+        6
+      ]
+    ]
+  },
+  "Stopping a scheduler task is not supported.": {
+    "translation": "不支持停止计划进程任务。",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/tasks/TasksView.js",
+        189
+      ]
+    ]
+  },
+  "Stopping the <0>{serviceName}</0> {0} will remove all currently running instances of the {1}. The {2} will not be deleted.": {
+    "translation": "停止 <0>{serviceName}</0> {0} 将移除 {1} 的所有当前运行实例。{2} 不会被删除。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceStopModal.js",
+        128
+      ]
+    ]
+  },
+  "Store": {
+    "translation": "存储",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/pages/SecretDetail.js",
+        222
+      ]
+    ]
+  },
+  "Success": {
+    "translation": "成功",
+    "origin": [
+      [
+        "plugins/jobs/src/js/constants/JobStates.ts",
+        29
+      ]
+    ]
+  },
+  "Success!": {
+    "translation": "成功！",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackageDetailTab.js",
+        404
+      ]
+    ]
+  },
+  "Successes": {
+    "translation": "成功次数",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/LoadBalancersTable.js",
+        43
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/VHostsTable.js",
+        42
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/BackendsTable.js",
+        76
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/NetworkItemChart.js",
+        97
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPsTable.js",
+        49
+      ]
+    ]
+  },
+  "Successes and Failures": {
+    "translation": "成功次数和失败次数",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/BackendDetailPage.js",
+        138
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPDetailPage.js",
+        113
+      ]
+    ]
+  },
+  "Successes and Failures per Minute": {
+    "translation": "每分钟的成功次数和失败次数",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/BackendDetailPage.js",
+        140
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPDetailPage.js",
+        115
+      ]
+    ]
+  },
+  "Summary": {
+    "translation": "摘要",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/pod-debug/PodDebugContainer.js",
+        172
+      ],
+      [
+        "plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js",
+        166
+      ],
+      [
+        "src/js/pages/system/units-health-node-detail/NodeInfoPanel.js",
+        25
+      ]
+    ]
+  },
+  "Support": {
+    "translation": "支持",
+    "origin": [
+      [
+        "src/js/components/ClusterHeader.js",
+        137
+      ]
+    ]
+  },
+  "Switch": {
+    "translation": "切换",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/cluster-linking/components/LinkedClustersTable.js",
+        86
+      ]
+    ]
+  },
+  "Switch Cluster": {
+    "translation": "切换集群",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/cluster-linking/components/ClusterLinkingModalTrigger.js",
+        44
+      ]
+    ]
+  },
+  "Switch to Pod": {
+    "translation": "切换至 Pod",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
+        426
+      ]
+    ]
+  },
+  "Switching to a pod service": {
+    "translation": "正在切换到 pod 服务",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
+        418
+      ]
+    ]
+  },
+  "TASK": {
+    "translation": "任务",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/BackendsTable.js",
+        41
+      ]
+    ]
+  },
+  "TCP": {
+    "translation": "TCP",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js",
+        434
+      ]
+    ]
+  },
+  "TRUE": {
+    "translation": "TRUE",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/PodContainerArtifactsConfigSection.js",
+        13
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodStorageConfigSection.js",
+        15
+      ]
+    ]
+  },
+  "Task": {
+    "translation": "任务",
+    "origin": [
+      [
+        "src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js",
+        26
+      ],
+      [
+        "src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js",
+        305
+      ]
+    ]
+  },
+  "Task ID": {
+    "translation": "任务 ID",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js",
+        81
+      ],
+      [
+        "plugins/services/src/js/containers/volume-detail/PodVolumeDetail.js",
+        97
+      ],
+      [
+        "plugins/services/src/js/containers/volume-detail/VolumeDetail.js",
+        91
+      ],
+      [
+        "plugins/services/src/js/pages/task-details/TaskDetailsTab.js",
+        123
+      ]
+    ]
+  },
+  "Task Statistics": {
+    "translation": "任务统计信息",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js",
+        356
+      ]
+    ]
+  },
+  "Tasks": {
+    "translation": "任务",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/NodesTable.tsx",
+        92
+      ],
+      [
+        "plugins/nodes/src/js/pages/nodes/NodeDetailPage.js",
+        36
+      ],
+      [
+        "plugins/nodes/src/js/pages/nodes/NodeDetailPage.js",
+        174
+      ],
+      [
+        "plugins/services/src/js/containers/pod-detail/PodDetail.js",
+        40
+      ],
+      [
+        "plugins/services/src/js/containers/pod-detail/PodDetail.js",
+        203
+      ],
+      [
+        "plugins/services/src/js/containers/service-detail/ServiceDetail.js",
+        43
+      ],
+      [
+        "plugins/services/src/js/containers/service-detail/ServiceDetail.js",
+        236
+      ],
+      [
+        "src/js/constants/DashboardHeadings.js",
+        9
+      ],
+      [
+        "src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.js",
+        64
+      ],
+      [
+        "src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.js",
+        146
+      ]
+    ]
+  },
+  "Tasks running": {
+    "translation": "任务运行",
+    "origin": [
+      [
+        "src/js/components/charts/TasksChart.js",
+        14
+      ]
+    ]
+  },
+  "Tasks staging": {
+    "translation": "任务缓存",
+    "origin": [
+      [
+        "src/js/components/charts/TasksChart.js",
+        15
+      ]
+    ]
+  },
+  "Terminated at {0} (<0/>)": {
+    "translation": "已终止于 {0} (<0/>)",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/pod-debug/PodDebugContainer.js",
+        86
+      ]
+    ]
+  },
+  "Terms and Conditions": {
+    "translation": "条款与条件",
+    "origin": [
+      [
+        "src/js/components/FrameworkConfiguration.js",
+        188
+      ]
+    ]
+  },
+  "Test Connection": {
+    "translation": "测试连接",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/components/DirectoryActionButtons.js",
+        21
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/components/DirectoryActionButtons.js",
+        153
+      ]
+    ]
+  },
+  "Test External Directory": {
+    "translation": "测试外部目录",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/components/DirectoryActionButtons.js",
+        172
+      ]
+    ]
+  },
+  "The CPUs offered": {
+    "translation": "已提供 CPU",
+    "origin": [
+      [
+        "plugins/services/src/js/components/RecentOffersSummary.js",
+        146
+      ]
+    ]
+  },
+  "The GPUs offered": {
+    "translation": "已提供 GPU",
+    "origin": [
+      [
+        "plugins/services/src/js/components/RecentOffersSummary.js",
+        158
+      ]
+    ]
+  },
+  "The Mesos master process orchestrates agent tasks.": {
+    "translation": "Mesos 管理节点进程编排代理任务。",
+    "origin": [
+      [
+        "src/js/constants/UnitSummaries.js",
+        30
+      ]
+    ]
+  },
+  "The command value will be wrapped by the underlying Mesos executor via {exampleCmd} <0>More information</0>.": {
+    "translation": "命令值将通过 {exampleCmd} 由底层 Mesos 执行器进行换行 <0>更多信息</0>.",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/ContainerServiceFormSection.js",
+        54
+      ]
+    ]
+  },
+  "The connection to the LDAP server was successful, but credentials were invalid.": {
+    "translation": "与 LDAP 服务器的连接成功，但凭据无效。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/components/DirectoryActionButtons.js",
+        62
+      ]
+    ]
+  },
+  "The container runtime is responsible for running your service. We support the Docker Engine and Universal Container Runtime (UCR).": {
+    "translation": "容器运行时负责运行您的服务。我们支持 Docker 引擎和通用容器运行时 (UCR)。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
+        229
+      ]
+    ]
+  },
+  "The contents of this secret store cannot be accessed until it is unsealed. See <0>instructions</0> on how to access sealed secret stores.": {
+    "translation": "无法访问该密钥存储库的内容，直到解封为止。参见 <0>有关</0> 如何访问密封密钥存储库的说明。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/SealedStoreAlert.js",
+        19
+      ]
+    ]
+  },
+  "The disk space offered": {
+    "translation": "已提供磁盘空间",
+    "origin": [
+      [
+        "plugins/services/src/js/components/RecentOffersSummary.js",
+        183
+      ]
+    ]
+  },
+  "The input entered is not a valid JSON string": {
+    "translation": "所输入的不是有效的 JSON 字符串",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/CreateServiceJsonOnly.js",
+        83
+      ]
+    ]
+  },
+  "The key cannot be empty.": {
+    "translation": "密钥不能为空。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/EnvironmentFormSection.js",
+        71
+      ],
+      [
+        "plugins/services/src/js/components/forms/EnvironmentFormSection.js",
+        142
+      ]
+    ]
+  },
+  "The memory offered": {
+    "translation": "已提供内存",
+    "origin": [
+      [
+        "plugins/services/src/js/components/RecentOffersSummary.js",
+        171
+      ]
+    ]
+  },
+  "The network type will be shared across all your containers.": {
+    "translation": "网络类型将在所有容器中共享。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js",
+        627
+      ]
+    ]
+  },
+  "The page you requested cannot be found. Check the address you provided, or head back to the <0>Dashboard</0>.": {
+    "translation": "无法找到您请求的页面。查看您提供的地址，或返回至 <0>仪表板</0>.",
+    "origin": [
+      [
+        "src/js/pages/NotFoundPage.js",
+        30
+      ]
+    ]
+  },
+  "The path where your application will read and write data. This must be a single-level path relative to the container. <0>More information</0>.": {
+    "translation": "应用程序读写数据的路径。这必须是相对于容器的单层路径。<0>更多信息</0>.",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/VolumesFormSection.js",
+        49
+      ]
+    ]
+  },
+  "The port offered": {
+    "translation": "已提供端口",
+    "origin": [
+      [
+        "plugins/services/src/js/components/RecentOffersSummary.js",
+        195
+      ]
+    ]
+  },
+  "The resource offer": {
+    "translation": "resource offer",
+    "origin": [
+      [
+        "plugins/services/src/js/components/RecentOffersSummary.js",
+        122
+      ],
+      [
+        "plugins/services/src/js/components/RecentOffersSummary.js",
+        134
+      ]
+    ]
+  },
+  "The secret cannot be empty.": {
+    "translation": "密钥不能为空。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/ServiceCreate.js",
+        109
+      ]
+    ]
+  },
+  "The service is currently locked by one or more deployments. Press again to force this operation.": {
+    "translation": "服务当前被一个或多个部署锁定。再次按下以强制执行此操作。",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorMessages.js",
+        25
+      ]
+    ]
+  },
+  "The service with the ID of \"{id}\" could not be found.": {
+    "translation": "未找到带有 ID \"{id}\" 的服务。",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/volume-detail/PodVolumeContainer.js",
+        63
+      ],
+      [
+        "plugins/services/src/js/containers/volume-detail/ServiceVolumeContainer.js",
+        63
+      ]
+    ]
+  },
+  "The service with the ID of \"{taskID}\" could not be found.": {
+    "translation": "未找到带有 ID \"{taskID}\" 的服务。",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/volume-detail/TaskVolumeContainer.js",
+        64
+      ]
+    ]
+  },
+  "The unique operator does not accept a value.": {
+    "translation": "唯一运算符不接受值。",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/OperatorTypes.js",
+        11
+      ]
+    ]
+  },
+  "The {0} Marathon instance starts and monitors {1} applications and services.": {
+    "translation": "{0} Marathon 实例启动和监控 {1} 应用程序和服务。",
+    "origin": [
+      [
+        "src/js/constants/UnitSummaries.js",
+        12
+      ]
+    ]
+  },
+  "The {itemType} with the ID of \"{itemId}\" could not be found.": {
+    "translation": "未找到带有 ID \"{itemId}\" 的 {itemType}。",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/services/ServicesContainer.js",
+        488
+      ]
+    ]
+  },
+  "Then, copy the command below into the DC/OS CLI.": {
+    "translation": "然后，将下面的命令复制到 DC/OS CLI 中。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceActionDisabledModal.js",
+        266
+      ]
+    ]
+  },
+  "Then, use this command to update each service.": {
+    "translation": "然后，使用此命令来更新每个服务。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceActionDisabledModal.js",
+        296
+      ]
+    ]
+  },
+  "There a currently no other nodes in your datacenter other than your DC/OS master node.": {
+    "translation": "除了 DC/OS 管理节点之外，您的数据中心目前没有其他节点。",
+    "origin": [
+      [
+        "plugins/nodes/src/js/pages/NodesAgents.js",
+        304
+      ]
+    ]
+  },
+  "There a currently no other virtual networks found on your datacenter. Virtual networks are configured during setup of your DC/OS cluster.": {
+    "translation": "您的数据中心目前没有其他虚拟网络。在设置 DC/OS 集群期间配置虚拟网络。",
+    "origin": [
+      [
+        "src/js/pages/network/VirtualNetworksTab.js",
+        92
+      ]
+    ]
+  },
+  "There are errors in your JSON definition": {
+    "translation": "您的 JSON 定义中存在错误",
+    "origin": [
+      [
+        "plugins/jobs/src/js/components/JobFormModal.tsx",
+        183
+      ]
+    ]
+  },
+  "There are no endpoints currently configured for {serviceId}. You can edit the configuration to add service endpoints.": {
+    "translation": "目前没有为 {serviceId} 配置端点。您可以编辑配置以添加服务端点。",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-connection/ServiceNoEndpointsPanel.js",
+        13
+      ]
+    ]
+  },
+  "There are no more known masters in this cluster.": {
+    "translation": "此集群中没有更多的已知管理节点。",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/NonLeadersGrid.js",
+        40
+      ]
+    ]
+  },
+  "There are no services associated with this load balancer.": {
+    "translation": "此负载均衡器没有相关服务。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerDetail.js",
+        237
+      ]
+    ]
+  },
+  "There is an error with your configuration": {
+    "translation": "您的配置有错误",
+    "origin": [
+      [
+        "src/js/components/ErrorsAlert.js",
+        51
+      ]
+    ]
+  },
+  "This action <0>CANNOT</0> be undone. This will permanently delete the <1>{serviceName}</1> {0}.": {
+    "translation": "此操作 <0>无法</0> 撤销。这将永久删除 <1>{serviceName}</1> {0}.",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceDestroyModal.js",
+        155
+      ]
+    ]
+  },
+  "This action is irreversible and may break your cluster.": {
+    "translation": "此操作不可逆，可能会破坏您的集群。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/service-accounts/components/ServiceAccountsActionsModal.js",
+        63
+      ]
+    ]
+  },
+  "This app does not have failed tasks": {
+    "translation": "此应用程序没有失败的任务",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js",
+        66
+      ]
+    ]
+  },
+  "This app does not have task statistics": {
+    "translation": "此应用程序没有任务统计信息",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js",
+        251
+      ]
+    ]
+  },
+  "This app does not have version change information": {
+    "translation": "此应用程序没有版本更改信息",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js",
+        124
+      ]
+    ]
+  },
+  "This directory does not contain any logs.": {
+    "translation": "此目录不包含任何日志。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/MesosLogContainer.js",
+        225
+      ]
+    ]
+  },
+  "This feature will be available once {dcosLBPackageName} finishes deploying.": {
+    "translation": "当 {dcosLBPackageName} 完成部署后，此功能就可用。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancersTab.js",
+        166
+      ]
+    ]
+  },
+  "This field is optional.": {
+    "translation": "此字段为可选。",
+    "origin": [
+      [
+        "src/js/components/PlacementConstraintsPartial.js",
+        185
+      ]
+    ]
+  },
+  "This field is required.": {
+    "translation": "此字段为必填。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/SecretFormModal.js",
+        136
+      ]
+    ]
+  },
+  "This group needs to be empty to delete it. Please delete any services in the group first.": {
+    "translation": "此组需要为空，才能删除。请先删除组中的任何服务。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/DisabledGroupDestroyModal.js",
+        32
+      ]
+    ]
+  },
+  "This host port will be accessible as an environment variable called '$PORT{index}'. <0>More information</0>.": {
+    "translation": "此主机端口可以作为一个名为 '$PORT{index}' 的环境变量进行访问。<0>更多信息</0>.",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/NetworkingFormSection.js",
+        89
+      ]
+    ]
+  },
+  "This host port will be accessible as an environment variable called {environmentVariableName}. <0>More information</0>.": {
+    "translation": "此主机端口可以作为一个名为 {environmentVariableName} 的环境变量进行访问。<0>更多信息</0>.",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js",
+        118
+      ]
+    ]
+  },
+  "This package can only be installed using the CLI. See the <0>documentation</0>.": {
+    "translation": "此包仅可使用 CLI 进行安装。查看 <0>文档</0>.",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackageDetailTab.js",
+        273
+      ]
+    ]
+  },
+  "This port will be used to load balance this service address internally": {
+    "translation": "此端口将用于在内部负载均衡此服务地址",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js",
+        274
+      ],
+      [
+        "plugins/services/src/js/components/forms/NetworkingFormSection.js",
+        229
+      ]
+    ]
+  },
+  "This repository": {
+    "translation": "此存储库",
+    "origin": [
+      [
+        "plugins/catalog/src/js/repositories/components/RepositoriesDeleteConfirm.js",
+        11
+      ]
+    ]
+  },
+  "This service has advanced networking configuration, which we don't currently support in the UI. Please use the JSON editor to make changes.": {
+    "translation": "此服务具有高级网络配置，我们的 UI（用户界面）目前无法支持。请使用 JSON 编辑器进行更改。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/NetworkingFormSection.js",
+        718
+      ]
+    ]
+  },
+  "This service is currently stopped. Do you want to resume this service?": {
+    "translation": "此服务目前已停止。是否要恢复此服务？",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceResumeModal.js",
+        117
+      ]
+    ]
+  },
+  "This service is currently stopped. Do you want to resume this service? You can change the number of instances to resume by using the field below.": {
+    "translation": "此服务目前已停止。是否要恢复此服务？ 您可以使用以下字段来更改要恢复的实例数。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceResumeModal.js",
+        125
+      ]
+    ]
+  },
+  "This service was initially deployed to a previous version of DC/OS that did not store service configuration settings. The default package values were used to populate the configuration in this form. Carefully verify the default settings are correct, prior to deploying the new configuration.": {
+    "translation": "此服务最初是部署到未存储服务配置设置的先前 DC/OS 版本。默认包值用于填充此表格中的配置。在部署新配置之前，请仔细验证默认设置是否正确。",
+    "origin": [
+      [
+        "plugins/services/src/js/pages/EditFrameworkConfiguration.js",
+        57
+      ]
+    ]
+  },
+  "This version of {0} requires DC/OS version {1} or higher, but you are running DC/OS version {2}": {
+    "translation": "{0} 的此版本需要 DC/OS 版本 {1} 或更高版本，但您正在运行 DC/OS 版本 {2}",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackageDetailTab.js",
+        306
+      ]
+    ]
+  },
+  "This will stop the current deployment of {listOfServiceNames} and start a new deployment to delete the affected service.": {
+    "translation": "这将停止 {listOfServiceNames} 的当前部署并开始新部署，以删除受影响的服务。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/DeploymentsModal.js",
+        210
+      ]
+    ]
+  },
+  "This will stop the current deployment of {listOfServiceNames} and start a new deployment to delete the affected services.": {
+    "translation": "这将停止 {listOfServiceNames} 的当前部署并开始新部署，以删除受影响的服务。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/DeploymentsModal.js",
+        217
+      ]
+    ]
+  },
+  "This will stop the current deployment of {listOfServiceNames} and start a new deployment to revert the affected service to its previous version.": {
+    "translation": "这将停止 {listOfServiceNames} 的当前部署并开始新部署，将受影响的服务恢复到其先前版本。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/DeploymentsModal.js",
+        228
+      ]
+    ]
+  },
+  "This will stop the current deployment of {listOfServiceNames} and start a new deployment to revert the affected services to their previous versions.": {
+    "translation": "这将停止 {listOfServiceNames} 的当前部署并开始新部署，将受影响的服务恢复到其先前版本。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/DeploymentsModal.js",
+        236
+      ]
+    ]
+  },
+  "Time Zone": {
+    "translation": "时区",
+    "origin": [
+      [
+        "plugins/jobs/src/js/pages/JobConfiguration.js",
+        90
+      ]
+    ]
+  },
+  "Timeout": {
+    "translation": "超时",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/PodHealthChecksConfigSection.js",
+        30
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceHealthChecksConfigSection.js",
+        134
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceHealthChecksConfigSection.js",
+        241
+      ]
+    ]
+  },
+  "Timeout (s)": {
+    "translation": "超时",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/HealthChecksFormSection.js",
+        163
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js",
+        142
+      ]
+    ]
+  },
+  "Timestamp": {
+    "translation": "时间戳",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js",
+        105
+      ]
+    ]
+  },
+  "To enable this feature please contact support via {slackLink} or send us an email at {supportLink}.": {
+    "translation": "要启用此功能，请通过 {slackLink} 联系支持人员或发送电子邮件至 {supportLink}。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancersTab.js",
+        240
+      ]
+    ]
+  },
+  "To update this service's configuration, please update <0>options.json</0>. Run the following CLI command:": {
+    "translation": "要更新此服务的配置，请更新 <0>options.json</0>。运行以下 CLI 命令：",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/sdk-services/components/SDKServiceEdit.js",
+        16
+      ]
+    ]
+  },
+  "To use a secret in an application, a user needs appropriate permissions. <0>More information</0>.": {
+    "translation": "要在应用程序中使用密钥，用户需要适当的权限。<0>更多信息</0>.",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/ServiceCreate.js",
+        189
+      ]
+    ]
+  },
+  "Total Summary": {
+    "translation": "总摘要",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-debug/TaskStatsTable.js",
+        19
+      ]
+    ]
+  },
+  "Total Tasks": {
+    "translation": "总任务",
+    "origin": [
+      [
+        "src/js/components/charts/TasksChart.js",
+        124
+      ]
+    ]
+  },
+  "Type": {
+    "translation": "键入",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/SecretStoresTable.js",
+        80
+      ],
+      [
+        "plugins/nodes/src/js/components/NodesTable.tsx",
+        86
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodStorageConfigSection.js",
+        30
+      ]
+    ]
+  },
+  "Type \"{serviceName}\" to confirm": {
+    "translation": "键入 \"{serviceName}\" 以确认",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceDestroyModal.js",
+        160
+      ]
+    ]
+  },
+  "UI Settings": {
+    "translation": "UI 设置",
+    "origin": [
+      [
+        "src/js/pages/settings/UISettingsPage.js",
+        24
+      ],
+      [
+        "src/js/pages/settings/UISettingsPage.js",
+        26
+      ],
+      [
+        "src/js/pages/settings/UISettingsPage.js",
+        85
+      ]
+    ]
+  },
+  "UNHEALTHY": {
+    "translation": "不健康",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-debug/TaskStatsTable.js",
+        24
+      ]
+    ]
+  },
+  "URL": {
+    "translation": "URL",
+    "origin": [
+      [
+        "plugins/catalog/src/js/repositories/components/AddRepositoryFormModal.js",
+        47
+      ],
+      [
+        "src/js/constants/RepositoriesTableHeaderLabels.js",
+        6
+      ]
+    ]
+  },
+  "USERNAME": {
+    "translation": "用户名",
+    "origin": [
+      [
+        "src/js/pages/system/OrganizationTab.js",
+        297
+      ]
+    ]
+  },
+  "Unable to edit this HealthCheck": {
+    "translation": "无法编辑此运行状况检查",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/HealthChecksFormSection.js",
+        420
+      ]
+    ]
+  },
+  "Unable to edit this Volume": {
+    "translation": "无法编辑此卷",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/dss/components/DSSInput.js",
+        73
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js",
+        91
+      ],
+      [
+        "plugins/services/src/js/components/forms/VolumesFormSection.js",
+        305
+      ]
+    ]
+  },
+  "Unable to edit {0}": {
+    "translation": "无法编辑 {0}",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/PlacementSchemaField.js",
+        47
+      ],
+      [
+        "src/js/components/PlacementConstraintsSchemaField.js",
+        31
+      ]
+    ]
+  },
+  "Unable to fetch permission schema.": {
+    "translation": "无法获取权限框架。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/PermissionBuilderModal.js",
+        71
+      ]
+    ]
+  },
+  "Unable to login to your DC/OS cluster. Clusters must be connected to the internet.": {
+    "translation": "无法登录到 DC/OS 集群。集群必须连接到互联网。",
+    "origin": [
+      [
+        "plugins/oauth/components/LoginPage.js",
+        113
+      ]
+    ]
+  },
+  "Unavailable": {
+    "translation": "不可用",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/VolumeStatus.js",
+        6
+      ]
+    ]
+  },
+  "Unhealthy": {
+    "translation": "不健康",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/dsl/NodesHealthDSLSection.js",
+        58
+      ],
+      [
+        "plugins/services/src/js/components/dsl/ServiceHealthDSLSection.js",
+        68
+      ],
+      [
+        "plugins/services/src/js/constants/PodContainerStatus.js",
+        37
+      ],
+      [
+        "plugins/services/src/js/constants/PodInstanceStatus.js",
+        13
+      ],
+      [
+        "plugins/services/src/js/constants/TaskHealthStates.js",
+        5
+      ],
+      [
+        "plugins/services/src/js/containers/pod-instances/PodInstancesTable.js",
+        416
+      ],
+      [
+        "src/js/constants/UnitHealthStatus.js",
+        25
+      ],
+      [
+        "src/js/pages/system/UnitsHealthTab.js",
+        196
+      ]
+    ]
+  },
+  "Unique": {
+    "translation": "唯一",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/OperatorTypes.js",
+        13
+      ]
+    ]
+  },
+  "Universal Container Runtime (UCR)": {
+    "translation": "通用容器运行时 (UCR)",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ContainerConstants.js",
+        10
+      ]
+    ]
+  },
+  "Universal Container Runtime using native Mesos engine. Supports Docker file format, multiple containers (Pods) and GPU resources.": {
+    "translation": "使用本机 Mesos 引擎的通用容器运行时。支持 Docker 文件格式、多个容器（Pod）和 GPU 资源。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
+        55
+      ]
+    ]
+  },
+  "Unknown": {
+    "translation": "未知",
+    "origin": [
+      [
+        "plugins/services/src/js/components/MarathonTaskDetailsList.js",
+        26
+      ],
+      [
+        "plugins/services/src/js/constants/TaskHealthStates.js",
+        6
+      ],
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        81
+      ]
+    ]
+  },
+  "Unlike": {
+    "translation": "不相似",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/OperatorTypes.js",
+        59
+      ]
+    ]
+  },
+  "Unreachable": {
+    "translation": "不可达",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/TaskStates.js",
+        76
+      ]
+    ]
+  },
+  "Unscheduled": {
+    "translation": "未计划",
+    "origin": [
+      [
+        "plugins/jobs/src/js/constants/JobStates.ts",
+        44
+      ]
+    ]
+  },
+  "Unspecified": {
+    "translation": "未指定",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js",
+        259
+      ]
+    ]
+  },
+  "Update the number of instances in your service's target configuration using an `options.json` file.": {
+    "translation": "使用 `options.json` 文件来更新服务目标配置中的实例数。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceActionDisabledModal.js",
+        136
+      ]
+    ]
+  },
+  "Updated": {
+    "translation": "已更新",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/PodTableHeaderLabels.js",
+        12
+      ],
+      [
+        "plugins/services/src/js/constants/TaskTableHeaderLabels.js",
+        15
+      ]
+    ]
+  },
+  "Upgrade": {
+    "translation": "已升级",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/licensing/components/LicensingExpirationRow.js",
+        77
+      ]
+    ]
+  },
+  "Upgrade Max Overcapacity": {
+    "translation": "升级最大超容量",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/PodGeneralConfigSection.js",
+        189
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js",
+        148
+      ]
+    ]
+  },
+  "Upgrade Min Health Capacity": {
+    "translation": "升级最小健康容量",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/PodGeneralConfigSection.js",
+        180
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js",
+        144
+      ]
+    ]
+  },
+  "Usage Logs": {
+    "translation": "使用日志",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/licensing/components/LicensingNodeCapacityRow.js",
+        80
+      ]
+    ]
+  },
+  "Use SSL/TLS for all connections": {
+    "translation": "对所有连接使用 SSL/TLS",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        25
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        26
+      ]
+    ]
+  },
+  "Use the <0>DC/OS Secret Store</0> to secure important values like private keys, API tokens, and database passwords.": {
+    "translation": "使用 <0>DC/OS 密钥存储库，</0> 以保护诸如私钥、API 令牌和数据库密码等重要值。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/ServiceCreate.js",
+        214
+      ]
+    ]
+  },
+  "Use the form below to build your permission. For more information see the <0>documentation</0>. To bulk add permissions, <1>switch to advanced mode</1>.": {
+    "translation": "使用下表构建您的权限。有关详细信息，请参阅 <0>文档</0>。要批量添加权限，<1>请切换至高级模式</1>.",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/PermissionBuilderModal.js",
+        597
+      ]
+    ]
+  },
+  "Use the form below to manually enter or paste permissions. <0>Switch to permission builder</0> to add a single permission.": {
+    "translation": "使用下表手动输入或粘贴权限。<0>切换到权限构建器，</0> 以添加单个权限。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/PermissionBuilderModal.js",
+        586
+      ]
+    ]
+  },
+  "Use this text area to customize your configuration via JSON.": {
+    "translation": "使用此文本区域，通过 JSON 自定义您的配置。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/CreateServiceJsonOnly.js",
+        105
+      ]
+    ]
+  },
+  "User": {
+    "translation": "用户",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js",
+        222
+      ]
+    ]
+  },
+  "User DN Template": {
+    "translation": "用户 DN 模板",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        13
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        14
+      ]
+    ]
+  },
+  "User Name": {
+    "translation": "用户名",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/users/components/modals/LDAPUserFormModal.js",
+        95
+      ]
+    ]
+  },
+  "User Preferences": {
+    "translation": "用户首选项",
+    "origin": [
+      [
+        "src/js/pages/settings/UISettingsPage.js",
+        60
+      ]
+    ]
+  },
+  "User Search": {
+    "translation": "用户搜索",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        50
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
+        152
+      ]
+    ]
+  },
+  "User Search Base": {
+    "translation": "用户搜索基准",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        53
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        54
+      ]
+    ]
+  },
+  "User Search Filter Template": {
+    "translation": "用户搜索筛选模板",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        57
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/constants/FieldDefinitions.js",
+        58
+      ]
+    ]
+  },
+  "User {successMsg} added.": {
+    "translation": "已添加用户 {successMsg}。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/users/components/modals/LDAPUserFormModal.js",
+        128
+      ]
+    ]
+  },
+  "Username": {
+    "translation": "用户名",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth/components/LoginModal.js",
+        84
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/components/GroupMemberTable.js",
+        105
+      ]
+    ]
+  },
+  "Username and password do not match.": {
+    "translation": "用户名和密码不匹配。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth/components/LoginModal.js",
+        48
+      ]
+    ]
+  },
+  "Users": {
+    "translation": "用户",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/AccountDetailPage.js",
+        162
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/components/GroupDetailPage.js",
+        53
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/components/GroupDetailPage.js",
+        275
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/users/components/UserDetailPage.js",
+        142
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/users/pages/UsersPage.js",
+        39
+      ],
+      [
+        "src/js/pages/system/OrganizationTab.js",
+        55
+      ],
+      [
+        "src/js/pages/system/UsersPage.js",
+        27
+      ],
+      [
+        "src/js/pages/system/UsersPage.js",
+        125
+      ]
+    ]
+  },
+  "Using {activeResource}/{0}": {
+    "translation": "使用 {activeResource}/{0}",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/pod-instances/PodInstancesTable.js",
+        455
+      ]
+    ]
+  },
+  "VIP": {
+    "translation": "VIP",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-connection/SDKServiceConnectionEndpointList.js",
+        83
+      ]
+    ]
+  },
+  "Value": {
+    "translation": "值",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/AdvancedConstraintsSection.js",
+        21
+      ],
+      [
+        ".dcos-ui-plugins-private/placement/components/PlacementConstraintsFields.js",
+        88
+      ],
+      [
+        ".dcos-ui-plugins-private/secrets/components/SecretFormModal.js",
+        238
+      ],
+      [
+        "plugins/services/src/js/components/forms/EnvironmentFormSection.js",
+        47
+      ],
+      [
+        "plugins/services/src/js/components/forms/EnvironmentFormSection.js",
+        121
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodEnvironmentVariablesConfigSection.js",
+        24
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodLabelsConfigSection.js",
+        26
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodPlacementConstraintsConfigSection.js",
+        30
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceEnvironmentVariablesConfigSection.js",
+        65
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceLabelsConfigSection.js",
+        59
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServicePlacementConstraintsConfigSection.js",
+        29
+      ],
+      [
+        "src/js/components/PlacementConstraintsPartial.js",
+        88
+      ]
+    ]
+  },
+  "Variable name": {
+    "translation": "变量名称",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/ServiceCreate.js",
+        27
+      ]
+    ]
+  },
+  "Version": {
+    "translation": "版本",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/LeaderGrid.js",
+        49
+      ],
+      [
+        "plugins/services/src/js/components/MarathonTaskDetailsList.js",
+        96
+      ],
+      [
+        "plugins/services/src/js/constants/PodTableHeaderLabels.js",
+        13
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceTableHeaderLabels.js",
+        10
+      ],
+      [
+        "plugins/services/src/js/constants/TaskTableHeaderLabels.js",
+        16
+      ],
+      [
+        "plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js",
+        111
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js",
+        243
+      ],
+      [
+        "src/js/pages/system/OverviewDetailTab.js",
+        294
+      ]
+    ]
+  },
+  "View All ({authProviderCount})": {
+    "translation": "查看全部 ({authProviderCount})",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/components/LoginModalProviders.js",
+        96
+      ]
+    ]
+  },
+  "View Cluster Configuration": {
+    "translation": "查看集群配置",
+    "origin": [
+      [
+        "src/js/pages/system/OverviewDetailTab.js",
+        213
+      ]
+    ]
+  },
+  "View Documentation": {
+    "translation": "查看文档",
+    "origin": [
+      [
+        "src/js/pages/system/units-health-node-detail/NodeInfoPanel.js",
+        30
+      ]
+    ]
+  },
+  "View Services": {
+    "translation": "查看服务",
+    "origin": [
+      [
+        "plugins/services/src/js/components/ServiceItemNotFound.js",
+        13
+      ]
+    ]
+  },
+  "View all {componentCount} {componentCountWord}": {
+    "translation": "查看全部 {componentCount} {componentCountWord}",
+    "origin": [
+      [
+        "src/js/pages/DashboardPage.js",
+        142
+      ]
+    ]
+  },
+  "View all {servicesCount} Services": {
+    "translation": "查看全部 {servicesCount} 服务",
+    "origin": [
+      [
+        "src/js/pages/DashboardPage.js",
+        164
+      ]
+    ]
+  },
+  "Virtual Network: {0}": {
+    "translation": "虚拟网络：{0}",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js",
+        536
+      ],
+      [
+        "plugins/services/src/js/components/forms/NetworkingFormSection.js",
+        560
+      ]
+    ]
+  },
+  "Volume": {
+    "translation": "卷",
+    "origin": [
+      [
+        "plugins/services/src/js/service-configuration/PodStorageConfigSection.js",
+        24
+      ]
+    ]
+  },
+  "Volume '{volumeId}' was not found.": {
+    "translation": "未找到卷 '{volumeId}'。",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/volume-detail/PodVolumeContainer.js",
+        79
+      ],
+      [
+        "plugins/services/src/js/containers/volume-detail/ServiceVolumeContainer.js",
+        79
+      ],
+      [
+        "plugins/services/src/js/containers/volume-detail/TaskVolumeContainer.js",
+        80
+      ]
+    ]
+  },
+  "Volume Name": {
+    "translation": "卷名称",
+    "origin": [
+      [
+        "plugins/services/src/js/components/PodVolumeTable.js",
+        70
+      ]
+    ]
+  },
+  "Volume Profile": {
+    "translation": "卷配置文件",
+    "origin": [
+      [
+        "plugins/services/src/js/components/PodVolumeTable.js",
+        69
+      ],
+      [
+        "plugins/services/src/js/components/VolumeTable.js",
+        68
+      ]
+    ]
+  },
+  "Volume Type": {
+    "translation": "卷类型",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/dss/components/DSSInput.js",
+        92
+      ],
+      [
+        ".dcos-ui-plugins-private/dss/components/DSSVolumeConfig.js",
+        44
+      ],
+      [
+        "plugins/services/src/js/components/PodVolumeTable.js",
+        68
+      ],
+      [
+        "plugins/services/src/js/components/VolumeTable.js",
+        67
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js",
+        137
+      ],
+      [
+        "plugins/services/src/js/components/forms/VolumesFormSection.js",
+        347
+      ]
+    ]
+  },
+  "Volume container path": {
+    "translation": "卷容器路径",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        30
+      ]
+    ]
+  },
+  "Volume host path": {
+    "translation": "卷主机路径",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        38
+      ]
+    ]
+  },
+  "Volume mode": {
+    "translation": "卷模式",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        42
+      ]
+    ]
+  },
+  "Volume size": {
+    "translation": "卷大小",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceErrorPathMapping.js",
+        34
+      ]
+    ]
+  },
+  "Volumes": {
+    "translation": "卷",
+    "origin": [
+      [
+        "plugins/services/src/js/components/dsl/ServiceOtherDSLSection.js",
+        68
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js",
+        280
+      ],
+      [
+        "plugins/services/src/js/components/forms/VolumesFormSection.js",
+        426
+      ],
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModalForm.js",
+        489
+      ],
+      [
+        "plugins/services/src/js/components/modals/CreateServiceModalForm.js",
+        505
+      ],
+      [
+        "plugins/services/src/js/constants/ServiceOtherLabels.js",
+        5
+      ],
+      [
+        "plugins/services/src/js/containers/pod-detail/PodDetail.js",
+        214
+      ],
+      [
+        "plugins/services/src/js/containers/service-detail/ServiceDetail.js",
+        247
+      ],
+      [
+        "plugins/services/src/js/service-configuration/PodStorageConfigSection.js",
+        143
+      ],
+      [
+        "plugins/services/src/js/service-configuration/ServiceStorageConfigSection.js",
+        65
+      ]
+    ]
+  },
+  "Waiting": {
+    "translation": "正在等待",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/ServiceStatusLabels.js",
+        9
+      ]
+    ]
+  },
+  "Warning": {
+    "translation": "警告",
+    "origin": [
+      [
+        "src/js/components/FrameworkConfigurationForm.js",
+        333
+      ],
+      [
+        "src/js/constants/UnitHealthStatus.js",
+        32
+      ]
+    ]
+  },
+  "Warning:": {
+    "translation": "警告：",
+    "origin": [
+      [
+        "src/js/components/FrameworkConfiguration.js",
+        240
+      ]
+    ]
+  },
+  "We are unable to retrieve the version {0} versions. Please try again.": {
+    "translation": "我们无法检索版本中的版本 {0}。请重试。",
+    "origin": [
+      [
+        "src/js/components/Modals.js",
+        116
+      ]
+    ]
+  },
+  "When you attempt to deploy a service, DC/OS waits for offers to match the resources your service requires. If the offer does not satisfy the requirement, it is declined and DC/OS retries. <0>Learn more</0>.": {
+    "translation": "当您尝试部署服务时，DC/OS 等待 offer，以匹配您的服务所需的资源。如果 offer 不能满足要求，则会被拒绝，而 DC/OS 会进行重试。<0>了解更多</0>.",
+    "origin": [
+      [
+        "plugins/services/src/js/constants/DeclinedOffersHelpText.js",
+        12
+      ]
+    ]
+  },
+  "With Latest Config": {
+    "translation": "附带最新配置",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-debug/TaskStatsTable.js",
+        17
+      ]
+    ]
+  },
+  "With Outdated Config": {
+    "translation": "附带过时配置",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/service-debug/TaskStatsTable.js",
+        18
+      ]
+    ]
+  },
+  "Working Directory": {
+    "translation": "工作目录",
+    "origin": [
+      [
+        "plugins/services/src/js/pages/task-details/TaskDetail.js",
+        306
+      ]
+    ]
+  },
+  "You are about to stop the job run with id": {
+    "translation": "您即将停止附带 ID 的作业运行",
+    "origin": [
+      [
+        "src/js/components/modals/JobStopRunModal.js",
+        72
+      ]
+    ]
+  },
+  "You are about to stop the selected job runs.": {
+    "translation": "您即将停止所选作业运行。",
+    "origin": [
+      [
+        "src/js/components/modals/JobStopRunModal.js",
+        74
+      ]
+    ]
+  },
+  "You are about to {0} {instanceCountContent}. Are you sure you want to continue?": {
+    "translation": "您即将 {0} {instanceCountContent}。确定要继续吗？",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/KillPodInstanceModal.js",
+        100
+      ]
+    ]
+  },
+  "You are about to {0} {taskCountContent}. Are you sure you want to continue?": {
+    "translation": "您即将 {0} {taskCountContent}。确定要继续吗？",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/KillTaskModal.js",
+        99
+      ]
+    ]
+  },
+  "You can also join us on our <0>Slack channel</0> or send us an email at <1>{0}</1>.": {
+    "translation": "您也可以通过 <0>Slack channel</0> 加入我们或发送电子邮件至 <1>{0}</1>.",
+    "origin": [
+      [
+        "src/js/components/RequestErrorMsg.js",
+        12
+      ]
+    ]
+  },
+  "You can configure the placement of agent nodes in regions and zones for high availability or to expand capacity to new regions when necessary": {
+    "translation": "您可以配置区域和区中代理节点的放置以实现高可用性，或在必要时将容量扩展到新区域",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/PlacementSection.js",
+        25
+      ]
+    ]
+  },
+  "You can go to the <0>Repositories Settings</0> page to change installed repositories.": {
+    "translation": "您可以转到 <0>存储库设置</0> 页面，来更改已安装的存储库。",
+    "origin": [
+      [
+        "src/js/components/CosmosErrorMessage.js",
+        102
+      ]
+    ]
+  },
+  "You can link a cluster via the DC/OS CLI. See {documentation} for complete instructions.": {
+    "translation": "您可以通过 DC/OS CLI 链接集群。参见 {documentation}，以获取完整说明。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/cluster-linking/pages/LinkedClustersPage.js",
+        45
+      ]
+    ]
+  },
+  "You can run Docker containers with both container runtimes. The Universal Container Runtime (UCR) is better supported in DC/OS. <0>More information</0>.": {
+    "translation": "您可以使用两个容器运行时运行 Docker 容器。DC/OS 支持通用容器运行时 (UCR)。<0>更多信息</0>.",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/GeneralServiceFormSection.js",
+        196
+      ]
+    ]
+  },
+  "You do not have access to this resource. Please contact your {0} administrator or see <0>security documentation</0> for more information.": {
+    "translation": "您无权访问此资源。请联系您的 {0} 管理员或查看 <0>安全文档，</0> 以获取更多信息。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth/hooks.js",
+        181
+      ]
+    ]
+  },
+  "You do not have access to this service. Please contact your {0} administrator or see <0>security documentation</0> for more information.": {
+    "translation": "您无权访问此服务。请联系您的 {0} 管理员或查看 <0>安全文档，</0> 以获取更多信息。",
+    "origin": [
+      [
+        "src/js/components/AccessDeniedPage.js",
+        47
+      ]
+    ]
+  },
+  "You do not have permission to": {
+    "translation": "您没有权限来",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/SecretFormModal.js",
+        112
+      ]
+    ]
+  },
+  "You do not have permission to list this cluster's secrets.<0/>Please contact your super admin to learn more.": {
+    "translation": "您没有列出此集群密钥的权限。<0/>请联系您的超级管理员，以了解更多信息。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/pages/SecretsPage.js",
+        67
+      ]
+    ]
+  },
+  "You do not have permission to see this secret.<0/>Please contact your super admin to learn more.": {
+    "translation": "您没有查看此密钥的权限。<0/>请联系您的超级管理员，以了解更多信息。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/pages/SecretDetail.js",
+        66
+      ]
+    ]
+  },
+  "You have": {
+    "translation": "您已",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/licensing/components/LicensingBanner.js",
+        79
+      ]
+    ]
+  },
+  "You have exceeded your {capacity} node licensed count. You have exceeded on 1 occasion": {
+    "translation": "您已超过 {capacity} 节点许可计数。您已超过 1 次",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/licensing/components/LicensingBanner.js",
+        55
+      ]
+    ]
+  },
+  "You have exceeded your {capacity} node licensed count. You have exceeded on {numberBreaches} occasions": {
+    "translation": "您已超过 {capacity} 节点许可计数。您已超过{numberBreaches} 次",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/licensing/components/LicensingBanner.js",
+        60
+      ]
+    ]
+  },
+  "You have several protocol options. <0>More Information</0>.": {
+    "translation": "您有几个协议选项。<0>更多信息</0>.",
+    "origin": [
+      [
+        "plugins/services/src/js/components/forms/HealthChecksFormSection.js",
+        428
+      ],
+      [
+        "plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js",
+        393
+      ]
+    ]
+  },
+  "You need at least one package repository with some packages to be able to install packages. For more <0>information on repositories</0>.": {
+    "translation": "您至少需要一个含有一些包的包存储库，才能安装包。获取更多 <0>有关存储库的信息</0>.",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackagesTab.js",
+        51
+      ]
+    ]
+  },
+  "Zone": {
+    "translation": "区",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/NodesTable.tsx",
+        90
+      ],
+      [
+        "plugins/nodes/src/js/pages/nodes/NodeDetailTab.js",
+        111
+      ],
+      [
+        "plugins/services/src/js/constants/PodTableHeaderLabels.js",
+        6
+      ],
+      [
+        "plugins/services/src/js/constants/TaskTableHeaderLabels.js",
+        8
+      ],
+      [
+        "plugins/services/src/js/pages/task-details/TaskDetailsTab.js",
+        134
+      ]
+    ]
+  },
+  "Zones": {
+    "translation": "区",
+    "origin": [
+      [
+        "plugins/nodes/src/js/components/dsl/NodesZoneDSLFilter.js",
+        47
+      ],
+      [
+        "plugins/services/src/js/components/dsl/TaskZoneDSLSection.js",
+        47
+      ]
+    ]
+  },
+  "and": {
+    "translation": "和",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/licensing/components/LicensingBanner.js",
+        85
+      ]
+    ]
+  },
+  "by {mesosBuildUser}": {
+    "translation": "{mesosBuildUser} 天",
+    "origin": [
+      [
+        "src/js/pages/system/OverviewDetailTab.js",
+        245
+      ]
+    ]
+  },
+  "days left": {
+    "translation": "剩余天数",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/licensing/components/LicensingExpirationRow.js",
+        59
+      ]
+    ]
+  },
+  "days overdue": {
+    "translation": "逾期天数",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/licensing/components/LicensingExpirationRow.js",
+        56
+      ]
+    ]
+  },
+  "deployment": {
+    "translation": "部署",
+    "origin": [
+      [
+        "plugins/services/src/js/components/DeploymentStatusIndicator.js",
+        64
+      ]
+    ]
+  },
+  "deployments": {
+    "translation": "部署",
+    "origin": [
+      [
+        "plugins/services/src/js/components/DeploymentStatusIndicator.js",
+        64
+      ]
+    ]
+  },
+  "did not match": {
+    "translation": "不匹配",
+    "origin": [
+      [
+        "plugins/services/src/js/components/RecentOffersSummary.js",
+        111
+      ]
+    ]
+  },
+  "documentation": {
+    "translation": "文档",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/cluster-linking/pages/LinkedClustersPage.js",
+        41
+      ]
+    ]
+  },
+  "exceeded license expiration by one day": {
+    "translation": "超过许可证到期日 1 天",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/licensing/components/LicensingBanner.js",
+        69
+      ]
+    ]
+  },
+  "exceeded license expiration by {daysExceeded} days": {
+    "translation": "超过许可证到期日{daysExceeded} 天",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/licensing/components/LicensingBanner.js",
+        71
+      ]
+    ]
+  },
+  "group will be deleted": {
+    "translation": "组将被删除",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/constants/BulkOptions.js",
+        27
+      ]
+    ]
+  },
+  "matched": {
+    "translation": "已匹配",
+    "origin": [
+      [
+        "plugins/services/src/js/components/RecentOffersSummary.js",
+        113
+      ]
+    ]
+  },
+  "or": {
+    "translation": "或",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/components/LoginModalProviders.js",
+        123
+      ]
+    ]
+  },
+  "partially matched": {
+    "translation": "部分匹配",
+    "origin": [
+      [
+        "plugins/services/src/js/components/RecentOffersSummary.js",
+        115
+      ]
+    ]
+  },
+  "resources": {
+    "translation": "资源",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/hooks.js",
+        436
+      ]
+    ]
+  },
+  "scaling each service to 0 instances": {
+    "translation": "将每个服务缩放到 0 个实例",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceActionDisabledModal.js",
+        309
+      ]
+    ]
+  },
+  "service account will be deleted": {
+    "translation": "服务帐户将被删除",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/constants/BulkOptions.js",
+        50
+      ]
+    ]
+  },
+  "system": {
+    "translation": "系统",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/hooks.js",
+        42
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/hooks.js",
+        32
+      ]
+    ]
+  },
+  "task": {
+    "translation": "任务",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/tasks/TasksView.js",
+        268
+      ]
+    ]
+  },
+  "this secret. Please contact your super admin to learn more.": {
+    "translation": "该密钥。请联系您的超级管理员，以了解更多信息。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/SecretFormModal.js",
+        116
+      ]
+    ]
+  },
+  "updating the number of instances of each service": {
+    "translation": "更新每个服务的实例数",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceActionDisabledModal.js",
+        313
+      ]
+    ]
+  },
+  "user will be deleted": {
+    "translation": "用户将被删除",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/constants/BulkOptions.js",
+        73
+      ]
+    ]
+  },
+  "will be deleted": {
+    "translation": "将被删除",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/AccountDetailPage.js",
+        191
+      ],
+      [
+        "src/js/constants/BulkOptions.js",
+        16
+      ]
+    ]
+  },
+  "your service's requirements ({requestedValue}).": {
+    "translation": "您服务的要求 ({requestedValue})。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/RecentOffersSummary.js",
+        135
+      ],
+      [
+        "plugins/services/src/js/components/RecentOffersSummary.js",
+        147
+      ],
+      [
+        "plugins/services/src/js/components/RecentOffersSummary.js",
+        159
+      ],
+      [
+        "plugins/services/src/js/components/RecentOffersSummary.js",
+        172
+      ],
+      [
+        "plugins/services/src/js/components/RecentOffersSummary.js",
+        184
+      ],
+      [
+        "plugins/services/src/js/components/RecentOffersSummary.js",
+        196
+      ]
+    ]
+  },
+  "your service's role ({requestedValue}).": {
+    "translation": "您服务的角色 ({requestedValue})。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/RecentOffersSummary.js",
+        123
+      ]
+    ]
+  },
+  "{0}": {
+    "translation": "{0}",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/cluster-linking/components/LinkedClustersTable.js",
+        66
+      ],
+      [
+        ".dcos-ui-plugins-private/dss/components/VolumeMountTypesSelect.js",
+        26
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
+        246
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
+        252
+      ]
+    ]
+  },
+  "{0} (Change)": {
+    "translation": "{0}（更改）",
+    "origin": [
+      [
+        "plugins/oauth/components/AuthenticatedUserAccountDropdown.js",
+        32
+      ]
+    ]
+  },
+  "{0} ({1} available)": {
+    "translation": "{0}（{1} 可用）",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerDetail.js",
+        351
+      ]
+    ]
+  },
+  "{0} Info": {
+    "translation": "{0} 信息",
+    "origin": [
+      [
+        "src/js/components/modals/VersionsModal.js",
+        31
+      ]
+    ]
+  },
+  "{0} Version": {
+    "translation": "{0} 版本",
+    "origin": [
+      [
+        "src/js/pages/system/OverviewDetailTab.js",
+        165
+      ]
+    ]
+  },
+  "{0} is being installed.": {
+    "translation": "{0} 正在安装。",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackageDetailTab.js",
+        407
+      ]
+    ]
+  },
+  "{0} will be deleted.": {
+    "translation": "{0} 将被删除。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerDetail.js",
+        212
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/VHostDetail.js",
+        184
+      ]
+    ]
+  },
+  "{0} your group by {updateDescription} from the DC/OS CLI.": {
+    "translation": "从  DC/OS CLI 通过{updateDescription} {0} 组",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/ServiceActionDisabledModal.js",
+        276
+      ]
+    ]
+  },
+  "{0} {packagesWord} found": {
+    "translation": "已找到 {0} {packagesWord}",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackagesTab.js",
+        250
+      ]
+    ]
+  },
+  "{agentsAvailable} of {agentsTotal}": {
+    "translation": "{agentsAvailable} 的 {agentsTotal}",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/LoadBalancersTable.js",
+        160
+      ]
+    ]
+  },
+  "{backendCount} Total Backends": {
+    "translation": "{backendCount} 总后端",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPDetailPage.js",
+        158
+      ]
+    ]
+  },
+  "{clientCount} Total Clients": {
+    "translation": "{clientCount} 总客户端",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/BackendDetailPage.js",
+        163
+      ]
+    ]
+  },
+  "{containerName} Path": {
+    "translation": "{containerName} 路径",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/volume-detail/PodVolumeDetail.js",
+        74
+      ]
+    ]
+  },
+  "{errorMsg} Go to <0>insert permission string</0> to enter a permission manually.": {
+    "translation": "{errorMsg} 转至 <0>插入权限字符串</0> 以手动输入权限。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/PermissionBuilderModal.js",
+        511
+      ]
+    ]
+  },
+  "{issueCount} issues need addressing": {
+    "translation": "{issueCount} 问题需要解决",
+    "origin": [
+      [
+        "src/js/components/FrameworkConfigurationForm.js",
+        102
+      ]
+    ]
+  },
+  "{itemType} is currently locked by one or more deployments. Press the button again to forcefully change and deploy the new configuration.": {
+    "translation": "{itemType} 当前被一个或多个部署锁定。再次按下按钮，以强制更改和部署新配置。",
+    "origin": [
+      [
+        "plugins/services/src/js/components/modals/AppLockedMessage.js",
+        22
+      ]
+    ]
+  },
+  "{logName} Log is Currently Empty": {
+    "translation": "{logName} 日志当前为空",
+    "origin": [
+      [
+        "plugins/services/src/js/components/EmptyLogScreen.js",
+        11
+      ]
+    ]
+  },
+  "{numBackends} Backends": {
+    "translation": "{numBackends} 后端",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/BackendsTable.js",
+        178
+      ]
+    ]
+  },
+  "{numClients} Clients": {
+    "translation": "{numClients} 客户端",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/ClientsTable.js",
+        109
+      ]
+    ]
+  },
+  "{runningInstances, plural, one {# instance running out of {instancesCount}} other {# instances running out of {instancesCount}}}": {
+    "translation": "{runningInstances, plural, one {# 实例将用完 {instancesCount}} other {# 实例将用完 {instancesCount}}}",
+    "origin": [
+      [
+        "plugins/services/src/js/components/ServiceBreadcrumbs.js",
+        145
+      ],
+      [
+        "plugins/services/src/js/components/ServiceList.js",
+        54
+      ]
+    ]
+  },
+  "{runningInstances} {0} running out of {instancesCount}": {
+    "translation": "{runningInstances} {0} 将用完 {instancesCount}",
+    "origin": [
+      [
+        "plugins/services/src/js/containers/services/ServicesTable.js",
+        386
+      ],
+      [
+        "plugins/services/src/js/containers/services/ServicesTable.js",
+        453
+      ]
+    ]
+  },
+  "{userLabel} will be removed from the {groupLabel} group.": {
+    "translation": "{userLabel} 将从 {groupLabel} 组移除。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/components/GroupMemberTable.js",
+        149
+      ]
+    ]
+  },
+  "{userName} will be removed from {groupLabel}.": {
+    "translation": "{userName} 将从 {groupLabel} 移除。",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/AccountGroupTable.js",
+        131
+      ]
+    ]
+  },
+  "{watching} out of {totalFound}": {
+    "translation": "{watching} 用完 {totalFound}",
+    "origin": [
+      [
+        "plugins/services/src/js/components/SearchLog.js",
+        112
+      ]
+    ]
+  }
+}

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -9,6 +9,7 @@ import { Provider } from "react-redux";
 import PluginSDK from "PluginSDK";
 
 import en from "#LOCALE/en/messages.js";
+import zh from "#LOCALE/zh/messages.js";
 
 // Load in our CSS.
 // TODO - DCOS-6452 - remove component @imports from index.less and
@@ -94,7 +95,7 @@ RequestUtil.json = function(options = {}) {
             <I18nProvider
               defaultRender="span"
               language={UserLanguageStore.get()}
-              catalogs={{ en }}
+              catalogs={{ en, zh }}
             >
               <Router history={hashHistory} routes={routes} />
             </I18nProvider>


### PR DESCRIPTION
## Testing

- Before starting, run `npx lingui compile`
- Switch to chinese locale in profile menu or UI settings

## Trade-offs

Including in the webpack build is probably not a good idea because each catalog is quite large (100 KB minified). Asynchronous loading can be added separately.

## Screenshots

<img width="451" alt="screen shot 2018-11-14 at 8 04 10 pm" src="https://user-images.githubusercontent.com/174332/48527874-d0509a00-e849-11e8-938c-a1b5d0b3bd00.png">
<img width="1508" alt="screen shot 2018-11-14 at 8 04 31 pm" src="https://user-images.githubusercontent.com/174332/48527875-d0509a00-e849-11e8-8ac8-559bf6c92fe9.png">
