### PR TITLE
DCOS-41719: localize dates

### DIFF
--- a/plugins/jobs/src/js/components/JobsOverviewTable.js
+++ b/plugins/jobs/src/js/components/JobsOverviewTable.js
@@ -1,4 +1,4 @@
-import { Trans } from "@lingui/macro";
+import { Trans, DateFormat } from "@lingui/macro";
 import classNames from "classnames";
 import { Link } from "react-router";
 import prettycron from "prettycron";
@@ -249,7 +249,17 @@ export default class JobsOverviewTable extends React.Component {
           <Trans render="span" className="text-success">
             Last Success:
           </Trans>{" "}
-          {new Date(lastSuccessAt).toLocaleString()}
+          <DateFormat
+            value={new Date(lastSuccessAt)}
+            format={{
+              year: "numeric",
+              month: "numeric",
+              day: "numeric",
+              hour: "numeric",
+              minute: "numeric",
+              second: "numeric"
+            }}
+          />
         </p>
       );
     }
@@ -260,7 +270,17 @@ export default class JobsOverviewTable extends React.Component {
           <Trans render="span" className="text-danger">
             Last Failure:
           </Trans>{" "}
-          {new Date(lastFailureAt).toLocaleString()}
+          <DateFormat
+            value={new Date(lastFailureAt)}
+            format={{
+              year: "numeric",
+              month: "numeric",
+              day: "numeric",
+              hour: "numeric",
+              minute: "numeric",
+              second: "numeric"
+            }}
+          />
         </p>
       );
     }

--- a/plugins/jobs/src/js/components/JobsOverviewTable.js
+++ b/plugins/jobs/src/js/components/JobsOverviewTable.js
@@ -9,6 +9,7 @@ import { Table, Tooltip } from "reactjs-components";
 import Icon from "#SRC/js/components/Icon";
 import ResourceTableUtil from "#SRC/js/utils/ResourceTableUtil";
 import TableUtil from "#SRC/js/utils/TableUtil";
+import DateUtil from "#SRC/js/utils/DateUtil";
 
 import JobStates from "../constants/JobStates";
 import JobStatus from "../constants/JobStatus";
@@ -251,14 +252,7 @@ export default class JobsOverviewTable extends React.Component {
           </Trans>{" "}
           <DateFormat
             value={new Date(lastSuccessAt)}
-            format={{
-              year: "numeric",
-              month: "numeric",
-              day: "numeric",
-              hour: "numeric",
-              minute: "numeric",
-              second: "numeric"
-            }}
+            format={DateUtil.getFormatOptions()}
           />
         </p>
       );
@@ -272,14 +266,7 @@ export default class JobsOverviewTable extends React.Component {
           </Trans>{" "}
           <DateFormat
             value={new Date(lastFailureAt)}
-            format={{
-              year: "numeric",
-              month: "numeric",
-              day: "numeric",
-              hour: "numeric",
-              minute: "numeric",
-              second: "numeric"
-            }}
+            format={DateUtil.getFormatOptions()}
           />
         </p>
       );

--- a/plugins/jobs/src/js/pages/JobRunHistoryTable.js
+++ b/plugins/jobs/src/js/pages/JobRunHistoryTable.js
@@ -331,12 +331,14 @@ class JobRunHistoryTable extends React.Component {
     if (time == null) {
       return <Trans render="div">N/A</Trans>;
     }
+    // L10NTODO: Relative time
     const runTimeFormat = moment.duration(time).humanize();
 
     return <div>{runTimeFormat}</div>;
   }
 
   renderTimeColumn(prop, row) {
+    // L10NTODO: Relative time
     return <TimeAgo time={row[prop]} autoUpdate={false} />;
   }
 

--- a/plugins/nodes/src/js/components/LeaderGrid.js
+++ b/plugins/nodes/src/js/components/LeaderGrid.js
@@ -9,7 +9,7 @@ import ConfigurationMapRow from "#SRC/js/components/ConfigurationMapRow";
 import ConfigurationMapSection from "#SRC/js/components/ConfigurationMapSection";
 import ConfigurationMapValue from "#SRC/js/components/ConfigurationMapValue";
 import Loader from "#SRC/js/components/Loader";
-import { msToRelativeTime } from "#SRC/js/utils/DateUtil";
+import DateUtil from "#SRC/js/utils/DateUtil";
 
 const Loading = () => <Loader size="small" type="ballBeat" />;
 
