### PR TITLE
DCOS-43910 SDK Service Plan data-layer

### DIFF
--- a/plugins/services/src/js/data/ServicePlansClient.ts
+++ b/plugins/services/src/js/data/ServicePlansClient.ts
@@ -27,7 +27,6 @@ export interface ServicePlanPhaseResponse {
 }
 
 export interface ServicePlanResponse {
-  name: string;
   phases: ServicePlanPhaseResponse[];
   status: ServicePlanStatus;
   errors: string[];
@@ -37,12 +36,42 @@ export interface ServicePlanResponse {
 export function fetchPlans(
   serviceName: string
 ): Observable<RequestResponse<string[]>> {
-  return request(`/service/${serviceName}/v1/plans`);
+  return request(`/service/${serviceName}/v1/plans`).map(
+    (reqResp: RequestResponse<any>) => {
+      if (reqResp.code !== 200) {
+        const respMessage =
+          reqResp.response && typeof reqResp.response === "object"
+            ? JSON.stringify(reqResp.response)
+            : reqResp.response;
+        throw new Error(
+          `Service Plans API request failed: ${reqResp.code} ${
+            reqResp.message
+          }:${respMessage}`
+        );
+      }
+      return reqResp;
+    }
+  );
 }
 
 export function fetchPlanDetails(
   serviceName: string,
   planName: string
 ): Observable<RequestResponse<ServicePlanResponse>> {
-  return request(`/service/${serviceName}/v1/plans/${planName}`);
+  return request(`/service/${serviceName}/v1/plans/${planName}`).map(
+    (reqResp: RequestResponse<any>) => {
+      if (reqResp.code !== 200) {
+        const respMessage =
+          reqResp.response && typeof reqResp.response === "object"
+            ? JSON.stringify(reqResp.response)
+            : reqResp.response;
+        throw new Error(
+          `Service Plan Detail API request failed: ${reqResp.code} ${
+            reqResp.message
+          }:${respMessage}`
+        );
+      }
+      return reqResp;
+    }
+  );
 }

--- a/plugins/services/src/js/data/ServicePlansClient.ts
+++ b/plugins/services/src/js/data/ServicePlansClient.ts
@@ -38,7 +38,7 @@ export function fetchPlans(
 ): Observable<RequestResponse<string[]>> {
   return request(`/service/${serviceName}/v1/plans`).map(
     (reqResp: RequestResponse<any>) => {
-      if (reqResp.code !== 200) {
+      if (reqResp.code >= 300) {
         const respMessage =
           reqResp.response && typeof reqResp.response === "object"
             ? JSON.stringify(reqResp.response)
@@ -60,7 +60,7 @@ export function fetchPlanDetails(
 ): Observable<RequestResponse<ServicePlanResponse>> {
   return request(`/service/${serviceName}/v1/plans/${planName}`).map(
     (reqResp: RequestResponse<any>) => {
-      if (reqResp.code !== 200) {
+      if (reqResp.code >= 300) {
         const respMessage =
           reqResp.response && typeof reqResp.response === "object"
             ? JSON.stringify(reqResp.response)

--- a/plugins/services/src/js/data/ServicePlansClient.ts
+++ b/plugins/services/src/js/data/ServicePlansClient.ts
@@ -13,8 +13,8 @@ export type ServicePlanStatus =
 
 export interface ServicePlanStepResponse {
   id: string;
-  status: ServicePlanStatus;
   name: string;
+  status: ServicePlanStatus;
   message: string;
 }
 

--- a/plugins/services/src/js/data/__tests__/index-test.ts
+++ b/plugins/services/src/js/data/__tests__/index-test.ts
@@ -1,0 +1,632 @@
+const mockRequest = jest.fn();
+jest.mock("@dcos/http-service", () => ({
+  request: mockRequest
+}));
+
+import { Observable } from "rxjs";
+import { marbles } from "rxjs-marbles/jest";
+import { makeExecutableSchema } from "graphql-tools";
+import { graphqlObservable } from "@dcos/data-service";
+import gql from "graphql-tag";
+
+import { schemas, resolvers } from "../index";
+import {
+  fetchPlanDetails,
+  fetchPlans,
+  ServicePlanResponse
+} from "#PLUGINS/services/src/js/data/ServicePlansClient";
+
+function makeFakePlanResponse(name: string): ServicePlanResponse {
+  return {
+    name,
+    strategy: "serial",
+    status: "IN_PROGRESS",
+    errors: [],
+    phases: [
+      {
+        id: "0001",
+        name: "phase-0",
+        strategy: "serial",
+        status: "IN_PROGRESS",
+        steps: [
+          {
+            id: "000A",
+            name: "step-0",
+            status: "IN_PROGRESS",
+            message: "this is a test"
+          }
+        ]
+      }
+    ]
+  };
+}
+
+function makeResolverConfig(
+  m: any,
+  plansResponse: string[] = ["plan-01", "plan-02", "plan-03"]
+) {
+  return {
+    fetchServicePlans: (_serviceName: string) =>
+      m.cold("(j|)", {
+        j: { code: 200, message: "ok", response: plansResponse }
+      }),
+    fetchServicePlanDetail: (_serviceName: string, planName: string) =>
+      m.cold("(j|)", {
+        j: {
+          code: 200,
+          message: "ok",
+          response: makeFakePlanResponse(planName)
+        }
+      }),
+    pollingInterval: m.time("--|")
+  };
+}
+
+describe("Service data-layer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("plans", () => {
+    it(
+      "handles a graphql query",
+      marbles(m => {
+        m.bind();
+
+        const serviceSchema = makeExecutableSchema({
+          typeDefs: schemas,
+          resolvers: resolvers(makeResolverConfig(m))
+        });
+
+        const query = gql`
+          query {
+            service(name: $serviceName) {
+              name
+              plans {
+                name
+                status
+                strategy
+              }
+            }
+          }
+        `;
+
+        const queryResult$ = graphqlObservable(query, serviceSchema, {
+          serviceName: "test"
+        });
+        const result$ = queryResult$.take(1);
+
+        const expected$ = m.cold("(j|)", {
+          j: {
+            data: {
+              service: {
+                name: "test",
+                plans: [
+                  {
+                    name: "plan-01",
+                    status: "IN_PROGRESS",
+                    strategy: "serial"
+                  },
+                  {
+                    name: "plan-02",
+                    status: "IN_PROGRESS",
+                    strategy: "serial"
+                  },
+                  {
+                    name: "plan-03",
+                    status: "IN_PROGRESS",
+                    strategy: "serial"
+                  }
+                ]
+              }
+            }
+          }
+        });
+
+        m.expect(result$).toBeObservable(expected$);
+      })
+    );
+
+    it(
+      "polls the endpoints",
+      marbles(m => {
+        m.bind();
+
+        const fetchServicePlans = (_service: string) =>
+          m.cold("j|", {
+            j: {
+              code: 200,
+              message: "ok",
+              response: ["plan-01"]
+            }
+          });
+        const fetchServicePlanDetail = (_service: string, planName: string) =>
+          m.cold("--j|", {
+            j: {
+              code: 200,
+              message: "ok",
+              response: makeFakePlanResponse(planName)
+            }
+          });
+        const serviceSchema = makeExecutableSchema({
+          typeDefs: schemas,
+          resolvers: resolvers({
+            fetchServicePlans,
+            fetchServicePlanDetail,
+            pollingInterval: m.time("--|")
+          })
+        });
+
+        const query = gql`
+          query {
+            service(name: $serviceName) {
+              name
+              plans {
+                name
+              }
+            }
+          }
+        `;
+
+        const queryResult$ = graphqlObservable(query, serviceSchema, {
+          serviceName: "test"
+        });
+
+        const expected$ = m.cold("--x-x-(x|)", {
+          x: {
+            data: {
+              service: {
+                name: "test",
+                plans: [
+                  {
+                    name: "plan-01"
+                  }
+                ]
+              }
+            }
+          }
+        });
+
+        m.expect(queryResult$.take(3)).toBeObservable(expected$);
+      })
+    );
+
+    it(
+      "shares the subscription",
+      marbles(m => {
+        m.bind();
+
+        const resolverConfig = makeResolverConfig(m);
+        resolverConfig.fetchServicePlans = jest.fn(
+          resolverConfig.fetchServicePlans
+        );
+
+        const serviceSchema = makeExecutableSchema({
+          typeDefs: schemas,
+          resolvers: resolvers(resolverConfig)
+        });
+
+        const query = gql`
+          query {
+            service(name: "test") {
+              name
+              plans {
+                name
+              }
+            }
+          }
+        `;
+
+        Observable.concat(
+          graphqlObservable(query, serviceSchema, {}).take(1),
+          graphqlObservable(query, serviceSchema, {}).take(1),
+          graphqlObservable(query, serviceSchema, {}).take(1),
+          graphqlObservable(query, serviceSchema, {}).take(1),
+          graphqlObservable(query, serviceSchema, {}).take(1),
+          graphqlObservable(query, serviceSchema, {}).take(1),
+          graphqlObservable(query, serviceSchema, {}).take(1),
+          graphqlObservable(query, serviceSchema, {}).take(1),
+          graphqlObservable(query, serviceSchema, {}).take(1),
+          graphqlObservable(query, serviceSchema, {}).take(1),
+          graphqlObservable(query, serviceSchema, {}).take(1)
+        ).subscribe(jest.fn(), jest.fn(), () => {
+          expect(resolverConfig.fetchServicePlans).toHaveBeenCalledTimes(1);
+        });
+      })
+    );
+
+    it(
+      "throws an error if plan detail API returns non-200",
+      marbles(m => {
+        m.bind();
+
+        const resolversConfig = makeResolverConfig(m);
+        resolversConfig.fetchServicePlans = (_serviceName: string) =>
+          m.cold("(j|)", {
+            j: { code: 500, message: "Internal Server Error", response: {} }
+          });
+
+        const serviceSchema = makeExecutableSchema({
+          typeDefs: schemas,
+          resolvers: resolvers(resolversConfig)
+        });
+
+        const query = gql`
+          query {
+            service(name: $serviceName) {
+              name
+              plans
+            }
+          }
+        `;
+
+        const queryResult$ = graphqlObservable(query, serviceSchema, {
+          serviceName: "test"
+        }).take(1);
+
+        const expected$ = m.cold("#", undefined, {
+          message:
+            "Service plans API request failed: 500 Internal Server Error:{}",
+          name: "Error"
+        });
+
+        m.expect(queryResult$).toBeObservable(expected$);
+      })
+    );
+
+    it(
+      "throws an error if plans API returns non-200",
+      marbles(m => {
+        m.bind();
+
+        const resolversConfig = makeResolverConfig(m);
+        resolversConfig.fetchServicePlanDetail = (
+          _serviceName: string,
+          _planName: string
+        ) =>
+          m.cold("(j|)", {
+            j: { code: 500, message: "Internal Server Error", response: {} }
+          });
+
+        const serviceSchema = makeExecutableSchema({
+          typeDefs: schemas,
+          resolvers: resolvers(resolversConfig)
+        });
+
+        const query = gql`
+          query {
+            service(name: $serviceName) {
+              name
+              plans
+            }
+          }
+        `;
+
+        const queryResult$ = graphqlObservable(query, serviceSchema, {
+          serviceName: "test"
+        }).take(1);
+
+        const expected$ = m.cold("#", undefined, {
+          message:
+            "Service plan detail API request failed: 500 Internal Server Error:{}",
+          name: "Error"
+        });
+
+        m.expect(queryResult$).toBeObservable(expected$);
+      })
+    );
+
+    it(
+      "works with ServicePlansClient",
+      marbles(m => {
+        m.bind();
+
+        const plansResult$ = m.cold("(j|)", {
+          j: { code: 200, message: "ok", response: ["client-plan"] }
+        });
+        const planDetailResult$ = m.cold("(j|)", {
+          j: {
+            code: 200,
+            message: "ok",
+            response: makeFakePlanResponse("client-plan")
+          }
+        });
+        const results = [plansResult$, planDetailResult$];
+        mockRequest.mockImplementation(() => results.shift());
+
+        const resolversConfig = {
+          fetchServicePlans: fetchPlans,
+          fetchServicePlanDetail: fetchPlanDetails,
+          pollingInterval: m.time("--|")
+        };
+
+        const serviceSchema = makeExecutableSchema({
+          typeDefs: schemas,
+          resolvers: resolvers(resolversConfig)
+        });
+
+        const query = gql`
+          query {
+            service(name: $serviceName) {
+              name
+              plans {
+                name
+                status
+                strategy
+              }
+            }
+          }
+        `;
+
+        const queryResult$ = graphqlObservable(query, serviceSchema, {
+          serviceName: "test"
+        });
+        const result$ = queryResult$.take(1);
+
+        const expected$ = m.cold("(j|)", {
+          j: {
+            data: {
+              service: {
+                name: "test",
+                plans: [
+                  {
+                    name: "client-plan",
+                    status: "IN_PROGRESS",
+                    strategy: "serial"
+                  }
+                ]
+              }
+            }
+          }
+        });
+
+        m.expect(result$).toBeObservable(expected$);
+      })
+    );
+  });
+
+  describe("single plan", () => {
+    it(
+      "handles a graphql query",
+      marbles(m => {
+        m.bind();
+
+        const serviceSchema = makeExecutableSchema({
+          typeDefs: schemas,
+          resolvers: resolvers(makeResolverConfig(m))
+        });
+
+        const query = gql`
+          query {
+            service(name: $serviceName) {
+              name
+              plans(name: $planName) {
+                name
+                status
+                strategy
+              }
+            }
+          }
+        `;
+
+        const queryResult$ = graphqlObservable(query, serviceSchema, {
+          serviceName: "test",
+          planName: "plan-01"
+        });
+        const result$ = queryResult$.take(1);
+
+        const expected$ = m.cold("(j|)", {
+          j: {
+            data: {
+              service: {
+                name: "test",
+                plans: [
+                  {
+                    name: "plan-01",
+                    status: "IN_PROGRESS",
+                    strategy: "serial"
+                  }
+                ]
+              }
+            }
+          }
+        });
+
+        m.expect(result$).toBeObservable(expected$);
+      })
+    );
+
+    it(
+      "queries only one plan if name given",
+      marbles(m => {
+        m.bind();
+        const resolversConfig = makeResolverConfig(m);
+        resolversConfig.fetchServicePlans = jest.fn(
+          resolversConfig.fetchServicePlans
+        );
+        resolversConfig.fetchServicePlanDetail = jest.fn(
+          resolversConfig.fetchServicePlanDetail
+        );
+        const serviceSchema = makeExecutableSchema({
+          typeDefs: schemas,
+          resolvers: resolvers(resolversConfig)
+        });
+
+        const query = gql`
+          query {
+            service(name: $serviceName) {
+              name
+              plans(name: $planName) {
+                name
+                status
+                strategy
+              }
+            }
+          }
+        `;
+
+        graphqlObservable(query, serviceSchema, {
+          serviceName: "test",
+          planName: "plan-01"
+        })
+          .take(1)
+          .subscribe(jest.fn(), jest.fn(), () => {
+            expect(resolversConfig.fetchServicePlans).toHaveBeenCalledTimes(0);
+            expect(
+              resolversConfig.fetchServicePlanDetail
+            ).toHaveBeenCalledTimes(1);
+          });
+      })
+    );
+
+    it(
+      "polls the endpoint",
+      marbles(m => {
+        m.bind();
+
+        const resolversConfig = makeResolverConfig(m);
+
+        resolversConfig.fetchServicePlanDetail = (
+          _service: string,
+          planName: string
+        ) =>
+          m.cold("-j|", {
+            j: {
+              code: 200,
+              message: "ok",
+              response: makeFakePlanResponse(planName)
+            }
+          });
+        const serviceSchema = makeExecutableSchema({
+          typeDefs: schemas,
+          resolvers: resolvers(resolversConfig)
+        });
+
+        const query = gql`
+          query {
+            service(name: $serviceName) {
+              name
+              plans(name: $planName) {
+                name
+                status
+              }
+            }
+          }
+        `;
+
+        const queryResult$ = graphqlObservable(query, serviceSchema, {
+          serviceName: "test",
+          planName: "plan-02"
+        });
+
+        const expected$ = m.cold("-x-x-(x|)", {
+          x: {
+            data: {
+              service: {
+                name: "test",
+                plans: [
+                  {
+                    name: "plan-02",
+                    status: "IN_PROGRESS"
+                  }
+                ]
+              }
+            }
+          }
+        });
+
+        m.expect(queryResult$.take(3)).toBeObservable(expected$);
+      })
+    );
+
+    it(
+      "shares the subscription",
+      marbles(m => {
+        m.bind();
+
+        const resolverConfig = makeResolverConfig(m);
+        resolverConfig.fetchServicePlanDetail = jest.fn(
+          resolverConfig.fetchServicePlanDetail
+        );
+
+        const serviceSchema = makeExecutableSchema({
+          typeDefs: schemas,
+          resolvers: resolvers(resolverConfig)
+        });
+
+        const query = gql`
+          query {
+            service(name: "test") {
+              name
+              plans(name: "test-plan") {
+                name
+              }
+            }
+          }
+        `;
+
+        Observable.concat(
+          graphqlObservable(query, serviceSchema, {}).take(1),
+          graphqlObservable(query, serviceSchema, {}).take(1),
+          graphqlObservable(query, serviceSchema, {}).take(1),
+          graphqlObservable(query, serviceSchema, {}).take(1),
+          graphqlObservable(query, serviceSchema, {}).take(1),
+          graphqlObservable(query, serviceSchema, {}).take(1),
+          graphqlObservable(query, serviceSchema, {}).take(1),
+          graphqlObservable(query, serviceSchema, {}).take(1),
+          graphqlObservable(query, serviceSchema, {}).take(1),
+          graphqlObservable(query, serviceSchema, {}).take(1),
+          graphqlObservable(query, serviceSchema, {}).take(1)
+        ).subscribe(jest.fn(), jest.fn(), () => {
+          expect(resolverConfig.fetchServicePlanDetail).toHaveBeenCalledTimes(
+            1
+          );
+        });
+      })
+    );
+
+    it(
+      "throws an error if API returns non-200",
+      marbles(m => {
+        m.bind();
+
+        const resolversConfig = makeResolverConfig(m);
+        resolversConfig.fetchServicePlanDetail = (
+          _serviceName: string,
+          _planName: string
+        ) =>
+          m.cold("(j|)", {
+            j: { code: 500, message: "Internal Server Error", response: {} }
+          });
+
+        const serviceSchema = makeExecutableSchema({
+          typeDefs: schemas,
+          resolvers: resolvers(resolversConfig)
+        });
+
+        const query = gql`
+          query {
+            service(name: $serviceName) {
+              name
+              plans(name: $planName) {
+                name
+              }
+            }
+          }
+        `;
+
+        const queryResult$ = graphqlObservable(query, serviceSchema, {
+          serviceName: "test"
+        }).take(1);
+
+        const expected$ = m.cold("#", undefined, {
+          message:
+            "Service plan detail API request failed: 500 Internal Server Error:{}",
+          name: "Error"
+        });
+
+        m.expect(queryResult$).toBeObservable(expected$);
+      })
+    );
+  });
+});

--- a/plugins/services/src/js/data/index.ts
+++ b/plugins/services/src/js/data/index.ts
@@ -1,0 +1,164 @@
+import { makeExecutableSchema } from "graphql-tools";
+import { ServicePlanStatusSchema } from "#PLUGINS/services/src/js/types/ServicePlanStatus";
+import { ServicePlanStepSchema } from "#PLUGINS/services/src/js/types/ServicePlanStep";
+import { ServicePlanPhaseSchema } from "#PLUGINS/services/src/js/types/ServicePlanPhase";
+import {
+  ServicePlanDetailResolver,
+  ServicePlanSchema
+} from "#PLUGINS/services/src/js/types/ServicePlan";
+import { Service, ServiceSchema } from "#PLUGINS/services/src/js/types/Service";
+import { Observable } from "rxjs";
+import { RequestResponse } from "@dcos/http-service";
+import {
+  fetchPlanDetails as fetchServicePlanDetail,
+  fetchPlans as fetchServicePlans,
+  ServicePlanResponse
+} from "#PLUGINS/services/src/js/data/ServicePlansClient";
+import Config from "#SRC/js/config/Config";
+
+export interface ResolverArgs {
+  fetchServicePlans: (
+    serviceName: string
+  ) => Observable<RequestResponse<string[]>>;
+  fetchServicePlanDetail: (
+    serviceName: string,
+    planName: string
+  ) => Observable<RequestResponse<ServicePlanResponse>>;
+  pollingInterval: number;
+}
+
+export interface GeneralArgs {
+  [key: string]: any;
+}
+
+export interface ServiceQueryArgs {
+  name: string;
+}
+
+function isServiceQueryArgs(args: GeneralArgs): args is ServiceQueryArgs {
+  return (args as ServiceQueryArgs).name !== undefined;
+}
+
+export interface PlansQueryArgs {
+  name: string;
+}
+
+function isPlansQueryArgs(args: GeneralArgs): args is PlansQueryArgs {
+  return (args as PlansQueryArgs).name !== undefined;
+}
+
+function handleAPIError(reqResp: RequestResponse<any>, message: string = "") {
+  if (reqResp.code !== 200) {
+    const respMessage =
+      reqResp.response && typeof reqResp.response === "object"
+        ? JSON.stringify(reqResp.response)
+        : reqResp.response;
+    throw new Error(
+      `${message}${message.length > 0 ? " " : ""}API request failed: ${
+        reqResp.code
+      } ${reqResp.message}:${respMessage}`
+    );
+  }
+}
+
+export const resolvers = ({
+  fetchServicePlans,
+  fetchServicePlanDetail,
+  pollingInterval
+}: ResolverArgs) => ({
+  Service: {
+    plans(parent: any, args: GeneralArgs = {}) {
+      if (!parent.name) {
+        return Observable.throw(
+          "Service name must be available to resolve plans"
+        );
+      }
+
+      const pollingInterval$ = Observable.timer(0, pollingInterval);
+      if (isPlansQueryArgs(args)) {
+        // If we're given a plan name, then only query that plan
+        const plan$ = pollingInterval$
+          .switchMap(() => fetchServicePlanDetail(parent.name, args.name))
+          .map(
+            (
+              reqResp: RequestResponse<ServicePlanResponse>
+            ): ServicePlanResponse[] => {
+              handleAPIError(reqResp, "Service plan detail");
+              return [ServicePlanDetailResolver(reqResp.response)];
+            }
+          );
+
+        return plan$;
+      } else {
+        // Otherwise query for all the service's plans, then pull details for each
+        // plan. Finally combine all of the detail's query observables.
+        const plans$ = pollingInterval$
+          .switchMap(() =>
+            fetchServicePlans(parent.name)
+              .map(
+                (reqResp: RequestResponse<string[]>): string[] => {
+                  handleAPIError(reqResp, "Service plans");
+                  return reqResp.response;
+                }
+              )
+              .map((plans: string[]) => {
+                return plans.map(name => ({ name }));
+              })
+          )
+          .switchMap(plans => {
+            const planDetials = plans.map(plan => {
+              return fetchServicePlanDetail(parent.name, plan.name).map(
+                (reqResp: RequestResponse<ServicePlanResponse>) => {
+                  handleAPIError(reqResp, "Service plan detail");
+                  return ServicePlanDetailResolver(reqResp.response);
+                }
+              );
+            });
+            return Observable.combineLatest(...planDetials);
+          });
+
+        return plans$;
+      }
+    }
+  },
+  Query: {
+    service(_parent = {}, args: GeneralArgs = {}) {
+      if (!isServiceQueryArgs(args)) {
+        return Observable.throw(
+          "Service resolver arguments aren't valid for type ServiceQueryArgs"
+        );
+      }
+
+      return Observable.of({ name: args.name });
+    }
+  }
+});
+
+const baseSchema = `
+type Query {
+  service(name: String!): Service
+}
+`;
+
+//Load All Sub Schemas
+export const schemas: string[] = [
+  ServicePlanStatusSchema,
+  ServicePlanStepSchema,
+  ServicePlanPhaseSchema,
+  ServicePlanSchema,
+  ServiceSchema,
+  baseSchema
+];
+
+export interface Query {
+  service: Service | null;
+}
+
+export default makeExecutableSchema({
+  typeDefs: schemas,
+  resolvers: resolvers({
+    fetchServicePlans,
+    fetchServicePlanDetail,
+    pollingInterval: Config.getRefreshRate()
+  })
+});

--- a/plugins/services/src/js/types/Service.ts
+++ b/plugins/services/src/js/types/Service.ts
@@ -1,0 +1,13 @@
+import { ServicePlan } from "#PLUGINS/services/src/js/types/ServicePlan";
+
+export interface Service {
+  name: string;
+  plans: ServicePlan[];
+}
+
+export const ServiceSchema = `
+type Service {
+  name: String!
+  plans(name: String = ""): [ServicePlan]!
+}
+`;

--- a/plugins/services/src/js/types/ServicePlan.ts
+++ b/plugins/services/src/js/types/ServicePlan.ts
@@ -1,8 +1,4 @@
-import { ServicePlanResponse } from "#PLUGINS/services/src/js/data/ServicePlansClient";
-import {
-  ServicePlanPhase,
-  ServicePlanPhasesResolver
-} from "#PLUGINS/services/src/js/types/ServicePlanPhase";
+import { ServicePlanPhase } from "#PLUGINS/services/src/js/types/ServicePlanPhase";
 import { ServicePlanStatus } from "#PLUGINS/services/src/js/types/ServicePlanStatus";
 
 export interface ServicePlan {
@@ -22,15 +18,3 @@ type ServicePlan {
   status: ServicePlanStatus!
 }
 `;
-
-export function ServicePlanDetailResolver(
-  response: ServicePlanResponse
-): ServicePlan {
-  return {
-    name: response.name,
-    phases: ServicePlanPhasesResolver(response.phases),
-    errors: response.errors,
-    strategy: response.strategy,
-    status: response.status as ServicePlanStatus
-  };
-}

--- a/plugins/services/src/js/types/ServicePlan.ts
+++ b/plugins/services/src/js/types/ServicePlan.ts
@@ -1,0 +1,36 @@
+import { ServicePlanResponse } from "#PLUGINS/services/src/js/data/ServicePlansClient";
+import {
+  ServicePlanPhase,
+  ServicePlanPhasesResolver
+} from "#PLUGINS/services/src/js/types/ServicePlanPhase";
+import { ServicePlanStatus } from "#PLUGINS/services/src/js/types/ServicePlanStatus";
+
+export interface ServicePlan {
+  name: string;
+  phases: ServicePlanPhase[];
+  status: ServicePlanStatus;
+  errors: string[];
+  strategy: string;
+}
+
+export const ServicePlanSchema = `
+type ServicePlan {
+  name: String!
+  phases: [ServicePlanPhase!]!
+  errors: [String!]!
+  strategy: String!
+  status: ServicePlanStatus!
+}
+`;
+
+export function ServicePlanDetailResolver(
+  response: ServicePlanResponse
+): ServicePlan {
+  return {
+    name: response.name,
+    phases: ServicePlanPhasesResolver(response.phases),
+    errors: response.errors,
+    strategy: response.strategy,
+    status: response.status as ServicePlanStatus
+  };
+}

--- a/plugins/services/src/js/types/ServicePlanPhase.ts
+++ b/plugins/services/src/js/types/ServicePlanPhase.ts
@@ -1,0 +1,42 @@
+import { ServicePlanStatus } from "#PLUGINS/services/src/js/types/ServicePlanStatus";
+import { ServicePlanPhaseResponse } from "#PLUGINS/services/src/js/data/ServicePlansClient";
+import {
+  ServicePlanStep,
+  ServicePlanStepsResolver
+} from "#PLUGINS/services/src/js/types/ServicePlanStep";
+
+export interface ServicePlanPhase {
+  id: string;
+  name: string;
+  steps: ServicePlanStep[];
+  strategy: string;
+  status: ServicePlanStatus;
+}
+
+export const ServicePlanPhaseSchema = `
+type ServicePlanPhase {
+  id: String!
+  name: String!
+  steps: [ServicePlanStep!]!
+  strategy: String!
+  status: ServicePlanStatus!
+}
+`;
+
+export function ServicePlanPhasesResolver(
+  phases: ServicePlanPhaseResponse[]
+): ServicePlanPhase[] {
+  return phases.map(ServicePlanPhaseResolver);
+}
+
+export function ServicePlanPhaseResolver(
+  phase: ServicePlanPhaseResponse
+): ServicePlanPhase {
+  return {
+    id: phase.id,
+    name: phase.name,
+    steps: ServicePlanStepsResolver(phase.steps),
+    strategy: phase.strategy,
+    status: phase.status as ServicePlanStatus
+  };
+}

--- a/plugins/services/src/js/types/ServicePlanPhase.ts
+++ b/plugins/services/src/js/types/ServicePlanPhase.ts
@@ -1,9 +1,5 @@
 import { ServicePlanStatus } from "#PLUGINS/services/src/js/types/ServicePlanStatus";
-import { ServicePlanPhaseResponse } from "#PLUGINS/services/src/js/data/ServicePlansClient";
-import {
-  ServicePlanStep,
-  ServicePlanStepsResolver
-} from "#PLUGINS/services/src/js/types/ServicePlanStep";
+import { ServicePlanStep } from "#PLUGINS/services/src/js/types/ServicePlanStep";
 
 export interface ServicePlanPhase {
   id: string;
@@ -22,21 +18,3 @@ type ServicePlanPhase {
   status: ServicePlanStatus!
 }
 `;
-
-export function ServicePlanPhasesResolver(
-  phases: ServicePlanPhaseResponse[]
-): ServicePlanPhase[] {
-  return phases.map(ServicePlanPhaseResolver);
-}
-
-export function ServicePlanPhaseResolver(
-  phase: ServicePlanPhaseResponse
-): ServicePlanPhase {
-  return {
-    id: phase.id,
-    name: phase.name,
-    steps: ServicePlanStepsResolver(phase.steps),
-    strategy: phase.strategy,
-    status: phase.status as ServicePlanStatus
-  };
-}

--- a/plugins/services/src/js/types/ServicePlanStatus.ts
+++ b/plugins/services/src/js/types/ServicePlanStatus.ts
@@ -1,0 +1,22 @@
+export type ServicePlanStatus =
+  | "ERROR"
+  | "WAITING"
+  | "PENDING"
+  | "PREPARED"
+  | "STARTING"
+  | "STARTED"
+  | "COMPLETE"
+  | "IN_PROGRESS";
+
+export const ServicePlanStatusSchema = `
+enum ServicePlanStatus {
+  ERROR
+  WAITING
+  PENDING
+  PREPARED
+  STARTING
+  STARTED
+  COMPLETE
+  IN_PROGRESS
+}
+`;

--- a/plugins/services/src/js/types/ServicePlanStep.ts
+++ b/plugins/services/src/js/types/ServicePlanStep.ts
@@ -1,0 +1,29 @@
+import { ServicePlanStatus } from "#PLUGINS/services/src/js/types/ServicePlanStatus";
+import { ServicePlanStepResponse } from "#PLUGINS/services/src/js/data/ServicePlansClient";
+
+export interface ServicePlanStep {
+  id: string;
+  name: string;
+  status: ServicePlanStatus;
+  message: string;
+}
+
+export const ServicePlanStepSchema = `
+type ServicePlanStep {
+  id: String!
+  name: String!
+  status: ServicePlanStatus!
+  message: String!
+}
+`;
+
+export function ServicePlanStepsResolver(
+  steps: ServicePlanStepResponse[]
+): ServicePlanStep[] {
+  return steps.map(step => ({
+    id: step.id,
+    name: step.name,
+    status: step.status as ServicePlanStatus,
+    message: step.message
+  }));
+}

--- a/plugins/services/src/js/types/ServicePlanStep.ts
+++ b/plugins/services/src/js/types/ServicePlanStep.ts
@@ -1,5 +1,4 @@
 import { ServicePlanStatus } from "#PLUGINS/services/src/js/types/ServicePlanStatus";
-import { ServicePlanStepResponse } from "#PLUGINS/services/src/js/data/ServicePlansClient";
 
 export interface ServicePlanStep {
   id: string;
@@ -16,14 +15,3 @@ type ServicePlanStep {
   message: String!
 }
 `;
-
-export function ServicePlanStepsResolver(
-  steps: ServicePlanStepResponse[]
-): ServicePlanStep[] {
-  return steps.map(step => ({
-    id: step.id,
-    name: step.name,
-    status: step.status as ServicePlanStatus,
-    message: step.message
-  }));
-}


### PR DESCRIPTION
Introducing data-layer for the services plugin. We are adding this to
support querying for a SDK service's plans. These will be displayed in
the UI. To support querying other service information through the
data-layer the root query object is the `Service` even though currently
this only supports a name and the plans.

## Testing

For now just run the unit tests, but component coming soon!

## Trade-offs

A graphql query that includes `plans` will result in `n+1` requests to the API. A service should have a limited number of plans and 🤞 never more then 100, but this is something we should be aware of when building service queries. We should be mindful of the performance implications of the `graphqlobservalble` polling with `n+1 `queries as well.
