### PR TITLE
DCOS-43909 SDK Plans Client

### DIFF
--- a/plugins/services/src/js/data/ServicePlansClient.ts
+++ b/plugins/services/src/js/data/ServicePlansClient.ts
@@ -1,0 +1,48 @@
+import { request, RequestResponse } from "@dcos/http-service";
+import { Observable } from "rxjs/Observable";
+
+export type ServicePlanStatus =
+  | "ERROR"
+  | "WAITING"
+  | "PENDING"
+  | "PREPARED"
+  | "STARTING"
+  | "STARTED"
+  | "COMPLETE"
+  | "IN_PROGRESS";
+
+export interface ServicePlanStepResponse {
+  id: string;
+  status: ServicePlanStatus;
+  name: string;
+  message: string;
+}
+
+export interface ServicePlanPhaseResponse {
+  id: string;
+  name: string;
+  steps: ServicePlanStepResponse[];
+  strategy: string;
+  status: ServicePlanStatus;
+}
+
+export interface ServicePlanResponse {
+  name: string;
+  phases: ServicePlanPhaseResponse[];
+  status: ServicePlanStatus;
+  errors: string[];
+  strategy: string;
+}
+
+export function fetchPlans(
+  serviceName: string
+): Observable<RequestResponse<string[]>> {
+  return request(`/service/${serviceName}/v1/plans`);
+}
+
+export function fetchPlanDetails(
+  serviceName: string,
+  planName: string
+): Observable<RequestResponse<ServicePlanResponse>> {
+  return request(`/service/${serviceName}/v1/plans/${planName}`);
+}

--- a/plugins/services/src/js/data/__tests__/ServicePlansClient-test.ts
+++ b/plugins/services/src/js/data/__tests__/ServicePlansClient-test.ts
@@ -1,0 +1,91 @@
+const mockRequest = jest.fn();
+jest.mock("@dcos/http-service", () => ({
+  request: mockRequest
+}));
+
+import { marbles } from "rxjs-marbles/jest";
+import { Observable } from "rxjs/Observable";
+import "rxjs/add/observable/of";
+import "rxjs/add/operator/take";
+
+import * as ServicePlansClient from "../ServicePlansClient";
+
+const planDetailData: ServicePlansClient.ServicePlanResponse = require("./_fixtures/service-plan-in-progress");
+
+describe("ServicePlansClient", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("#fetchPlans", () => {
+    it("makes a request", () => {
+      mockRequest.mockReturnValueOnce(Observable.of({}));
+      ServicePlansClient.fetchPlans("fakeService");
+      expect(mockRequest).toHaveBeenCalled();
+    });
+
+    it("makes a request to the correct URL", () => {
+      mockRequest.mockReturnValueOnce(Observable.of({}));
+      ServicePlansClient.fetchPlans("fakeService");
+      expect(mockRequest).toHaveBeenCalledWith("/service/fakeService/v1/plans");
+    });
+
+    it("emits an event when the data is received", () => {
+      marbles(m => {
+        m.bind();
+        const expectedResult = ["plan01", "plan02", "plan03"];
+        const expected$ = m.cold("--j|", {
+          j: {
+            response: expectedResult,
+            code: 200,
+            message: "OK"
+          }
+        });
+
+        mockRequest.mockReturnValueOnce(expected$);
+
+        const result$ = ServicePlansClient.fetchPlans("test");
+        m.expect(result$).toBeObservable(expected$);
+      });
+    });
+  });
+
+  describe("#fetchPlanDetail", () => {
+    it("makes a request", () => {
+      mockRequest.mockReturnValueOnce(Observable.of({}));
+      ServicePlansClient.fetchPlanDetails("fakeService", "test-plan");
+      expect(mockRequest).toHaveBeenCalled();
+    });
+
+    it("makes a request to the correct URL", () => {
+      mockRequest.mockReturnValueOnce(Observable.of({}));
+      ServicePlansClient.fetchPlanDetails("fakeService", "test-plan01");
+      expect(mockRequest).toHaveBeenCalledWith(
+        "/service/fakeService/v1/plans/test-plan01"
+      );
+    });
+
+    it(
+      "emits the successful request result",
+      marbles(m => {
+        m.bind();
+
+        const expected$ = m.cold("--j|", {
+          j: {
+            response: planDetailData,
+            code: 200,
+            message: "OK"
+          }
+        });
+
+        mockRequest.mockReturnValueOnce(expected$);
+        const result$ = ServicePlansClient.fetchPlanDetails(
+          "fakeService",
+          "test-plan03"
+        );
+
+        m.expect(result$).toBeObservable(expected$);
+      })
+    );
+  });
+});

--- a/plugins/services/src/js/data/__tests__/_fixtures/service-plan-in-progress.json
+++ b/plugins/services/src/js/data/__tests__/_fixtures/service-plan-in-progress.json
@@ -1,0 +1,32 @@
+{
+  "phases" : [ {
+    "id" : "9d6bfeab-bf0b-4465-b0c8-f438c10fb6ec",
+    "name" : "node-deploy",
+    "steps" : [ {
+      "id" : "e2fe078f-2d0e-4879-bfee-aad43865778f",
+      "status" : "COMPLETE",
+      "name" : "node-0:[server]",
+      "message" : "com.mesosphere.sdk.scheduler.plan.DeploymentStep: node-0:[server] [e2fe078f-2d0e-4879-bfee-aad43865778f] with status: COMPLETE"
+    }, {
+      "id" : "10333e55-317b-424f-ae69-757bf951befa",
+      "status" : "COMPLETE",
+      "name" : "node-0:[init_system_keyspaces]",
+      "message" : "com.mesosphere.sdk.scheduler.plan.DeploymentStep: node-0:[init_system_keyspaces] [10333e55-317b-424f-ae69-757bf951befa] with status: COMPLETE"
+    }, {
+      "id" : "5071bc65-453e-46d2-b0a5-982a292a6456",
+      "status" : "PREPARED",
+      "name" : "node-1:[server]",
+      "message" : "com.mesosphere.sdk.scheduler.plan.DeploymentStep: node-1:[server] [5071bc65-453e-46d2-b0a5-982a292a6456] with status: PREPARED"
+    }, {
+      "id" : "54911c5c-618b-47b3-a87c-35dd60af2e39",
+      "status" : "PENDING",
+      "name" : "node-2:[server]",
+      "message" : "com.mesosphere.sdk.scheduler.plan.DeploymentStep: node-2:[server] [54911c5c-618b-47b3-a87c-35dd60af2e39] with status: PENDING"
+    } ],
+    "strategy" : "serial",
+    "status" : "IN_PROGRESS"
+  } ],
+  "strategy" : "serial",
+  "errors" : [ ],
+  "status" : "IN_PROGRESS"
+}


### PR DESCRIPTION
Created the client for querying a service's plans from the API and
associated types. This will be used by a data-layer GraphQL connection that will be written after this. That is why I placed it in the data folder for the services plugin.

## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->
There are unit tests to run.

Otherwise this client will be used by a data-layer connection that will be written in another ticket.

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->
I wasn't 100% sure where these files should live. I actually moved them 3 times while developing this. If you think there is a better place for this to live I am open to suggestions.
