### PR TITLE
DCOS-43620: Fully support scheduling in pods

### DIFF
--- a/plugins/services/src/js/reducers/JSONMultiContainerParser.js
+++ b/plugins/services/src/js/reducers/JSONMultiContainerParser.js
@@ -1,4 +1,6 @@
 import { simpleParser } from "#SRC/js/utils/ParserUtil";
+import Transaction from "#SRC/js/structs/Transaction";
+import Util from "#SRC/js/utils/Util";
 
 import { JSONParser as constraints } from "./serviceForm/MultiContainerConstraints";
 import { JSONParser as fetch } from "./serviceForm/JSONReducers/Artifacts";
@@ -23,6 +25,17 @@ module.exports = [
   simpleParser(["disk"]),
   simpleParser(["gpus"]),
   simpleParser(["cmd"]),
+  function scheduling(state) {
+    if (state == null) {
+      return [];
+    }
+
+    if (state.scheduling == null) {
+      return [];
+    }
+
+    return new Transaction(["scheduling"], Util.deepCopy(state.scheduling));
+  },
   constraints,
   containers,
   environmentVariables,

--- a/plugins/services/src/js/reducers/JSONMultiContainerParser.js
+++ b/plugins/services/src/js/reducers/JSONMultiContainerParser.js
@@ -26,11 +26,7 @@ module.exports = [
   simpleParser(["gpus"]),
   simpleParser(["cmd"]),
   function scheduling(state) {
-    if (state == null) {
-      return [];
-    }
-
-    if (state.scheduling == null) {
+    if (state == null || state.scheduling == null) {
       return [];
     }
 

--- a/plugins/services/src/js/reducers/JSONMultiContainerReducers.js
+++ b/plugins/services/src/js/reducers/JSONMultiContainerReducers.js
@@ -1,4 +1,5 @@
 import { simpleReducer } from "#SRC/js/utils/ReducerUtil";
+import Util from "#SRC/js/utils/Util";
 
 import { JSONReducer as constraints } from "./serviceForm/MultiContainerConstraints";
 import { JSONReducer as containers } from "./serviceForm/JSONReducers/Containers";
@@ -16,13 +17,24 @@ module.exports = {
   environment,
   scaling,
   labels,
-  scheduling(state = { placement: { constraints: [] } }, transaction) {
+  scheduling(state, transaction) {
+    if (state == null) {
+      return {};
+    }
+
+    const { path, value } = transaction;
+    const joinedPath = path.join(".");
+
+    const scheduling =
+      joinedPath === "scheduling" ? Util.deepCopy(value) : state;
+
     const constraintsState =
       state != null && state.placement != null
         ? state.placement.constraints
         : [];
 
     return {
+      ...scheduling,
       residency: residency.bind(this)(state.residency, transaction),
       placement: {
         constraints: constraints.bind(this)(constraintsState, transaction)

--- a/plugins/services/src/js/reducers/__tests__/JSONMultiContainer-test.js
+++ b/plugins/services/src/js/reducers/__tests__/JSONMultiContainer-test.js
@@ -77,6 +77,20 @@ describe("JSONMultiContainer", function() {
         scheduling: {
           placement: {
             constraints: [{ fieldName: "hostname", operator: "UNIQUE" }]
+          },
+          backoff: {
+            backoff: 1,
+            backoffFactor: 1.15,
+            maxLaunchDelay: 30
+          },
+          upgrade: {
+            minimumHealthCapacity: 1,
+            maximumOverCapacity: 1
+          },
+          killSelection: "YOUNGEST_FIRST",
+          unreachableStrategy: {
+            inactiveAfterSeconds: 0,
+            expungeAfterSeconds: 0
           }
         }
       };


### PR DESCRIPTION
Closes DCOS-43620

## Testing

1. Create a pod.
2. Add/modify it's `scheduling` field
```js
scheduling: {
  placement: {
    constraints: [{ fieldName: "hostname", operator: "UNIQUE" }]
  },
  backoff: {
    backoff: 1,
    backoffFactor: 1.15,
    maxLaunchDelay: 30
  },
  upgrade: {
    minimumHealthCapacity: 1,
    maximumOverCapacity: 1
  },
  killSelection: "YOUNGEST_FIRST",
  unreachableStrategy: {
    inactiveAfterSeconds: 0,
    expungeAfterSeconds: 0
  }
}
```
3. Verify that the form doesn't truncate the scheduling definition.

## Trade-offs

in line parser/reducer otherwise I'd write it in TS. Please tell me if I should.