### PR TITLE
DCOS-41707: [1.12] DCOS UI Shows foreign tasks for a service if they match the name

### DIFF
--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -255,8 +255,16 @@ class MesosStateStore extends GetSetBaseStore {
       }
     }
 
+    // Check which tasks belong to this service
     return tasks
-      .filter(task => task.isStartedByMarathon && task.name === mesosTaskName)
+      .filter(
+        task =>
+          task.isStartedByMarathon &&
+          task.name === mesosTaskName &&
+          (service.get("tasks") && service.findTaskById
+            ? service.findTaskById(task.id)
+            : true)
+      )
       .concat(serviceTasks)
       .map(task => MesosStateUtil.flagSDKTask(task, service));
   }

--- a/src/js/stores/__tests__/MesosStateStore-test.js
+++ b/src/js/stores/__tests__/MesosStateStore-test.js
@@ -158,7 +158,10 @@ describe("MesosStateStore", function() {
       var tasks = MesosStateStore.getTasksByService(
         new Framework({
           id: "/spark",
-          labels: { DCOS_PACKAGE_FRAMEWORK_NAME: "spark" }
+          labels: { DCOS_PACKAGE_FRAMEWORK_NAME: "spark" },
+          findTaskById: () => {
+            return true;
+          }
         })
       );
       expect(tasks).toEqual([
@@ -176,7 +179,12 @@ describe("MesosStateStore", function() {
 
     it("returns matching application tasks", function() {
       var tasks = MesosStateStore.getTasksByService(
-        new Application({ id: "/alpha" })
+        new Application({
+          id: "/alpha",
+          findTaskById: () => {
+            return true;
+          }
+        })
       );
       expect(tasks).toEqual([
         {
@@ -233,6 +241,9 @@ describe("MesosStateStore", function() {
           labels: {
             DCOS_COMMONS_API_VERSION: 1,
             DCOS_PACKAGE_FRAMEWORK_NAME: "spark"
+          },
+          findTaskById: () => {
+            return true;
           }
         })
       );


### PR DESCRIPTION
Closes https://jira.mesosphere.com/browse/DCOS-41707

## Testing
1. Run a pod with the following configuration (taken from jira):
```
{
  "id": "/nginx-busybox",
  "version": "2018-09-17T16:36:00.220Z",
  "containers": [
    {
      "name": "nginx",
      "resources": {
        "cpus": 0.001,
        "mem": 32,
        "disk": 0
      },
      "image": {
        "kind": "DOCKER",
        "id": "nginx"
      }
    },
    {
      "name": "container-2",
      "resources": {
        "cpus": 0.001,
        "mem": 32,
        "disk": 0
      },
      "image": {
        "kind": "DOCKER",
        "id": "alpine"
      },
      "exec": {
        "command": {
          "shell": "sleep 100000"
        }
      }
    }
  ],
  "networks": [
    {
      "name": "dcos",
      "mode": "container"
    }
  ],
  "scaling": {
    "instances": 1,
    "kind": "fixed"
  },
  "scheduling": {
    "placement": {
      "constraints": []
    }
  },
  "executorResources": {
    "cpus": 0.1,
    "mem": 32,
    "disk": 10
  },
  "volumes": [],
  "fetch": []
}
```
2. Run `nginx` from the catalog
3. Verify that the task for `nginx-busybox` does not appear in the tasks table for `nginx`.
4. Verify that other catalog packages show and work correctly

## Trade-offs
~This is the best solution that I could think of. I tested some framework tasks, and they all had `discovery` and `discovery.name`.~

Added a new solution. It should work. An alternative that @zen-dog suggested is to check in Marathon (we currently use the Mesos store). I checked and we do have this information in the Marathon store, but I think that changing the store logic gives room for errors and since we are moving away from store in order to use the data layer, I don't think it is worth it.

## Dependencies
None.

## Screenshots

### Before
![screenshot from 2019-01-07 14-57-32](https://user-images.githubusercontent.com/40791275/50771879-94a7de80-1294-11e9-9363-7c8e71275d4f.png)

### After
![screenshot from 2019-01-09 15-28-33](https://user-images.githubusercontent.com/40791275/50902335-4248f800-1423-11e9-84e0-f373e8a1997c.png)

