### PR TITLE
DCOS_OSS-4597: [1.12] service config dropdown content overflows

### DIFF
--- a/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
@@ -136,8 +136,10 @@ class ServiceConfiguration extends mixin(StoreMixin) {
         let itemCaption = localeVersion;
         if (version === service.getVersion()) {
           itemCaption = (
-            <span className="badge-container">
-              <span className="badge-container-text">{localeVersion}</span>
+            <span className="badge-container flex">
+              <span className="badge-container-text services-version-text text-overflow">
+                {localeVersion}
+              </span>
               <Badge>Active</Badge>
             </span>
           );
@@ -146,21 +148,21 @@ class ServiceConfiguration extends mixin(StoreMixin) {
         return {
           id: version,
           html: (
-            <div className="button-split-content-wrapper">
+            <div className="service-version-dropdown-wrapper button-split-content-wrapper flex">
               <Icon
-                className="services-version-select-icon services-version-select-icon-selected button-split-content-item"
+                className="services-version-select-icon services-version-select-icon-selected button-split-content-item flex-item-shrink-0"
                 id="check"
                 size="mini"
                 color="neutral"
               />
               <Icon
-                className="services-version-select-icon button-split-content-item"
+                className="services-version-select-icon button-split-content-item flex-item-shrink-0"
                 id="commit"
                 size="mini"
                 color="neutral"
               />
               <span
-                className="button-split-content-item text-overflow"
+                className="button-split-content-item flex-item-grow-1 text-overflow"
                 title={version}
               >
                 {itemCaption}

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
@@ -136,10 +136,8 @@ class ServiceConfiguration extends mixin(StoreMixin) {
         let itemCaption = localeVersion;
         if (version === service.getVersion()) {
           itemCaption = (
-            <span className="badge-container flex">
-              <span className="badge-container-text services-version-text text-overflow">
-                {localeVersion}
-              </span>
+            <span className="badge-container">
+              <span className="badge-container-text">{localeVersion}</span>
               <Badge>Active</Badge>
             </span>
           );
@@ -148,21 +146,21 @@ class ServiceConfiguration extends mixin(StoreMixin) {
         return {
           id: version,
           html: (
-            <div className="service-version-dropdown-wrapper button-split-content-wrapper flex">
+            <div className="button-split-content-wrapper">
               <Icon
-                className="services-version-select-icon services-version-select-icon-selected button-split-content-item flex-item-shrink-0"
+                className="services-version-select-icon services-version-select-icon-selected button-split-content-item"
                 id="check"
                 size="mini"
                 color="neutral"
               />
               <Icon
-                className="services-version-select-icon button-split-content-item flex-item-shrink-0"
+                className="services-version-select-icon button-split-content-item"
                 id="commit"
                 size="mini"
                 color="neutral"
               />
               <span
-                className="button-split-content-item flex-item-grow-1 text-overflow"
+                className="button-split-content-item text-overflow"
                 title={version}
               >
                 {itemCaption}

--- a/src/js/components/FrameworkConfigurationReviewScreen.js
+++ b/src/js/components/FrameworkConfigurationReviewScreen.js
@@ -44,25 +44,27 @@ class FrameworkConfigurationReviewScreen extends React.Component {
       {
         id: frameworkMeta,
         html: (
-          <div className="button-split-content-wrapper">
+          <div className="service-version-dropdown-wrapper button-split-content-wrapper flex">
             <Icon
-              className="services-version-select-icon services-version-select-icon-selected button-split-content-item"
+              className="services-version-select-icon services-version-select-icon-selected button-split-content-item flex-item-shrink-0"
               id="check"
               size="mini"
               color="neutral"
             />
             <Icon
-              className="services-version-select-icon button-split-content-item"
+              className="services-version-select-icon button-split-content-item flex-item-shrink-0"
               id="commit"
               size="mini"
               color="neutral"
             />
             <span
-              className="button-split-content-item text-overflow"
+              className="button-split-content-item flex-item-grow-1 text-overflow"
               title={frameworkMeta}
             >
-              <span className="badge-container">
-                <span className="badge-container-text">{frameworkMeta}</span>
+              <span className="badge-container flex">
+                <span className="badge-container-text services-version-text text-overflow">
+                  {frameworkMeta}
+                </span>
                 <span className="badge">Active</span>
               </span>
             </span>

--- a/src/js/components/FrameworkConfigurationReviewScreen.js
+++ b/src/js/components/FrameworkConfigurationReviewScreen.js
@@ -44,27 +44,25 @@ class FrameworkConfigurationReviewScreen extends React.Component {
       {
         id: frameworkMeta,
         html: (
-          <div className="service-version-dropdown-wrapper button-split-content-wrapper flex">
+          <div className="button-split-content-wrapper">
             <Icon
-              className="services-version-select-icon services-version-select-icon-selected button-split-content-item flex-item-shrink-0"
+              className="services-version-select-icon services-version-select-icon-selected button-split-content-item"
               id="check"
               size="mini"
               color="neutral"
             />
             <Icon
-              className="services-version-select-icon button-split-content-item flex-item-shrink-0"
+              className="services-version-select-icon button-split-content-item"
               id="commit"
               size="mini"
               color="neutral"
             />
             <span
-              className="button-split-content-item flex-item-grow-1 text-overflow"
+              className="button-split-content-item text-overflow"
               title={frameworkMeta}
             >
-              <span className="badge-container flex">
-                <span className="badge-container-text services-version-text text-overflow">
-                  {frameworkMeta}
-                </span>
+              <span className="badge-container">
+                <span className="badge-container-text">{frameworkMeta}</span>
                 <span className="badge">Active</span>
               </span>
             </span>

--- a/src/styles/views/services/styles.less
+++ b/src/styles/views/services/styles.less
@@ -73,15 +73,6 @@
       align-items: center;
     }
   }
-
-  .services-version-text {
-    min-width: 0;
-    width: auto;
-  }
-
-  .service-version-dropdown-wrapper {
-    width: 100%;
-  }
 }
 
 .filter-tasks-bar {

--- a/src/styles/views/services/styles.less
+++ b/src/styles/views/services/styles.less
@@ -73,6 +73,15 @@
       align-items: center;
     }
   }
+
+  .services-version-text {
+    min-width: 0;
+    width: auto;
+  }
+
+  .service-version-dropdown-wrapper {
+    width: 100%;
+  }
 }
 
 .filter-tasks-bar {


### PR DESCRIPTION
## Testing
1. In `plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js`, on line 143, change the `<DateFormat />` component to just be a span with a long string
2. Open a service from the "Services" tab
3. Go to the "Configuration" tab
4. Click the dropdown at the top of that screen

The long string you replaced `<DateFormat />` with should not overflow the container - it should appear truncated

## Trade-offs
None

## Dependencies
None

## Screenshots
Before:
<img width="942" alt="screen shot 2018-12-10 at 3 42 01 pm" src="https://user-images.githubusercontent.com/2313998/49761713-d5143c80-fc95-11e8-888d-61faea45bd54.png">

After:
<img width="921" alt="screen shot 2018-12-10 at 3 45 04 pm" src="https://user-images.githubusercontent.com/2313998/49761725-d9405a00-fc95-11e8-9160-31b623b3fa01.png">

Note: I tested this in Chrome, FF, Safari, and Edge