### PR TITLE
DCOS-42113: no duplicate carat dropdown on select inputs

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -4,7 +4,7 @@ module.exports = ({ env }) => {
   return {
     parser: false,
     plugins: {
-      autoprefixer: shouldOptimize,
+      autoprefixer: true,
       "postcss-merge-rules": shouldOptimize,
       "postcss-discard-duplicates": shouldOptimize,
       "postcss-merge-longhand": shouldOptimize,


### PR DESCRIPTION
## Testing
Using a 1.12 cluster, check out `release/1.12`
Find a <select> input (for example, there's one on Services>Add Service>Single Container>Placement tab)

The select input should only have 1 down chevron, it should not also show the browser-native arrow/s

## Trade-offs
None

## Dependencies
None

## Screenshots
Before:
<img width="683" alt="screen shot 2018-12-07 at 2 50 17 pm" src="https://user-images.githubusercontent.com/2313998/49669476-7d749780-fa2f-11e8-9bba-b024506c73f7.png">

After:
<img width="685" alt="screen shot 2018-12-07 at 2 50 25 pm" src="https://user-images.githubusercontent.com/2313998/49669479-806f8800-fa2f-11e8-9d80-5ddc0075bfe8.png">
