### PR TITLE
DCOS_OSS-4582: [1.11]  accept floating points in FrameworkConfigurationForm

### DIFF
--- a/src/js/components/FrameworkConfigurationForm.js
+++ b/src/js/components/FrameworkConfigurationForm.js
@@ -315,6 +315,10 @@ export default class FrameworkConfigurationForm extends Component {
                       validate={this.validate}
                       showErrorList={false}
                       transformErrors={this.transformErrors}
+                      noHtml5Validate={true}
+                      ref={form => {
+                        this.schemaForm = form;
+                      }}
                     >
                       <div />
                     </SchemaForm>

--- a/src/js/components/SchemaField.js
+++ b/src/js/components/SchemaField.js
@@ -223,6 +223,7 @@ class SchemaField extends Component {
         onChange={handleChange}
         onBlur={onBlur && (event => onBlur(name, event.target.value))}
         onFocus={onFocus && (event => onFocus(name, event.target.value))}
+        lang={navigator.language}
       />
     );
     if (autofocus) {


### PR DESCRIPTION
## Testing
Use a browser other than Chrome.. With your browser and OS in locale that uses "," as a decimal separator  (de-DE, ru, fr-FR, etc...).
1. Go to Catalog and add a new service
2. Go to the "Nodes" tab
3. Change CPUs to another floating point

The field should not be considered invalid

## Trade-offs
- Setting `novalidate` on this form makes us miss out on browser validation (e.g.: people can put letters into an `input[type="number"]`)
- We're setting `novalidate` on this form, but there may be other forms where we have this issue that we just haven't caught yet

## Dependencies
None

## Screenshots
Before:
![floatingpoint-broken](https://user-images.githubusercontent.com/2313998/50024596-ea98a780-ffb0-11e8-9ee1-f162ac201311.gif)

After:
![floatingpoint-fixed](https://user-images.githubusercontent.com/2313998/49668622-ba8b5a80-fa2c-11e8-96fb-f010630aca38.gif)
