### PR TITLE
DCOS-46093: COPS-3907 DCOS-UI Crash

### DIFF
--- a/src/js/components/FrameworkConfigurationForm.js
+++ b/src/js/components/FrameworkConfigurationForm.js
@@ -152,7 +152,7 @@ export default class FrameworkConfigurationForm extends Component {
     if (schema == null) {
       return;
     }
-    if (Util.isObject(formData)) {
+    if (Util.isObject(formData) && schema.properties) {
       Object.keys(formData).forEach(property => {
         this.writeErrors(
           formData[property],

--- a/src/js/components/__tests__/FrameworkConfigurationForm-test.js
+++ b/src/js/components/__tests__/FrameworkConfigurationForm-test.js
@@ -1,0 +1,115 @@
+const React = require("react");
+const { shallow } = require("enzyme");
+
+const {
+  default: FrameworkConfigurationForm
+} = require("../FrameworkConfigurationForm");
+const UniversePackage = require("../../structs/UniversePackage");
+
+function createWrapper(formData, formErrors, packageDetails) {
+  return shallow(
+    <FrameworkConfigurationForm
+      packageDetails={packageDetails}
+      jsonEditorActive={false}
+      formData={formData}
+      formErrors={formErrors}
+      focusField={""}
+      activeTab={""}
+      onFormDataChange={jest.fn()}
+      onFormErrorChange={jest.fn()}
+      handleActiveTabChange={jest.fn()}
+      handleFocusFieldChange={jest.fn()}
+    />
+  );
+}
+
+describe("FrameworkConfigurationForm", function() {
+  describe("validate", function() {
+    it("should add error is required key is empty", function() {
+      const addError = jest.fn();
+      const formData = {
+        foo: "",
+        bar: 0
+      };
+      const formErrors = {
+        foo: {
+          addError
+        },
+        bar: {
+          addError
+        }
+      };
+      const testPackage = new UniversePackage({
+        config: {
+          type: "object",
+          properties: {
+            foo: {
+              type: "string",
+              default: "foo"
+            },
+            bar: {
+              type: "number"
+            }
+          },
+          required: ["foo"]
+        }
+      });
+
+      const instance = createWrapper(
+        formData,
+        formErrors,
+        testPackage
+      ).instance();
+
+      instance.validate(formData, formErrors);
+
+      expect(addError).toHaveBeenCalledWith("Expecting a string here, eg: foo");
+    });
+
+    it("should handle an array value", function() {
+      const addError = jest.fn();
+      const formData = {
+        foo: "",
+        bar: [
+          {
+            key: "env",
+            value: "MYTEST=true"
+          }
+        ]
+      };
+      const formErrors = {
+        foo: {
+          addError
+        },
+        bar: {
+          addError
+        }
+      };
+      const testPackage = new UniversePackage({
+        config: {
+          type: "object",
+          properties: {
+            foo: {
+              type: "string",
+              default: "foo"
+            },
+            bar: {
+              type: "array"
+            }
+          },
+          required: []
+        }
+      });
+
+      const instance = createWrapper(
+        formData,
+        formErrors,
+        testPackage
+      ).instance();
+
+      instance.validate(formData, formErrors);
+
+      expect(addError).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
When attempting to `writeErrors` we check that the `formData` is an object,
but if so we assume the schema has properties. But if the `formData` is an
Array then its an object and the schema does not have any properties.

Added a check that the schema has properties before iterating over
`formData` keys. To resolve this issue.

See #3454

## Testing

 - See [COPS-3907](https://jira.mesosphere.com/browse/COPS-3907)