### PR TITLE
[1.12] DCOS-46088: get status for all deployments

### DIFF
--- a/plugins/services/src/js/components/DeploymentsModal.js
+++ b/plugins/services/src/js/components/DeploymentsModal.js
@@ -437,10 +437,11 @@ class DeploymentsModal extends mixin(StoreMixin) {
       {});
     }
 
-    let statusText = item.getStatus();
+    let statusText = !item.isStale ? item.getStatus() : null;
+    const itemId = item.isStale ? item.serviceID : item.id;
 
-    if (currentActions[item.id] != null) {
-      statusText = currentActions[item.id];
+    if (currentActions[itemId] != null) {
+      statusText = currentActions[itemId];
     }
 
     return statusText;

--- a/tests/_fixtures/deployments/two-deployments-one-stale.json
+++ b/tests/_fixtures/deployments/two-deployments-one-stale.json
@@ -1,0 +1,82 @@
+[
+  {
+    "id": "b4f69082-6f96-4c92-a778-37bf61c59686",
+    "version": "2016-07-05T17:54:37.134Z",
+    "affectedApps": [
+      "/kafka"
+    ],
+    "steps": [
+      {
+        "actions": [
+          {
+            "action": "StartApplication",
+            "app": "/kafka"
+          }
+        ]
+      },
+      {
+        "actions": [
+          {
+            "action": "ScaleApplication",
+            "app": "/kafka"
+          }
+        ]
+      }
+    ],
+    "currentActions": [
+      {
+        "action": "ScaleApplication",
+        "app": "/kafka",
+        "readinessCheckResults": [
+          {
+            "name": "cassandraUpdateProgress",
+            "taskId": "kafka.8a29a459-42d9-11e6-b767-1ea433350c2b",
+            "ready": false,
+            "lastResponse": {
+              "status": 504,
+              "contentType": "text/plain",
+              "body": "Marathon could not query http://10.0.2.243:15790/v1/plan: Connection attempt to 10.0.2.243:15790 failed"
+            }
+          },
+          {
+            "name": "cassandraUpdateProgress",
+            "taskId": "kafka.93bd3c2b-42f2-11e6-b767-1ea433350c2b",
+            "ready": false,
+            "lastResponse": {
+              "status": 503,
+              "contentType": "application/json",
+              "body": "{\"phases\":[{\"id\":\"5f9c9c05-faff-45b1-aa57-4f4d0aada233\",\"name\":\"Reconciliation\",\"blocks\":[{\"id\":\"e91d36fd-4504-4e8e-8d96-fc22e5b7149f\",\"status\":\"Pending\",\"name\":\"Reconciliation\",\"message\":\"Reconciliation pending\",\"has_decision_point\":false}],\"status\":\"Pending\"},{\"id\":\"bd320876-6ece-4fb1-a506-7e3f4f34b62d\",\"name\":\"Update to: 1aee477f-7751-4a9a-a0dd-79948789ff76\",\"blocks\":[{\"id\":\"e9d11c20-fe67-4239-8c29-7447a73bd9a1\",\"status\":\"Pending\",\"name\":\"broker-0\",\"message\":\"Broker-0 is Pending\",\"has_decision_point\":false},{\"id\":\"7e97125f-5701-45f0-84d5-a079ea3faf28\",\"status\":\"Pending\",\"name\":\"broker-1\",\"message\":\"Broker-1 is Pending\",\"has_decision_point\":false},{\"id\":\"0aeb40d1-5c96-4362-9455-42a9b9f9915c\",\"status\":\"Pending\",\"name\":\"broker-2\",\"message\":\"Broker-2 is Pending\",\"has_decision_point\":false}],\"status\":\"Pending\"}],\"errors\":[],\"status\":\"Pending\"}"
+            }
+          }
+        ]
+      }
+    ],
+    "currentStep": 2,
+    "totalSteps": 2
+  },
+  {
+    "affectedApps": ["/spark/spark-history-stale"],
+    "affectedPods": [],
+    "currentActions": [
+      {
+        "action": "StopApplication",
+        "app": "/spark/spark-history-stale",
+        "readinessCheckResults": []
+      }
+    ],
+    "currentStep": 1,
+    "id": "staleId",
+    "steps": [
+      {
+        "actions": [
+          {
+            "action": "StopApplication",
+            "app": "/spark/spark-history-stale"
+          }
+        ]
+      }
+    ],
+    "totalSteps": 1,
+    "version": "2018-11-20T01:12:31.465Z"
+  }
+]


### PR DESCRIPTION
Ensure status is retrieved from deployments, even when getStatus method is not available.

Closes DCOS-46088.

## Testing

Not sure if this will hold up as deployments change over time, but for me I tested using the 1.12 soak cluster.
- Go to Services
- Click on "X Deployments" in top right corner
- List of deployments in modal should match X

Compare this to same set of steps on soak cluster (not using this branch, just soak url). For me, it was 3 deployments but only 2 would show up in the modal (+ errors in dev console).

## Trade-offs

Code trade-offs, none that I can see. But it is weird that the format of the deployment items is not consistent. This issue came up because most of the items had all the regular "Service" properties, but there was one that only had 
```js
{
deployment: {...},
isStale: true,
serviceId: "/spark/spark-history-kerberos"
}
```
which is why the `getStatus` method was causing errors. Also id stored as property `serviceId` instead of `id` as expected. Is this typical of any "stale" service/application?

## Dependencies

None

## Screenshots

Before:
<img width="1043" alt="screen shot 2018-12-07 at 11 51 22 am" src="https://user-images.githubusercontent.com/19582796/49670404-7b074300-fa19-11e8-933e-398dbbe422cd.png">

After:
<img width="1043" alt="screen shot 2018-12-07 at 11 50 17 am" src="https://user-images.githubusercontent.com/19582796/49670422-8a868c00-fa19-11e8-92fd-b208d74acbe7.png">

