### PR TITLE
DCOS_OSS-4579: [1.12] accept floating points in FrameworkConfigurationForm

### DIFF
--- a/src/js/components/FrameworkConfigurationForm.js
+++ b/src/js/components/FrameworkConfigurationForm.js
@@ -365,6 +365,7 @@ export default class FrameworkConfigurationForm extends Component {
                       validate={this.validate}
                       ErrorList={this.jsonSchemaErrorList}
                       transformErrors={this.transformErrors}
+                      noHtml5Validate={true}
                       ref={form => {
                         this.schemaForm = form;
                       }}


### PR DESCRIPTION
## Testing
Use a browser other than Chrome.. With your browser and OS in locale that uses "," as a decimal separator  (de-DE, ru, fr-FR, etc...).
1. Go to Catalog and add a new service
2. Go to the "Nodes" tab
3. Change CPUs to another floating point

The field should not be considered invalid

## Trade-offs
- Setting `novalidate` on this form makes us miss out on browser validation (e.g.: people can put letters into an `input[type="number"]`)
- We're setting `novalidate` on this form, but there may be other forms where we have this issue that we just haven't caught yet

## Dependencies
None

## Screenshots
Before:
![floatingpoint-broken](https://user-images.githubusercontent.com/2313998/50024596-ea98a780-ffb0-11e8-9ee1-f162ac201311.gif)

After:
![floatingpoint-fixed](https://user-images.githubusercontent.com/2313998/49668622-ba8b5a80-fa2c-11e8-96fb-f010630aca38.gif)
