### PR TITLE
DCOS-46049: [1.12] COPS-3759 affecting dcos-ui: When no nodes are in the cluster the message should have different wording

### DIFF
--- a/plugins/nodes/src/js/pages/NodesAgents.js
+++ b/plugins/nodes/src/js/pages/NodesAgents.js
@@ -294,8 +294,8 @@ var NodesAgents = React.createClass({
         <AlertPanel>
           <AlertPanelHeader>No nodes detected</AlertPanelHeader>
           <p className="flush-bottom">
-            There a currently no other nodes in your datacenter other than your
-            DC/OS master node.
+            There are currently no other nodes in this DC/OS cluster other than
+            your DC/OS master node.
           </p>
         </AlertPanel>
       </Page>


### PR DESCRIPTION
Changed the message when there are no nodes to be more accurate.

Closes https://jira.mesosphere.com/browse/DCOS-46049

## Testing
1. In `plugins/nodes/src/js/pages/NodesAgents.js` change line 306 to be `if (true) {`
2. Click on Nodes tab.
3. Verify that the message shown is changed.

## Trade-offs
Also changed "a" to "are".

## Dependencies
None.

## Screenshots

### Before
![screenshot from 2018-12-07 10-51-54](https://user-images.githubusercontent.com/40791275/49637839-324a8c80-fa0f-11e8-9169-37cb678d59a2.png)

### After
![screenshot from 2018-12-07 16-29-13](https://user-images.githubusercontent.com/40791275/49653416-83717500-fa3d-11e8-8b54-16b45079cc1d.png)
