### PR TITLE
DCOS-45800: Handle Cosmos Errors in configuration tab

### DIFF
--- a/tests/pages/services/ServiceDetail-cy.js
+++ b/tests/pages/services/ServiceDetail-cy.js
@@ -185,13 +185,45 @@ describe("Service Detail Page", function() {
         nodeHealth: true,
         universePackages: true
       });
+    });
 
-      cy.visitUrl({
-        url: "/services/detail/%2Fcassandra-healthy/configuration"
+    context("Configuration Tab", function() {
+      it("shows configuration of a service", function() {
+        cy.visitUrl({
+          url: "/services/detail/%2Fcassandra-healthy/configuration"
+        });
+        cy.get("h1").contains("Service");
+        cy.get("h1").contains("Elasticsearch");
+        cy.get("h1").contains("Master Nodes");
+        cy.get("h1").contains("Data Nodes");
+        cy.get("h1").contains("Ingest Nodes");
+        cy.get("h1").contains("Coordinator Nodes");
+      });
+
+      it("handles network errors", function() {
+        cy.visitUrl({
+          url: "/services/detail/%2Fcassandra-healthy/configuration"
+        });
+        cy.route({
+          method: "POST",
+          url: /cosmos\/service\/describe(\?_timestamp=[0-9]+)?$/,
+          status: 400,
+          response: {
+            message: "Version doesn't exists"
+          }
+        }).as("cosmosDescribe");
+
+        cy.wait("@cosmosDescribe");
+
+        cy.get(".page-body").contains("Version doesn't exists");
       });
     });
 
     it("edit config button opens the edit flow", function() {
+      cy.visitUrl({
+        url: "/services/detail/%2Fcassandra-healthy/configuration"
+      });
+
       cy.get(".container")
         .contains("Edit Config")
         .click();
@@ -202,6 +234,10 @@ describe("Service Detail Page", function() {
     });
 
     it("download button exists", function() {
+      cy.visitUrl({
+        url: "/services/detail/%2Fcassandra-healthy/configuration"
+      });
+
       cy.get(".container").contains("Download Config");
     });
   });


### PR DESCRIPTION
This PR adds cosmos error handling for the configuration tab

## Testing

Please refer to the ticket. Some private info involved.

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
