### PR TITLE
DCOS-43091: [COPS] Logs view / Nodes view don't scroll in Firefox

### DIFF
--- a/src/styles/components/code/styles.less
+++ b/src/styles/components/code/styles.less
@@ -6,6 +6,7 @@
       border: @code-block-prettyprint-border-width @code-block-prettyprint-border-style @code-block-prettyprint-border-color;
       border-radius: @code-border-radius;
       border-style: @code-block-prettyprint-border-style;
+      flex-basis: @code-block-prettyprint-flex-basis;
 
       &.inverse {
         border-color: @code-block-prettyprint-border-color-inverse;

--- a/src/styles/components/code/variables.less
+++ b/src/styles/components/code/variables.less
@@ -13,3 +13,4 @@
 @code-block-prettyprint-border-right-color: @code-block-prettyprint-border-color;
 @code-block-prettyprint-border-width: 0;
 @code-block-prettyprint-border-style: solid;
+@code-block-prettyprint-flex-basis: 0;


### PR DESCRIPTION
Allow the logs to be scrollable in Firefox.

Closes DCOS-43091

## Testing
1. Test in both Firefox and Chrome
2. Start a service
3. Go to Services Tab, click the service.
4. Click a task
5. Open the logs tab
6. Verify that Error(stderr) and Output(stdout) are scrollable
7. Go to Nodes
8. Click a node
9. Click a task
10. Open the logs tab
11. Verify that Error(stderr) and Output(stdout) are scrollable

## Trade-offs
Firefox need an explicit height (so not `100%` or `auto`) for `overflow: auto` or `overflow: scroll` to work.

## Dependencies
None.

## Screenshots

### Before
![screenshot from 2018-10-05 17-35-33](https://user-images.githubusercontent.com/40791275/49650706-d21b1100-fa35-11e8-83a0-934269e0b693.png)

### After
![peek 2018-12-07 15-24](https://user-images.githubusercontent.com/40791275/49650664-b152bb80-fa35-11e8-929d-f1c7ecbdf3f2.gif)
