### PR TITLE
DCOS-44818: add script that detects .only statements

### DIFF
--- a/scripts/utils/test
+++ b/scripts/utils/test
@@ -16,3 +16,12 @@ find_debug_directives(){
 
  echo -e "${matches}"
 }
+
+find_files_with_debug_directives(){
+  if [[ -z $* ]]
+  then
+   exit 0
+  fi
+
+  grep -E -l --recursive ${DEBUG_DIRECTIVE_PATTERN} "$@"
+}

--- a/scripts/utils/test
+++ b/scripts/utils/test
@@ -4,12 +4,13 @@ DEBUG_DIRECTIVE_PATTERN="(f(it|describe)|(it|describe|test|context)\.only)\("
 
 # Example: find_debug_directives ./test src/js/components/__tests__/Component-test.js
 find_debug_directives(){
-  if [[ ! -n $* ]]
+  if [[ -z $* ]]
   then
    exit 0
   fi
 
- local matches=$(
+ local matches
+ matches=$(
     grep -E -R -s --color=always ${DEBUG_DIRECTIVE_PATTERN} $*
   )
 


### PR DESCRIPTION
## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

You can add a bash file like this on the top-level and call it:

```bash
#!/bin/bash

set -e
source "./scripts/utils/test"

echo "$(find_files_with_debug_directives './tests')"
```

It should exit with status code 1 if there is no file in ./tests to contain `.only`. If you change that it should display each file name in a new line


## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

- Wrote it in bash as we wanted to reuse the code that is already there, so that we can rewrite it later together, rather then having two versions, one for bash and one for JS

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
	