@@ -56,17 +56,11 @@ export default function LeaderGrid({ leader }) {
             title={<Trans render="span">Started</Trans>}
             value={
               <ToggleContent
-                contentOn={msToRelativeTime(leader.startTime * 1000)}
+                contentOn={DateUtil.msToRelativeTime(leader.startTime * 1000)}
                 contentOff={
                   <DateFormat
                     value={new Date(leader.startTime * 1000)}
-                    format={{
-                      day: "numeric",
-                      month: "long",
-                      year: "numeric",
-                      hour: "numeric",
-                      minute: "numeric"
-                    }}
+                    format={DateUtil.getFormatOptions("longMonthDateTime")}
                   />
                 }
               />
@@ -79,17 +73,11 @@ export default function LeaderGrid({ leader }) {
             title={<Trans render="span">Elected</Trans>}
             value={
               <ToggleContent
-                contentOn={msToRelativeTime(leader.electedTime * 1000)}
+                contentOn={DateUtil.msToRelativeTime(leader.electedTime * 1000)}
                 contentOff={
                   <DateFormat
                     value={new Date(leader.electedTime * 1000)}
-                    format={{
-                      day: "numeric",
-                      month: "long",
-                      year: "numeric",
-                      hour: "numeric",
-                      minute: "numeric"
-                    }}
+                    format={DateUtil.getFormatOptions("longMonthDateTime")}
                   />
                 }
               />

--- a/plugins/nodes/src/js/components/LeaderGrid.js
+++ b/plugins/nodes/src/js/components/LeaderGrid.js
@@ -1,4 +1,4 @@
-import { Trans } from "@lingui/macro";
+import { Trans, DateFormat } from "@lingui/macro";
 import React from "react";
 import { ToggleContent } from "@dcos/ui-kit";
 
@@ -9,7 +9,7 @@ import ConfigurationMapRow from "#SRC/js/components/ConfigurationMapRow";
 import ConfigurationMapSection from "#SRC/js/components/ConfigurationMapSection";
 import ConfigurationMapValue from "#SRC/js/components/ConfigurationMapValue";
 import Loader from "#SRC/js/components/Loader";
-import { msToRelativeTime, msToDateStr } from "#SRC/js/utils/DateUtil";
+import { msToRelativeTime } from "#SRC/js/utils/DateUtil";
 
 const Loading = () => <Loader size="small" type="ballBeat" />;
 
@@ -50,24 +50,48 @@ export default function LeaderGrid({ leader }) {
             value={leader.version}
           />
 
+          {/* L10NTODO: Relative time */}
           <ConfigurationRow
             keyValue="started"
             title={<Trans render="span">Started</Trans>}
             value={
               <ToggleContent
                 contentOn={msToRelativeTime(leader.startTime * 1000)}
-                contentOff={msToDateStr(leader.startTime * 1000)}
+                contentOff={
+                  <DateFormat
+                    value={new Date(leader.startTime * 1000)}
+                    format={{
+                      day: "numeric",
+                      month: "long",
+                      year: "numeric",
+                      hour: "numeric",
+                      minute: "numeric"
+                    }}
+                  />
+                }
               />
             }
           />
 
+          {/* L10NTODO: Relative time */}
           <ConfigurationRow
             keyValue="elected"
             title={<Trans render="span">Elected</Trans>}
             value={
               <ToggleContent
                 contentOn={msToRelativeTime(leader.electedTime * 1000)}
-                contentOff={msToDateStr(leader.electedTime * 1000)}
+                contentOff={
+                  <DateFormat
+                    value={new Date(leader.electedTime * 1000)}
+                    format={{
+                      day: "numeric",
+                      month: "long",
+                      year: "numeric",
+                      hour: "numeric",
+                      minute: "numeric"
+                    }}
+                  />
+                }
               />
             }
           />

--- a/plugins/nodes/src/js/pages/nodes/NodeDetailTab.js
+++ b/plugins/nodes/src/js/pages/nodes/NodeDetailTab.js
@@ -1,4 +1,4 @@
-import { Trans } from "@lingui/macro";
+import { Trans, DateFormat } from "@lingui/macro";
 import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import { request } from "@dcos/mesos-client";
@@ -12,7 +12,6 @@ import ConfigurationMapLabel from "#SRC/js/components/ConfigurationMapLabel";
 import ConfigurationMapRow from "#SRC/js/components/ConfigurationMapRow";
 import ConfigurationMapSection from "#SRC/js/components/ConfigurationMapSection";
 import ConfigurationMapValue from "#SRC/js/components/ConfigurationMapValue";
-import DateUtil from "#SRC/js/utils/DateUtil";
 import HashMapDisplay from "#SRC/js/components/HashMapDisplay";
 import Node from "#SRC/js/structs/Node";
 import StringUtil from "#SRC/js/utils/StringUtil";
@@ -84,7 +83,16 @@ class NodeDetailTab extends PureComponent {
                 <Trans render="span">Registered</Trans>
               </ConfigurationMapLabel>
               <ConfigurationMapValue>
-                {DateUtil.msToDateStr(node.registered_time.toFixed(3) * 1000)}
+                <DateFormat
+                  value={new Date(node.registered_time.toFixed(3) * 1000)}
+                  format={{
+                    day: "numeric",
+                    month: "long",
+                    year: "numeric",
+                    hour: "numeric",
+                    minute: "numeric"
+                  }}
+                />
               </ConfigurationMapValue>
             </ConfigurationMapRow>
             <ConfigurationMapRow>

--- a/plugins/nodes/src/js/pages/nodes/NodeDetailTab.js
+++ b/plugins/nodes/src/js/pages/nodes/NodeDetailTab.js
@@ -15,6 +15,7 @@ import ConfigurationMapValue from "#SRC/js/components/ConfigurationMapValue";
 import HashMapDisplay from "#SRC/js/components/HashMapDisplay";
 import Node from "#SRC/js/structs/Node";
 import StringUtil from "#SRC/js/utils/StringUtil";
+import DateUtil from "#SRC/js/utils/DateUtil";
 import Units from "#SRC/js/utils/Units";
 import Loader from "#SRC/js/components/Loader";
 
@@ -85,13 +86,7 @@ class NodeDetailTab extends PureComponent {
               <ConfigurationMapValue>
                 <DateFormat
                   value={new Date(node.registered_time.toFixed(3) * 1000)}
-                  format={{
-                    day: "numeric",
-                    month: "long",
-                    year: "numeric",
-                    hour: "numeric",
-                    minute: "numeric"
-                  }}
+                  format={DateUtil.getFormatOptions("longMonthDateTime")}
                 />
               </ConfigurationMapValue>
             </ConfigurationMapRow>

--- a/plugins/services/src/js/components/MarathonTaskDetailsList.js
+++ b/plugins/services/src/js/components/MarathonTaskDetailsList.js
@@ -1,4 +1,4 @@
-import { Trans } from "@lingui/macro";
+import { Trans, DateFormat } from "@lingui/macro";
 import { i18nMark } from "@lingui/react";
 import PropTypes from "prop-types";
 import React from "react";
@@ -30,16 +30,24 @@ class MarathonTaskDetailsList extends React.Component {
   }
 
   getTimeField(time) {
-    let timeString = <Trans render="span">Never</Trans>;
-
-    if (time != null) {
-      timeString = new Date(time).toLocaleString();
+    if (time == null) {
+      return <Trans render="span">Never</Trans>;
     }
 
+    const timeString = new Date(time);
+
     return (
-      <time dateTime={time} title={time}>
-        {timeString}
-      </time>
+      <DateFormat
+        value={timeString}
+        format={{
+          year: "numeric",
+          month: "numeric",
+          day: "numeric",
+          hour: "numeric",
+          minute: "numeric",
+          second: "numeric"
+        }}
+      />
     );
   }
 

--- a/plugins/services/src/js/components/MarathonTaskDetailsList.js
+++ b/plugins/services/src/js/components/MarathonTaskDetailsList.js
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import DCOSStore from "#SRC/js/stores/DCOSStore";
+import DateUtil from "#SRC/js/utils/DateUtil";
 import ConfigurationMapHeading from "#SRC/js/components/ConfigurationMapHeading";
 import ConfigurationMapLabel from "#SRC/js/components/ConfigurationMapLabel";
 import ConfigurationMapRow from "#SRC/js/components/ConfigurationMapRow";
@@ -37,17 +38,7 @@ class MarathonTaskDetailsList extends React.Component {
     const timeString = new Date(time);
 
     return (
-      <DateFormat
-        value={timeString}
-        format={{
-          year: "numeric",
-          month: "numeric",
-          day: "numeric",
-          hour: "numeric",
-          minute: "numeric",
-          second: "numeric"
-        }}
-      />
+      <DateFormat value={timeString} format={DateUtil.getFormatOptions()} />
     );
   }
 

--- a/plugins/services/src/js/components/TaskDirectoryTable.js
+++ b/plugins/services/src/js/components/TaskDirectoryTable.js
@@ -95,6 +95,7 @@ class TaskDirectoryTable extends React.Component {
   renderDate(prop, directoryItem) {
     const ms = directoryItem.get(prop) * 1000;
 
+    // L10NTODO: Relative time
     return <TimeAgo time={ms} autoUpdate={false} />;
   }
 

--- a/plugins/services/src/js/containers/pod-configuration/PodConfigurationContainer.js
+++ b/plugins/services/src/js/containers/pod-configuration/PodConfigurationContainer.js
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 import React from "react";
-import { Trans } from "@lingui/macro";
+import { Trans, DateFormat } from "@lingui/macro";
 
 import Pod from "../../structs/Pod";
 import ServiceConfigDisplay from "../../service-configuration/ServiceConfigDisplay";
@@ -8,7 +8,19 @@ import ServiceConfigDisplay from "../../service-configuration/ServiceConfigDispl
 class PodConfigurationTabView extends React.Component {
   render() {
     const spec = this.props.pod.getSpec();
-    const localeVersion = new Date(spec.getVersion()).toLocaleString();
+    const localeVersion = (
+      <DateFormat
+        value={new Date(spec.getVersion())}
+        format={{
+          year: "numeric",
+          month: "numeric",
+          day: "numeric",
+          hour: "numeric",
+          minute: "numeric",
+          second: "numeric"
+        }}
+      />
+    );
 
     // TODO (DCOS_OSS-1037): Implement ability to edit a Pod
     return (

--- a/plugins/services/src/js/containers/pod-configuration/PodConfigurationContainer.js
+++ b/plugins/services/src/js/containers/pod-configuration/PodConfigurationContainer.js
@@ -2,6 +2,7 @@ import PropTypes from "prop-types";
 import React from "react";
 import { Trans, DateFormat } from "@lingui/macro";
 
+import DateUtil from "#SRC/js/utils/DateUtil";
 import Pod from "../../structs/Pod";
 import ServiceConfigDisplay from "../../service-configuration/ServiceConfigDisplay";
 
@@ -11,14 +12,7 @@ class PodConfigurationTabView extends React.Component {
     const localeVersion = (
       <DateFormat
         value={new Date(spec.getVersion())}
-        format={{
-          year: "numeric",
-          month: "numeric",
-          day: "numeric",
-          hour: "numeric",
-          minute: "numeric",
-          second: "numeric"
-        }}
+        format={DateUtil.getFormatOptions()}
       />
     );
 

--- a/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
+++ b/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
@@ -1,4 +1,4 @@
-import { Trans } from "@lingui/macro";
+import { Trans, DateFormat } from "@lingui/macro";
 import classNames from "classnames";
 import isEqual from "lodash.isequal";
 import PropTypes from "prop-types";
@@ -478,7 +478,19 @@ class PodInstancesTable extends React.Component {
       return null;
     }
 
-    const localeVersion = new Date(row.version).toLocaleString();
+    const localeVersion = (
+      <DateFormat
+        value={new Date(row.version)}
+        format={{
+          year: "numeric",
+          month: "numeric",
+          day: "numeric",
+          hour: "numeric",
+          minute: "numeric",
+          second: "numeric"
+        }}
+      />
+    );
 
     return this.renderWithClickHandler(
       rowOptions,

--- a/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
+++ b/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
@@ -13,6 +13,7 @@ import Icon from "#SRC/js/components/Icon";
 import TimeAgo from "#SRC/js/components/TimeAgo";
 import Units from "#SRC/js/utils/Units";
 import TableUtil from "#SRC/js/utils/TableUtil";
+import DateUtil from "#SRC/js/utils/DateUtil";
 
 import Pod from "../../structs/Pod";
 import PodUtil from "../../utils/PodUtil";
@@ -481,14 +482,7 @@ class PodInstancesTable extends React.Component {
     const localeVersion = (
       <DateFormat
         value={new Date(row.version)}
-        format={{
-          year: "numeric",
-          month: "numeric",
-          day: "numeric",
-          hour: "numeric",
-          minute: "numeric",
-          second: "numeric"
-        }}
+        format={DateUtil.getFormatOptions()}
       />
     );
 

--- a/plugins/services/src/js/containers/pod-instances/__tests__/PodInstancesTable-test.js
+++ b/plugins/services/src/js/containers/pod-instances/__tests__/PodInstancesTable-test.js
@@ -82,8 +82,9 @@ describe("PodInstancesTable", function() {
 
     describe("collapsed table", function() {
       beforeEach(function() {
+        const WrappedComponent = JestUtil.withI18nProvider(PodInstancesTable);
         thisInstance = mount(
-          <PodInstancesTable
+          <WrappedComponent
             pod={pod}
             instances={pod.getInstanceList().getItems()}
           />
@@ -179,10 +180,25 @@ describe("PodInstancesTable", function() {
             return el.text();
           });
 
+        const options = {
+          year: "numeric",
+          month: "numeric",
+          day: "numeric",
+          hour: "numeric",
+          minute: "numeric",
+          second: "numeric"
+        };
+
         expect(names).toEqual([
-          new Date(PodFixture.spec.version).toLocaleString(),
-          new Date(PodFixture.spec.version).toLocaleString(),
-          new Date(PodFixture.spec.version).toLocaleString()
+          Intl.DateTimeFormat("en", options).format(
+            new Date(PodFixture.spec.version)
+          ),
+          Intl.DateTimeFormat("en", options).format(
+            new Date(PodFixture.spec.version)
+          ),
+          Intl.DateTimeFormat("en", options).format(
+            new Date(PodFixture.spec.version)
+          )
         ]);
       });
     });
@@ -191,7 +207,9 @@ describe("PodInstancesTable", function() {
       beforeEach(function() {
         // Create a stub router context because when the items are expanded
         // the are creating <Link /> instances.
-        const WrappedComponent = JestUtil.stubRouterContext(PodInstancesTable);
+        const WrappedComponent = JestUtil.withI18nProvider(
+          JestUtil.stubRouterContext(PodInstancesTable)
+        );
         thisInstance = mount(
           <WrappedComponent
             pod={pod}
@@ -222,7 +240,9 @@ describe("PodInstancesTable", function() {
       beforeEach(function() {
         // Create a stub router context because when the items are expanded
         // the are creating <Link /> instances.
-        const WrappedComponent = JestUtil.stubRouterContext(PodInstancesTable);
+        const WrappedComponent = JestUtil.withI18nProvider(
+          JestUtil.stubRouterContext(PodInstancesTable)
+        );
         thisInstance = mount(
           <WrappedComponent
             pod={pod}
@@ -253,7 +273,9 @@ describe("PodInstancesTable", function() {
       beforeEach(function() {
         // Create a stub router context because when the items are expanded
         // the are creating <Link /> instances.
-        const WrappedComponent = JestUtil.stubRouterContext(PodInstancesTable);
+        const WrappedComponent = JestUtil.withI18nProvider(
+          JestUtil.stubRouterContext(PodInstancesTable)
+        );
         thisInstance = mount(
           <WrappedComponent
             pod={pod}
@@ -403,10 +425,25 @@ describe("PodInstancesTable", function() {
             return el.text().trim();
           });
 
+        const options = {
+          year: "numeric",
+          month: "numeric",
+          day: "numeric",
+          hour: "numeric",
+          minute: "numeric",
+          second: "numeric"
+        };
+
         expect(names).toEqual([
-          new Date(PodFixture.spec.version).toLocaleString(),
-          new Date(PodFixture.spec.version).toLocaleString(),
-          new Date(PodFixture.spec.version).toLocaleString()
+          Intl.DateTimeFormat("en", options).format(
+            new Date(PodFixture.spec.version)
+          ),
+          Intl.DateTimeFormat("en", options).format(
+            new Date(PodFixture.spec.version)
+          ),
+          Intl.DateTimeFormat("en", options).format(
+            new Date(PodFixture.spec.version)
+          )
         ]);
       });
     });

--- a/plugins/services/src/js/containers/pod-instances/__tests__/PodInstancesTable-test.js
+++ b/plugins/services/src/js/containers/pod-instances/__tests__/PodInstancesTable-test.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { mount } from "enzyme";
+import DateUtil from "#SRC/js/utils/DateUtil";
 
 const JestUtil = require("#SRC/js/utils/JestUtil");
 
@@ -180,23 +181,14 @@ describe("PodInstancesTable", function() {
             return el.text();
           });
 
-        const options = {
-          year: "numeric",
-          month: "numeric",
-          day: "numeric",
-          hour: "numeric",
-          minute: "numeric",
-          second: "numeric"
-        };
-
         expect(names).toEqual([
-          Intl.DateTimeFormat("en", options).format(
+          Intl.DateTimeFormat("en", DateUtil.getFormatOptions()).format(
             new Date(PodFixture.spec.version)
           ),
-          Intl.DateTimeFormat("en", options).format(
+          Intl.DateTimeFormat("en", DateUtil.getFormatOptions()).format(
             new Date(PodFixture.spec.version)
           ),
-          Intl.DateTimeFormat("en", options).format(
+          Intl.DateTimeFormat("en", DateUtil.getFormatOptions()).format(
             new Date(PodFixture.spec.version)
           )
         ]);
@@ -425,23 +417,14 @@ describe("PodInstancesTable", function() {
             return el.text().trim();
           });
 
-        const options = {
-          year: "numeric",
-          month: "numeric",
-          day: "numeric",
-          hour: "numeric",
-          minute: "numeric",
-          second: "numeric"
-        };
-
         expect(names).toEqual([
-          Intl.DateTimeFormat("en", options).format(
+          Intl.DateTimeFormat("en", DateUtil.getFormatOptions()).format(
             new Date(PodFixture.spec.version)
           ),
-          Intl.DateTimeFormat("en", options).format(
+          Intl.DateTimeFormat("en", DateUtil.getFormatOptions()).format(
             new Date(PodFixture.spec.version)
           ),
-          Intl.DateTimeFormat("en", options).format(
+          Intl.DateTimeFormat("en", DateUtil.getFormatOptions()).format(
             new Date(PodFixture.spec.version)
           )
         ]);

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
@@ -12,6 +12,7 @@ import Icon from "#SRC/js/components/Icon";
 import Loader from "#SRC/js/components/Loader";
 import { isSDKService } from "#SRC/js/utils/ServiceUtil";
 import RouterUtil from "#SRC/js/utils/RouterUtil";
+import DateUtil from "#SRC/js/utils/DateUtil";
 
 import ApplicationSpec from "../../structs/ApplicationSpec";
 import ServiceConfigDisplay from "../../service-configuration/ServiceConfigDisplay";
@@ -141,15 +142,7 @@ class ServiceConfiguration extends mixin(StoreMixin) {
               <span className="badge-container-text">
                 <DateFormat
                   value={localeVersion}
-                  render="span"
-                  format={{
-                    year: "numeric",
-                    month: "numeric",
-                    day: "numeric",
-                    hour: "numeric",
-                    minute: "numeric",
-                    second: "numeric"
-                  }}
+                  format={DateUtil.getFormatOptions()}
                 />
               </span>
               <Trans render={<Badge />}>Active</Trans>

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import React from "react";
 import { routerShape } from "react-router";
 import { StoreMixin } from "mesosphere-shared-reactjs";
-import { Trans } from "@lingui/macro";
+import { Trans, DateFormat } from "@lingui/macro";
 
 import { Badge } from "@dcos/ui-kit";
 import DCOSStore from "#SRC/js/stores/DCOSStore";
@@ -138,7 +138,20 @@ class ServiceConfiguration extends mixin(StoreMixin) {
         if (version === service.getVersion()) {
           itemCaption = (
             <span className="badge-container">
-              <span className="badge-container-text">{localeVersion}</span>
+              <span className="badge-container-text">
+                <DateFormat
+                  value={localeVersion}
+                  render="span"
+                  format={{
+                    year: "numeric",
+                    month: "numeric",
+                    day: "numeric",
+                    hour: "numeric",
+                    minute: "numeric",
+                    second: "numeric"
+                  }}
+                />
+              </span>
               <Trans render={<Badge />}>Active</Trans>
             </span>
           );

--- a/plugins/services/src/js/containers/service-configuration/__tests__/ServiceConfigurationContainer-test.js
+++ b/plugins/services/src/js/containers/service-configuration/__tests__/ServiceConfigurationContainer-test.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { mount } from "enzyme";
+import JestUtil from "#SRC/js/utils/JestUtil";
 
 const Application = require("../../../structs/Application");
 const ServiceConfigurationContainer = require("../ServiceConfigurationContainer");
@@ -49,11 +50,11 @@ describe("ServiceConfigurationContainer", function() {
   });
 
   beforeEach(function() {
+    const WrappedComponent = JestUtil.withI18nProvider(
+      ServiceConfigurationContainer
+    );
     thisInstance = mount(
-      <ServiceConfigurationContainer
-        onEditClick={function() {}}
-        service={service}
-      />
+      <WrappedComponent onEditClick={function() {}} service={service} />
     );
   });
 

--- a/plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js
+++ b/plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js
@@ -104,12 +104,14 @@ class ServiceDebugContainer extends React.Component {
         <ConfigurationMapRow>
           <Trans render={<ConfigurationMapLabel />}>Timestamp</Trans>
           <ConfigurationMapValue>
+            {/* L10NTODO: Relative time */}
             {timestamp} (<TimeAgo time={new Date(timestamp)} />)
           </ConfigurationMapValue>
         </ConfigurationMapRow>
         <ConfigurationMapRow>
           <Trans render={<ConfigurationMapLabel />}>Version</Trans>
           <ConfigurationMapValue>
+            {/* L10NTODO: Relative time */}
             {version} (<TimeAgo time={new Date(version)} />)
           </ConfigurationMapValue>
         </ConfigurationMapRow>
@@ -130,6 +132,7 @@ class ServiceDebugContainer extends React.Component {
     const { lastScalingAt, lastConfigChangeAt } = versionInfo;
     let lastScaling = "No operation since last config change";
     if (lastScalingAt !== lastConfigChangeAt) {
+      // L10NTODO: Relative time
       lastScaling = (
         <span>
           {lastScalingAt} (<TimeAgo time={new Date(lastScalingAt)} />)
@@ -147,6 +150,7 @@ class ServiceDebugContainer extends React.Component {
           <Trans render={<ConfigurationMapLabel />}>Configuration</Trans>
           <ConfigurationMapValue>
             {`${lastConfigChangeAt} `}
+            {/* L10NTODO: Relative time */}
             (<TimeAgo time={new Date(lastConfigChangeAt)} />)
           </ConfigurationMapValue>
         </ConfigurationMapRow>
@@ -286,6 +290,7 @@ class ServiceDebugContainer extends React.Component {
 
     return (
       <div className="infoBoxWrapper">
+        {/* L10NTODO: Relative time */}
         <InfoBoxInline
           appearance="warning"
           message={

--- a/plugins/services/src/js/containers/service-debug/TaskStatsTable.js
+++ b/plugins/services/src/js/containers/service-debug/TaskStatsTable.js
@@ -124,20 +124,26 @@ class TaskStatsTable extends React.Component {
   }
 
   renderTime(prop, taskStats) {
-    let label = "seconds";
+    let label = i18nMark("seconds");
     const lifeTimeSeconds = taskStats[prop]();
     let timeValue = lifeTimeSeconds;
 
     if (lifeTimeSeconds > 3600) {
-      label = "minutes";
+      label = i18nMark("minutes");
       timeValue = timeValue / 60;
     }
 
+    // L10NTODO: Number
     timeValue = new Number(parseFloat(timeValue).toFixed()).toLocaleString();
 
+    // L10NTODO: Relative time
     const humanReadable = DateUtil.getDuration(parseInt(lifeTimeSeconds, 10));
 
-    return `${timeValue} ${label} (${humanReadable})`;
+    return (
+      <span>
+        {timeValue} <Trans id={label} /> ({humanReadable})
+      </span>
+    );
   }
 
   render() {

--- a/plugins/services/src/js/containers/tasks/TaskTable.js
+++ b/plugins/services/src/js/containers/tasks/TaskTable.js
@@ -30,8 +30,7 @@ const tableColumnClasses = {
   cpus: "task-table-column-cpus",
   mem: "task-table-column-mem",
   gpus: "task-table-column-gpus",
-  updated: "task-table-column-updated",
-  version: "task-table-column-version"
+  updated: "task-table-column-updated"
 };
 
 const METHODS_TO_BIND = [
@@ -40,8 +39,7 @@ const METHODS_TO_BIND = [
   "renderHost",
   "renderLog",
   "renderStatus",
-  "renderStats",
-  "renderVersion"
+  "renderStats"
 ];
 
 class TaskTable extends React.Component {
@@ -59,10 +57,6 @@ class TaskTable extends React.Component {
 
   getStatusValue(task) {
     return this.props.i18n._(TaskStates[task.state].displayName);
-  }
-
-  getVersionValue(task) {
-    return task.version || null;
   }
 
   getClassName(prop, sortBy, row) {
@@ -409,18 +403,6 @@ class TaskTable extends React.Component {
         </div>
       </div>
     );
-  }
-
-  renderVersion(prop, task) {
-    const version = this.getVersionValue(task);
-
-    if (version == null) {
-      return null;
-    }
-
-    const localeVersion = new Date(version).toLocaleString();
-
-    return <span>{localeVersion}</span>;
   }
 
   render() {

--- a/src/js/stores/SystemLogStore.js
+++ b/src/js/stores/SystemLogStore.js
@@ -22,7 +22,9 @@ import SystemLogActions from "../events/SystemLogActions";
 import { APPEND, PREPEND } from "../constants/SystemLogTypes";
 import { findNestedPropertyInObject } from "../utils/Util";
 import { MESSAGE } from "../constants/LogFields";
-import { msToLogTime } from "../utils/DateUtil";
+import DateUtil from "../utils/DateUtil";
+
+const { msToLogTime } = DateUtil;
 
 class SystemLogStore extends BaseStore {
   constructor() {

--- a/src/js/structs/__tests__/JobRunList-test.js
+++ b/src/js/structs/__tests__/JobRunList-test.js
@@ -1,5 +1,6 @@
+import DateUtil from "../../utils/DateUtil";
+
 const JobRunList = require("../JobRunList");
-const DateUtil = require("../../utils/DateUtil");
 
 describe("JobRunList", function() {
   describe("#getLongestRunningActiveRun", function() {

--- a/src/js/structs/__tests__/JobTaskList-test.js
+++ b/src/js/structs/__tests__/JobTaskList-test.js
@@ -1,5 +1,6 @@
+import DateUtil from "../../utils/DateUtil";
+
 const JobTaskList = require("../JobTaskList");
-const DateUtil = require("../../utils/DateUtil");
 
 describe("JobTaskList", function() {
   describe("#getLongestRunningTask", function() {

--- a/src/js/utils/DateUtil.d.ts
+++ b/src/js/utils/DateUtil.d.ts
@@ -1,3 +1,0 @@
-export default class DateUtil {
-  static strToMs(str: string): number;
-}

--- a/src/js/utils/DateUtil.ts
+++ b/src/js/utils/DateUtil.ts
@@ -8,6 +8,28 @@ const DEFAULT_MULTIPLICANTS = {
   d: 86400000
 };
 
+interface Multiplicants {
+  [key: string]: number;
+}
+
+const fullDateTime = "fullDateTime";
+const longMonthDateTime = "longMonthDateTime";
+
+type FormatOptionType = typeof fullDateTime | typeof longMonthDateTime;
+interface FormatOptions {
+  timeZone?: string;
+  hour12?: boolean;
+  weekday?: "narrow" | "short" | "long";
+  era?: "narrow" | "short" | "long";
+  year?: "numeric" | "2-digit";
+  month?: "numeric" | "2-digit" | "narrow" | "short" | "long";
+  day?: "numeric" | "2-digit";
+  hour?: "numeric" | "2-digit";
+  minute?: "numeric" | "2-digit";
+  second?: "numeric" | "2-digit";
+  timeZoneName?: "short" | "long";
+}
+
 const DateUtil = {
   /*
    * Composes a string expression by de-composing the given time in milliseconds
@@ -15,7 +37,10 @@ const DateUtil = {
    *
    * 11002 = 11002 ms (11 sec, 2 ms)
    */
-  msToMultiplicants(ms, multiplicants = DEFAULT_MULTIPLICANTS) {
+  msToMultiplicants(
+    ms: number,
+    multiplicants: Multiplicants = DEFAULT_MULTIPLICANTS
+  ): string[] {
     const expressionComponents = [];
     const multiplicantKeys = Object.keys(multiplicants);
 
@@ -35,20 +60,11 @@ const DateUtil = {
   },
 
   /**
-   * Creates a time string from time provided
-   * @param  {Date|Number} ms number to convert to time string
-   * @return {String} time string with the format 'MM-DD-YYYY [at] h:mma'
-   */
-  msToDateStr(ms) {
-    return moment(ms).format("MMMM Do, YYYY h:mm a");
-  },
-
-  /**
    * Creates a UTC time string from time provided
    * @param  {Date|Number} ms number to convert to UTC time string
    * @return {String} time string with the format 'YYYY-MM-DD[T]HH:mm:ss.SSS[Z]'
    */
-  msToUTCDate(ms) {
+  msToUTCDate(ms: Date | number): string {
     return moment(ms)
       .utc()
       .format("YYYY-MM-DD[T]HH:mm:ss.SSS[Z]");
@@ -59,24 +75,55 @@ const DateUtil = {
    * @param  {Date|Number} ms number to convert to ANSI C time string
    * @return {String} time string with the format 'YYYY-MM-DD hh:mm:ss'
    */
-  msToLogTime(ms) {
+  msToLogTime(ms: Date | number): string {
     return moment(ms)
       .utc()
       .format("YYYY-MM-DD hh:mm:ss");
   },
 
   /**
+   * Returns format object for Intl.DateTimeFormat (and DateFormat translation macro)
+   */
+  getFormatOptions(formatType?: FormatOptionType): FormatOptions {
+    const longMonthDateTimeFormat: FormatOptions = {
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+      hour: "numeric",
+      minute: "numeric"
+    };
+    const fullDateTimeFormat: FormatOptions = {
+      year: "numeric",
+      month: "numeric",
+      day: "numeric",
+      hour: "numeric",
+      minute: "numeric",
+      second: "numeric"
+    };
+    if (formatType === fullDateTime) {
+      return fullDateTimeFormat;
+    } else if (formatType === longMonthDateTime) {
+      return longMonthDateTimeFormat;
+    } else {
+      // default to full numeric date time format
+      return fullDateTimeFormat;
+    }
+  },
+
   /**
    * Creates relative time based on now and the time provided
    * @param  {Date|Number} ms number to convert to relative time string
    * @param  {Boolean} suppressRelativeTime whether to remove 'ago' from string
    * @return {String} time string relative from now
    */
-  msToRelativeTime(ms, suppressRelativeTime = false) {
+  msToRelativeTime(
+    ms: Date | number,
+    suppressRelativeTime: boolean = false
+  ): string {
     return moment(ms).fromNow(suppressRelativeTime);
   },
 
-  strToMs(str) {
+  strToMs(str: string | null): number | null {
     if (str == null) {
       return null;
     }
@@ -86,9 +133,12 @@ const DateUtil = {
     );
   },
 
-  getDuration(time, formatKey = "seconds") {
+  getDuration(
+    time: number,
+    formatKey: moment.DurationInputArg2 = "seconds"
+  ): string {
     return moment.duration(time, formatKey).humanize();
   }
 };
 
-module.exports = DateUtil;
+export default DateUtil;

--- a/src/js/utils/JestUtil.js
+++ b/src/js/utils/JestUtil.js
@@ -21,6 +21,7 @@ const RouterStub = {
 // Default prototype functions when mocking timezone
 const defaultGetTimezoneOffset = Date.prototype.getTimezoneOffset;
 const defaultToLocaleString = Date.prototype.toLocaleString;
+const defaultDateTimeFormat = Intl.DateTimeFormat;
 
 const JestUtil = {
   /**
@@ -80,7 +81,7 @@ const JestUtil = {
    * Mock a different timezone by overriding relevant Date primitive
    * prototype functions.
    *
-   * This function will mock Date.getTimezoneOffset and Date.toLocaleString
+   * This function will mock Date.getTimezoneOffset, Date.toLocaleString and Intl.DateTimeFormat
    *
    * @param {String} timezone - The IANA timezone string (ex. Europe/Athens) or 'UTC'
    */
@@ -100,6 +101,11 @@ const JestUtil = {
       options.timeZone = options.timeZone || timezone;
 
       return defaultToLocaleString.call(this, locale, options);
+    };
+    Intl.DateTimeFormat = function(locales, options) {
+      options.timeZone = options.timeZone || timezone;
+
+      return defaultDateTimeFormat.call(this, locales, options);
     };
     /* eslint-enable no-extend-native */
   },
@@ -203,6 +209,7 @@ const JestUtil = {
     /* eslint-disable no-extend-native */
     Date.prototype.getTimezoneOffset = defaultGetTimezoneOffset;
     Date.prototype.toLocaleString = defaultToLocaleString;
+    Intl.DateTimeFormat = defaultDateTimeFormat;
     /* eslint-enable no-extend-native */
   }
 };

--- a/src/js/utils/__tests__/DateUtil-test.js
+++ b/src/js/utils/__tests__/DateUtil-test.js
@@ -1,4 +1,4 @@
-const DateUtil = require("../DateUtil");
+import DateUtil from "../DateUtil";
 
 describe("DateUtil", function() {
   describe("#msToMultiplicants", function() {
@@ -54,36 +54,6 @@ describe("DateUtil", function() {
       var result = DateUtil.msToMultiplicants(1080000000);
 
       expect(result).toEqual(["12 d", "12 h"]);
-    });
-  });
-
-  describe("#msToDateStr", function() {
-    it("returns the correct string for AM", function() {
-      // December is 11 due to months being 0-based index.
-      var christmas = new Date(2015, 11, 25, 8, 13);
-      var christmasValue = christmas.valueOf();
-
-      var result = DateUtil.msToDateStr(christmasValue);
-
-      expect(result).toEqual("December 25th, 2015 8:13 am");
-    });
-
-    it("returns the correct string for PM", function() {
-      var halloween = new Date(2015, 9, 31, 20, 30);
-      var halloweenValue = halloween.valueOf();
-
-      var result = DateUtil.msToDateStr(halloweenValue);
-
-      expect(result).toEqual("October 31st, 2015 8:30 pm");
-    });
-
-    it("can handle older dates", function() {
-      var specialDay = new Date(1993, 9, 19, 11, 29);
-      var specialDayValue = specialDay.valueOf();
-
-      var result = DateUtil.msToDateStr(specialDayValue);
-
-      expect(result).toEqual("October 19th, 1993 11:29 am");
     });
   });
 


### PR DESCRIPTION
Localize dates using DateFormat macro. Does not include relative dates.

Closes DCOS-41719.

## Testing

There should be no visual changes as a result of this PR.

## Trade-offs

Lingui `DateFormat` macro uses `Intl.DateTimeFormat` instead of `Date` functions like `toLocaleString` (not so much a tradeoff as just something to be aware of).

## Dependencies

None

## Screenshots

N/A
