### PR TITLE
[1.12] DCOS-45494: fix truncated columns on DeclinedOffersTable

### DIFF
--- a/plugins/services/src/js/components/DeclinedOffersTable.js
+++ b/plugins/services/src/js/components/DeclinedOffersTable.js
@@ -157,15 +157,16 @@ class DeclinedOffersTable extends React.Component {
   getColGroup() {
     return (
       <colgroup>
+        <col style={{ width: "135px" }} />
+        <col style={{ width: "9%" }} />
+        <col style={{ width: "15%" }} />
         <col />
-        <col style={{ width: "10%" }} />
-        <col style={{ width: "10%" }} />
-        <col className="hidden-large-up" style={{ width: "30%" }} />
-        <col className="hidden-medium-down" style={{ width: "10%" }} />
-        <col className="hidden-medium-down" style={{ width: "10%" }} />
-        <col className="hidden-medium-down" style={{ width: "10%" }} />
-        <col style={{ width: "10%" }} />
-        <col className="hidden-small-down" />
+        <col className="hidden-large-up" style={{ width: "9%" }} />
+        <col className="hidden-medium-down" style={{ width: "9%" }} />
+        <col className="hidden-medium-down" style={{ width: "9%" }} />
+        <col className="hidden-medium-down" style={{ width: "9%" }} />
+        <col />
+        <col className="hidden-small-down" style={{ width: "15%" }} />
       </colgroup>
     );
   }
@@ -181,9 +182,14 @@ class DeclinedOffersTable extends React.Component {
           const node = MesosStateStore.getNodeFromHostname(hostname);
 
           return (
-            <Link className="table-cell-link-primary" to={`/nodes/${node.id}`}>
-              {hostname}
-            </Link>
+            <Tooltip content={hostname} maxWidth={400} wrapText={true}>
+              <Link
+                className="table-cell-link-primary"
+                to={`/nodes/${node.id}`}
+              >
+                {hostname}
+              </Link>
+            </Tooltip>
           );
         },
         sortable: true


### PR DESCRIPTION
[COPS ticket](https://jira.mesosphere.com/browse/COPS-4160) reported that the Host IP addresses were being truncated, but the Constraint header as well as the Received content was also being truncated. Fix Host, Constraint, and Received columns which were being truncated with content cut off. Added a tooltip to the Host column.

Closes DCOS-45494.

## Testing

- Use a 1.12 soak cluster and go to Services 
- Choose a pod that's deploying 
- Debug tab 
- Look at table under Recent Resource Offers > Details and check that above mentioned columns are not truncated

## Trade-offs

None that I'm aware of

## Dependencies

None

## Screenshots

Before
<img width="1006" alt="screen shot 2018-11-22 at 1 29 49 pm" src="https://user-images.githubusercontent.com/19582796/48922560-5e391000-ee5c-11e8-906b-0fb507d4aa2e.png">

After
<img width="1008" alt="screen shot 2018-11-22 at 1 25 08 pm" src="https://user-images.githubusercontent.com/19582796/48922567-65601e00-ee5c-11e8-95a6-f6dcf6ffc4c7.png">

