### PR TITLE
DCOS_OSS-4509: 1.13 CLI URL in the UI is broken

### DIFF
--- a/src/js/components/modals/CliInstallModal.js
+++ b/src/js/components/modals/CliInstallModal.js
@@ -56,10 +56,6 @@ class CliInstallModal extends React.Component {
   }
 
   getCliInstructions() {
-    // TODO (DCOS-8495): Binary cli links have hardcoded version, these should
-    // be updated to a /latest endpoint, when that becomes available.
-    // Binary cli links are also all pointing to the open version, which is
-    // intentional.
     const hostname = global.location.hostname;
     const protocol = global.location.protocol.replace(/[^\w]/g, "");
     let port = "";
@@ -68,14 +64,16 @@ class CliInstallModal extends React.Component {
     }
     const clusterUrl = `${protocol}://${hostname}${port}`;
     const { selectedOS } = this.state;
-    let version = MetadataStore.parsedVersion;
-    // Prepend 'dcos-' to any version other than latest
-    if (version !== "latest") {
-      version = `dcos-${version}`;
-    }
-    const downloadUrl = `https://downloads.dcos.io/binaries/cli/${
-      osTypes[selectedOS]
-    }/x86-64/${version}/dcos`;
+
+    const downloadUrl =
+      MetadataStore.version && !MetadataStore.version.includes("-dev")
+        ? `https://downloads.dcos.io/cli/releases/binaries/dcos/${
+            osTypes[selectedOS]
+          }/x86-64/latest/dcos`
+        : `https://downloads.dcos.io/cli/testing/binaries/dcos/${
+            osTypes[selectedOS]
+          }/x86-64/master/dcos`;
+
     if (selectedOS === "Windows") {
       return this.getWindowsInstallInstruction(clusterUrl, downloadUrl);
     }


### PR DESCRIPTION
It currently points to a deprecated URL format we don't publish to
(starting from 1.13).

Eventually it will be replaced by a "latest" URL, but for now as DC/OS
1.13 is still in development we'll use the testing/master URL (the
latest commit).

https://jira.mesosphere.com/browse/DCOS_OSS-4509