### PR TITLE
DCOS-45393: Add GPU to Nodes Detail Page

### DIFF
--- a/plugins/nodes/src/js/pages/nodes/NodeDetailTab.js
+++ b/plugins/nodes/src/js/pages/nodes/NodeDetailTab.js
@@ -144,6 +144,14 @@ class NodeDetailTab extends PureComponent {
                 {Units.formatResource("cpus", resources.cpus)}
               </ConfigurationMapValue>
             </ConfigurationMapRow>
+            <ConfigurationMapRow>
+              <ConfigurationMapLabel>
+                <Trans render="span">GPUs</Trans>
+              </ConfigurationMapLabel>
+              <ConfigurationMapValue>
+                {Units.formatResource("gpus", resources.gpus)}
+              </ConfigurationMapValue>
+            </ConfigurationMapRow>
           </ConfigurationMapSection>
         </ConfigurationMap>
       </div>


### PR DESCRIPTION
Added GPU information to the node detail tab table.

Closes DCOS-45393

## Testing
Go to Nodes tab.
Click a node.
Open the Details tab.
Verify that the GPU row is there.

## Trade-offs
Unless I am missing something, I think this should be a 1-story point ticket.

## Dependencies
None.

## Screenshots

### Before
![screenshot from 2018-11-23 11-46-45](https://user-images.githubusercontent.com/40791275/48937492-f72c6180-ef16-11e8-9032-24560ee50c35.png)

### After
![screenshot from 2018-11-23 11-47-05](https://user-images.githubusercontent.com/40791275/48937500-fabfe880-ef16-11e8-8bfa-1e8acdaecbe8.png)
