### PR TITLE
DCOS-46053: Metronome client to stop sending Content-Type header with GET requests

### DIFF
--- a/src/js/events/MetronomeClient.ts
+++ b/src/js/events/MetronomeClient.ts
@@ -158,8 +158,7 @@ export function fetchJobs(): Observable<RequestResponse<JobResponse[]>> {
   return request(
     `${
       Config.metronomeAPI
-    }/v1/jobs?embed=activeRuns&embed=schedules&embed=historySummary`,
-    { headers: defaultHeaders }
+    }/v1/jobs?embed=activeRuns&embed=schedules&embed=historySummary`
   );
 }
 
@@ -169,8 +168,7 @@ export function fetchJobDetail(
   return request(
     `${
       Config.metronomeAPI
-    }/v1/jobs/${jobID}?embed=activeRuns&embed=history&embed=schedules`,
-    { headers: defaultHeaders }
+    }/v1/jobs/${jobID}?embed=activeRuns&embed=history&embed=schedules`
   );
 }
 

--- a/src/js/events/__tests__/MetronomeClient-test.ts
+++ b/src/js/events/__tests__/MetronomeClient-test.ts
@@ -185,8 +185,7 @@ describe("MetronomeClient", () => {
       expect(mockRequest).toHaveBeenCalledWith(
         `${
           Config.metronomeAPI
-        }/v1/jobs?embed=activeRuns&embed=schedules&embed=historySummary`,
-        { headers: expect.anything() }
+        }/v1/jobs?embed=activeRuns&embed=schedules&embed=historySummary`
       );
     });
 
@@ -221,8 +220,7 @@ describe("MetronomeClient", () => {
       expect(mockRequest).toHaveBeenCalledWith(
         `${
           Config.metronomeAPI
-        }/v1/jobs/${jobId}?embed=activeRuns&embed=history&embed=schedules`,
-        { headers: expect.anything() }
+        }/v1/jobs/${jobId}?embed=activeRuns&embed=history&embed=schedules`
       );
     });
 

--- a/src/js/events/__tests__/MetronomeClient-test.ts
+++ b/src/js/events/__tests__/MetronomeClient-test.ts
@@ -152,7 +152,7 @@ describe("MetronomeClient", () => {
     });
 
     it(
-      "emits the sucessful request result",
+      "emits the successful request result",
       marbles(m => {
         m.bind();
 
@@ -227,7 +227,7 @@ describe("MetronomeClient", () => {
     });
 
     it(
-      "emits the sucessful request result",
+      "emits the successful request result",
       marbles(m => {
         m.bind();
 
@@ -270,7 +270,7 @@ describe("MetronomeClient", () => {
     });
 
     it(
-      "emits the sucessful request result",
+      "emits the successful request result",
       marbles(m => {
         m.bind();
 
@@ -312,7 +312,7 @@ describe("MetronomeClient", () => {
     });
 
     it(
-      "emits the sucessful request result",
+      "emits the successful request result",
       marbles(m => {
         m.bind();
 
@@ -354,7 +354,7 @@ describe("MetronomeClient", () => {
     });
 
     it(
-      "emits the sucessful request result",
+      "emits the successful request result",
       marbles(m => {
         m.bind();
 
@@ -394,7 +394,7 @@ describe("MetronomeClient", () => {
     });
 
     it(
-      "emits the sucessful request result",
+      "emits the successful request result",
       marbles(m => {
         m.bind();
 


### PR DESCRIPTION
As this behaviour breaks proxying requests. More background in the issue.

## Testing

1. Verify that `fetchJobs` and `fetchJobDetail` stopped sending Content-Type on respective pages.

## Trade-offs

Fixed a typo in a sep commit 🤷‍♂️ 