### PR TITLE
DCOS-47175: Update Table component in nodes page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,9 +85,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.6.tgz",
-      "integrity": "sha512-DMiUzlY9DSjVsOylJssxLHSgj6tWM9PRFJOGW/RaOglVOK9nzTxoOMfTfRQXGUCUQ/HmlG2efwC+XqUEJ5ay4w==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.0.tgz",
+      "integrity": "sha512-QkFPw68QqWU1/RVPyBe8SO7lXbPfjtqAxRYQKpFpaB8yMq7X2qAqfwK5LKoQufEkSmO5NQ70O6Kc3Afk03RwXw==",
       "requires": {
         "esutils": "^2.0.2",
         "lodash": "^4.17.10",
@@ -1016,150 +1016,32 @@
       "integrity": "sha512-inJlb0Idr6frKKVJNweG4t3BUbrvfSPhtwTuMzjLIUjSjEzu+/bNmSb4FrZcSfOGW9KCsvWY2pP4HMaoKzu86g=="
     },
     "@dcos/ui-kit": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@dcos/ui-kit/-/ui-kit-1.17.1.tgz",
-      "integrity": "sha512-0H1SDhPOcgxcfnM/N9E6n8JUnc8dtZ+ovg76h0Ndh9N+AKMmtOX3lDQKGLY77p5TnlvrFrHb0ovk2KXW1ZBuzQ==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@dcos/ui-kit/-/ui-kit-1.26.0.tgz",
+      "integrity": "sha512-xQqfv2mDzZjIVPwkaX2Hd/IeyCSCXma+R3xVLcTvWn4OqyX0Tx9UgoEVOfdazLtG6oUNGUH6ho3khv8n7KWyHg==",
       "requires": {
         "emotion": "9.2.12",
+        "emotion-theming": "9.2.9",
+        "focus-trap-react": "4.0.1",
         "memoize-one": "4.0.2",
-        "react": "16.5.2",
-        "react-dom": "16.5.2",
+        "react-click-outside": "3.0.1",
+        "react-delegate-component": "1.0.0",
         "react-emotion": "9.2.12",
+        "react-toggled": "1.2.7",
         "react-transition-group": "2.5.0",
         "react-virtualized": "9.20.1",
-        "semantic-release": "^15.9.6"
+        "semantic-release": "15.9.6"
       },
       "dependencies": {
-        "@octokit/rest": {
-          "version": "16.0.1",
-          "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.0.1.tgz",
-          "integrity": "sha512-4Vbn3TtKADUOSk9usbfJ6XsEErt9h6Thms6EejI/MWMeVqdY5a3NevbAp7rVSXBl2xYIw3erPLkeFpGg+RmkoQ==",
-          "requires": {
-            "@octokit/request": "2.1.1",
-            "before-after-hook": "^1.2.0",
-            "btoa-lite": "^1.0.0",
-            "lodash.get": "^4.4.2",
-            "lodash.pick": "^4.4.0",
-            "lodash.set": "^4.3.2",
-            "lodash.uniq": "^4.5.0",
-            "node-fetch": "^2.1.1",
-            "octokit-pagination-methods": "^1.1.0",
-            "universal-user-agent": "^2.0.0",
-            "url-template": "^2.0.8"
-          }
-        },
-        "@semantic-release/commit-analyzer": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-6.1.0.tgz",
-          "integrity": "sha512-2lb+t6muGenI86mYGpZYOgITx9L3oZYF697tJoqXeQEk0uw0fm+OkkOuDTBA3Oax9ftoNIrCKv9bwgYvxrbM6w==",
-          "requires": {
-            "conventional-changelog-angular": "^5.0.0",
-            "conventional-commits-filter": "^2.0.0",
-            "conventional-commits-parser": "^3.0.0",
-            "debug": "^4.0.0",
-            "import-from": "^2.1.0",
-            "lodash": "^4.17.4"
-          }
-        },
-        "@semantic-release/github": {
-          "version": "5.2.4",
-          "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-5.2.4.tgz",
-          "integrity": "sha512-6WSOaHZLk1e5Cs9digWJnysN7HYJZsNAIckrGJbVSDcwIxb0KtEyp0V4G02VCJNNDjOLJBMMaIhA+lPdiGOqrw==",
-          "requires": {
-            "@octokit/rest": "^16.0.1",
-            "@semantic-release/error": "^2.2.0",
-            "aggregate-error": "^1.0.0",
-            "bottleneck": "^2.0.1",
-            "debug": "^4.0.0",
-            "dir-glob": "^2.0.0",
-            "fs-extra": "^7.0.0",
-            "globby": "^8.0.0",
-            "http-proxy-agent": "^2.1.0",
-            "https-proxy-agent": "^2.2.1",
-            "issue-parser": "^3.0.0",
-            "lodash": "^4.17.4",
-            "mime": "^2.0.3",
-            "p-filter": "^1.0.0",
-            "p-retry": "^2.0.0",
-            "parse-github-url": "^1.0.1",
-            "url-join": "^4.0.0"
-          }
-        },
-        "@semantic-release/npm": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-5.1.1.tgz",
-          "integrity": "sha512-5OnV0od1HKp2QjToXxQufvHNG8n+IQlp7h3FjqmZYH7DAHzAGx4NCf/R4p3RhyX5YJEfQl4ZflX9219JVNsuJg==",
-          "requires": {
-            "@semantic-release/error": "^2.2.0",
-            "aggregate-error": "^1.0.0",
-            "execa": "^1.0.0",
-            "fs-extra": "^7.0.0",
-            "lodash": "^4.17.4",
-            "nerf-dart": "^1.0.0",
-            "normalize-url": "^4.0.0",
-            "npm": "^6.3.0",
-            "rc": "^1.2.8",
-            "read-pkg": "^4.0.0",
-            "registry-auth-token": "^3.3.1"
-          },
-          "dependencies": {
-            "read-pkg": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-4.0.1.tgz",
-              "integrity": "sha1-ljYlN48+HE1IyFhytabsfV0JMjc=",
-              "requires": {
-                "normalize-package-data": "^2.3.2",
-                "parse-json": "^4.0.0",
-                "pify": "^3.0.0"
-              }
-            }
-          }
-        },
-        "@semantic-release/release-notes-generator": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-7.1.4.tgz",
-          "integrity": "sha512-pWPouZujddgb6t61t9iA9G3yIfp3TeQ7bPbV1ixYSeP6L7gI1+Du82fY/OHfEwyifpymLUQW0XnIKgKct5IMMw==",
-          "requires": {
-            "conventional-changelog-angular": "^5.0.0",
-            "conventional-changelog-writer": "^4.0.0",
-            "conventional-commits-filter": "^2.0.0",
-            "conventional-commits-parser": "^3.0.0",
-            "debug": "^4.0.0",
-            "get-stream": "^4.0.0",
-            "import-from": "^2.1.0",
-            "into-stream": "^4.0.0",
-            "lodash": "^4.17.4"
-          }
-        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
-        "array-uniq": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-2.0.0.tgz",
-          "integrity": "sha512-O3QZEr+3wDj7otzF7PjNGs6CA3qmYMLvt5xGkjY/V0VxS+ovvqVo/5wKM/OVOAyuX4DTh9H31zE/yKtO66hTkg=="
-        },
-        "before-after-hook": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.2.0.tgz",
-          "integrity": "sha512-wI3QtdLppHNkmM1VgRVLCrlWCKk/YexlPicYbXPs4eYdd1InrUCTFsx5bX1iUQzzMsoRXXPpM1r+p7JEJJydag=="
-        },
         "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-        },
-        "camelcase-keys": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
-          "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
-          "requires": {
-            "camelcase": "^4.1.0",
-            "map-obj": "^2.0.0",
-            "quick-lru": "^1.0.0"
-          }
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
         },
         "cliui": {
           "version": "4.1.0",
@@ -1169,29 +1051,6 @@
             "string-width": "^2.1.1",
             "strip-ansi": "^4.0.0",
             "wrap-ansi": "^2.0.0"
-          }
-        },
-        "conventional-changelog-angular": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.2.tgz",
-          "integrity": "sha512-yx7m7lVrXmt4nKWQgWZqxSALEiAKZhOAcbxdUaU9575mB0CzXVbgrgpfSnSP7OqWDUTYGD0YVJ0MSRdyOPgAwA==",
-          "requires": {
-            "compare-func": "^1.3.1",
-            "q": "^1.5.1"
-          }
-        },
-        "conventional-commits-parser": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.1.tgz",
-          "integrity": "sha512-P6U5UOvDeidUJ8ebHVDIoXzI7gMlQ1OF/id6oUvp8cnZvOXMt1n8nYl74Ey9YMn0uVQtxmCtjPQawpsssBWtGg==",
-          "requires": {
-            "JSONStream": "^1.0.4",
-            "is-text-path": "^1.0.0",
-            "lodash": "^4.2.1",
-            "meow": "^4.0.0",
-            "split2": "^2.0.0",
-            "through2": "^2.0.0",
-            "trim-off-newlines": "^1.0.0"
           }
         },
         "cosmiconfig": {
@@ -1218,17 +1077,12 @@
           }
         },
         "debug": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "deep-extend": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
         },
         "end-of-stream": {
           "version": "1.4.1",
@@ -1238,27 +1092,18 @@
             "once": "^1.4.0"
           }
         },
-        "env-ci": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-3.1.1.tgz",
-          "integrity": "sha512-1UUsCAvRcm263a2mTvEHm2Q1MXyH2z+e8jkiCSHfO1153LOeDKEbrsc0U4qgXEoVsoJ2rYe6lxsrofBcZCcKEg==",
-          "requires": {
-            "execa": "^1.0.0",
-            "java-properties": "^0.2.9"
-          }
-        },
         "esprima": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
           "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
         },
         "execa": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
           "requires": {
             "cross-spawn": "^6.0.0",
-            "get-stream": "^4.0.0",
+            "get-stream": "^3.0.0",
             "is-stream": "^1.1.0",
             "npm-run-path": "^2.0.0",
             "p-finally": "^1.0.0",
@@ -1275,85 +1120,26 @@
           }
         },
         "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "^3.0.0"
           }
         },
         "find-versions": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-3.0.0.tgz",
-          "integrity": "sha512-IUvtItVFNmTtKoB0PRfbkR0zR9XMG5rWNO3qI1S8L0zdv+v2gqzM0pAunloxqbqAfT8w7bg8n/5gHzTXte8H5A==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-2.0.0.tgz",
+          "integrity": "sha1-KtkNSQ9oKMGqQCks9wmsMxghDDw=",
           "requires": {
-            "array-uniq": "^2.0.0",
-            "semver-regex": "^2.0.0"
-          }
-        },
-        "fs-extra": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "get-stream": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "globby": {
-          "version": "8.0.1",
-          "resolved": "http://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
-          "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
-          "requires": {
-            "array-union": "^1.0.1",
-            "dir-glob": "^2.0.0",
-            "fast-glob": "^2.0.2",
-            "glob": "^7.1.2",
-            "ignore": "^3.3.5",
-            "pify": "^3.0.0",
-            "slash": "^1.0.0"
+            "array-uniq": "^1.0.0",
+            "semver-regex": "^1.0.0"
           }
         },
         "hosted-git-info": {
           "version": "2.7.1",
           "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
           "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
-        },
-        "indent-string": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
-        },
-        "into-stream": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-4.0.0.tgz",
-          "integrity": "sha512-i29KNyE5r0Y/UQzcQ0IbZO1MYJ53Jn0EcFRZPj5FzWKYH17kDFEOwuA+3jroymOI06SW1dEDnly9A1CAreC5dg==",
-          "requires": {
-            "from2": "^2.1.1",
-            "p-is-promise": "^2.0.0"
-          }
         },
         "invert-kv": {
           "version": "2.0.0",
@@ -1365,38 +1151,13 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "issue-parser": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-3.0.0.tgz",
-          "integrity": "sha512-VWIhBdy0eOhlvpxOOMecBCHMpjx7lWVZcYpSzjD4dSdxptzI9TBR/cQEh057HL8+7jQKTLs+uCtezY/9VoveCA==",
-          "requires": {
-            "lodash.capitalize": "^4.2.1",
-            "lodash.escaperegexp": "^4.1.2",
-            "lodash.isplainobject": "^4.0.6",
-            "lodash.isstring": "^4.0.1",
-            "lodash.uniqby": "^4.7.0"
-          }
-        },
         "js-yaml": {
-          "version": "3.12.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-          "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+          "version": "3.12.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
+          "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
           "requires": {
             "argparse": "^1.0.7",
             "esprima": "^4.0.0"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "requires": {
-            "graceful-fs": "^4.1.6"
           }
         },
         "lcid": {
@@ -1418,20 +1179,32 @@
             "strip-bom": "^3.0.0"
           }
         },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
         "lodash": {
           "version": "4.17.11",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
           "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
         },
-        "map-obj": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-          "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
+        "loose-envify": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
         },
         "marked": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.5.2.tgz",
-          "integrity": "sha512-fdZvBa7/vSQIZCi4uuwo2N3q+7jJURpMVCcbaX0S1Mg65WZ5ilXvC67MviJAsdjqqgD+CEq4RKo5AYGgINkVAA=="
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
+          "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw=="
         },
         "mem": {
           "version": "4.0.0",
@@ -1441,53 +1214,6 @@
             "map-age-cleaner": "^0.1.1",
             "mimic-fn": "^1.0.0",
             "p-is-promise": "^1.1.0"
-          },
-          "dependencies": {
-            "p-is-promise": {
-              "version": "1.1.0",
-              "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
-              "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
-            }
-          }
-        },
-        "meow": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
-          "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
-          "requires": {
-            "camelcase-keys": "^4.0.0",
-            "decamelize-keys": "^1.0.0",
-            "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
-            "minimist-options": "^3.0.1",
-            "normalize-package-data": "^2.3.4",
-            "read-pkg-up": "^3.0.0",
-            "redent": "^2.0.0",
-            "trim-newlines": "^2.0.0"
-          },
-          "dependencies": {
-            "read-pkg-up": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-              "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-              "requires": {
-                "find-up": "^2.0.0",
-                "read-pkg": "^3.0.0"
-              }
-            }
-          }
-        },
-        "mime": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
-          "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "requires": {
-            "brace-expansion": "^1.1.7"
           }
         },
         "ms": {
@@ -1495,3120 +1221,28 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         },
-        "node-fetch": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
-          "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
-        },
-        "normalize-url": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.0.0.tgz",
-          "integrity": "sha512-OrtNzJOeI9+UaF8KfvPoqh8ZVjLiun+fggtLzrpPsmdOU01eIp3vYXDfeFv4KwqJxcmmrW/ubNCN+9iIQRVtfw=="
-        },
-        "npm": {
-          "version": "6.4.1",
-          "resolved": "https://registry.npmjs.org/npm/-/npm-6.4.1.tgz",
-          "integrity": "sha512-mXJL1NTVU136PtuopXCUQaNWuHlXCTp4McwlSW8S9/Aj8OEPAlSBgo8og7kJ01MjCDrkmqFQTvN5tTEhBMhXQg==",
-          "requires": {
-            "JSONStream": "^1.3.4",
-            "abbrev": "~1.1.1",
-            "ansicolors": "~0.3.2",
-            "ansistyles": "~0.1.3",
-            "aproba": "~1.2.0",
-            "archy": "~1.0.0",
-            "bin-links": "^1.1.2",
-            "bluebird": "~3.5.1",
-            "byte-size": "^4.0.3",
-            "cacache": "^11.2.0",
-            "call-limit": "~1.1.0",
-            "chownr": "~1.0.1",
-            "ci-info": "^1.4.0",
-            "cli-columns": "^3.1.2",
-            "cli-table3": "^0.5.0",
-            "cmd-shim": "~2.0.2",
-            "columnify": "~1.5.4",
-            "config-chain": "~1.1.11",
-            "debuglog": "*",
-            "detect-indent": "~5.0.0",
-            "detect-newline": "^2.1.0",
-            "dezalgo": "~1.0.3",
-            "editor": "~1.0.0",
-            "figgy-pudding": "^3.4.1",
-            "find-npm-prefix": "^1.0.2",
-            "fs-vacuum": "~1.2.10",
-            "fs-write-stream-atomic": "~1.0.10",
-            "gentle-fs": "^2.0.1",
-            "glob": "~7.1.2",
-            "graceful-fs": "~4.1.11",
-            "has-unicode": "~2.0.1",
-            "hosted-git-info": "^2.7.1",
-            "iferr": "^1.0.2",
-            "imurmurhash": "*",
-            "inflight": "~1.0.6",
-            "inherits": "~2.0.3",
-            "ini": "^1.3.5",
-            "init-package-json": "^1.10.3",
-            "is-cidr": "^2.0.6",
-            "json-parse-better-errors": "^1.0.2",
-            "lazy-property": "~1.0.0",
-            "libcipm": "^2.0.2",
-            "libnpmhook": "^4.0.1",
-            "libnpx": "^10.2.0",
-            "lock-verify": "^2.0.2",
-            "lockfile": "^1.0.4",
-            "lodash._baseindexof": "*",
-            "lodash._baseuniq": "~4.6.0",
-            "lodash._bindcallback": "*",
-            "lodash._cacheindexof": "*",
-            "lodash._createcache": "*",
-            "lodash._getnative": "*",
-            "lodash.clonedeep": "~4.5.0",
-            "lodash.restparam": "*",
-            "lodash.union": "~4.6.0",
-            "lodash.uniq": "~4.5.0",
-            "lodash.without": "~4.4.0",
-            "lru-cache": "^4.1.3",
-            "meant": "~1.0.1",
-            "mississippi": "^3.0.0",
-            "mkdirp": "~0.5.1",
-            "move-concurrently": "^1.0.1",
-            "node-gyp": "^3.8.0",
-            "nopt": "~4.0.1",
-            "normalize-package-data": "~2.4.0",
-            "npm-audit-report": "^1.3.1",
-            "npm-cache-filename": "~1.0.2",
-            "npm-install-checks": "~3.0.0",
-            "npm-lifecycle": "^2.1.0",
-            "npm-package-arg": "^6.1.0",
-            "npm-packlist": "^1.1.11",
-            "npm-pick-manifest": "^2.1.0",
-            "npm-profile": "^3.0.2",
-            "npm-registry-client": "^8.6.0",
-            "npm-registry-fetch": "^1.1.0",
-            "npm-user-validate": "~1.0.0",
-            "npmlog": "~4.1.2",
-            "once": "~1.4.0",
-            "opener": "^1.5.0",
-            "osenv": "^0.1.5",
-            "pacote": "^8.1.6",
-            "path-is-inside": "~1.0.2",
-            "promise-inflight": "~1.0.1",
-            "qrcode-terminal": "^0.12.0",
-            "query-string": "^6.1.0",
-            "qw": "~1.0.1",
-            "read": "~1.0.7",
-            "read-cmd-shim": "~1.0.1",
-            "read-installed": "~4.0.3",
-            "read-package-json": "^2.0.13",
-            "read-package-tree": "^5.2.1",
-            "readable-stream": "^2.3.6",
-            "readdir-scoped-modules": "*",
-            "request": "^2.88.0",
-            "retry": "^0.12.0",
-            "rimraf": "~2.6.2",
-            "safe-buffer": "^5.1.2",
-            "semver": "^5.5.0",
-            "sha": "~2.0.1",
-            "slide": "~1.1.6",
-            "sorted-object": "~2.0.1",
-            "sorted-union-stream": "~2.1.3",
-            "ssri": "^6.0.0",
-            "stringify-package": "^1.0.0",
-            "tar": "^4.4.6",
-            "text-table": "~0.2.0",
-            "tiny-relative-date": "^1.3.0",
-            "uid-number": "0.0.6",
-            "umask": "~1.1.0",
-            "unique-filename": "~1.1.0",
-            "unpipe": "~1.0.0",
-            "update-notifier": "^2.5.0",
-            "uuid": "^3.3.2",
-            "validate-npm-package-license": "^3.0.4",
-            "validate-npm-package-name": "~3.0.0",
-            "which": "^1.3.1",
-            "worker-farm": "^1.6.0",
-            "write-file-atomic": "^2.3.0"
-          },
-          "dependencies": {
-            "JSONStream": {
-              "version": "1.3.4",
-              "resolved": false,
-              "integrity": "sha512-Y7vfi3I5oMOYIr+WxV8NZxDSwcbNgzdKYsTNInmycOq9bUYwGg9ryu57Wg5NLmCjqdFPNUmpMBo3kSJN9tCbXg==",
-              "requires": {
-                "jsonparse": "^1.2.0",
-                "through": ">=2.2.7 <3"
-              }
-            },
-            "abbrev": {
-              "version": "1.1.1",
-              "resolved": false,
-              "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-            },
-            "agent-base": {
-              "version": "4.2.0",
-              "resolved": false,
-              "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
-              "requires": {
-                "es6-promisify": "^5.0.0"
-              }
-            },
-            "agentkeepalive": {
-              "version": "3.4.1",
-              "resolved": false,
-              "integrity": "sha512-MPIwsZU9PP9kOrZpyu2042kYA8Fdt/AedQYkYXucHgF9QoD9dXVp0ypuGnHXSR0hTstBxdt85Xkh4JolYfK5wg==",
-              "requires": {
-                "humanize-ms": "^1.2.1"
-              }
-            },
-            "ajv": {
-              "version": "5.5.2",
-              "resolved": false,
-              "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-              "requires": {
-                "co": "^4.6.0",
-                "fast-deep-equal": "^1.0.0",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.3.0"
-              }
-            },
-            "ansi-align": {
-              "version": "2.0.0",
-              "resolved": false,
-              "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
-              "requires": {
-                "string-width": "^2.0.0"
-              }
-            },
-            "ansi-regex": {
-              "version": "2.1.1",
-              "resolved": false,
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-            },
-            "ansi-styles": {
-              "version": "3.2.1",
-              "resolved": false,
-              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-              "requires": {
-                "color-convert": "^1.9.0"
-              }
-            },
-            "ansicolors": {
-              "version": "0.3.2",
-              "resolved": false,
-              "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk="
-            },
-            "ansistyles": {
-              "version": "0.1.3",
-              "resolved": false,
-              "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk="
-            },
-            "aproba": {
-              "version": "1.2.0",
-              "resolved": false,
-              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
-            },
-            "archy": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
-            },
-            "are-we-there-yet": {
-              "version": "1.1.4",
-              "resolved": false,
-              "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-              "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
-              }
-            },
-            "asap": {
-              "version": "2.0.6",
-              "resolved": false,
-              "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-            },
-            "asn1": {
-              "version": "0.2.4",
-              "resolved": false,
-              "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-              "requires": {
-                "safer-buffer": "~2.1.0"
-              }
-            },
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-            },
-            "asynckit": {
-              "version": "0.4.0",
-              "resolved": false,
-              "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-            },
-            "aws-sign2": {
-              "version": "0.7.0",
-              "resolved": false,
-              "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-            },
-            "aws4": {
-              "version": "1.8.0",
-              "resolved": false,
-              "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
-            },
-            "balanced-match": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-            },
-            "bcrypt-pbkdf": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-              "optional": true,
-              "requires": {
-                "tweetnacl": "^0.14.3"
-              }
-            },
-            "bin-links": {
-              "version": "1.1.2",
-              "resolved": false,
-              "integrity": "sha512-8eEHVgYP03nILphilltWjeIjMbKyJo3wvp9K816pHbhP301ismzw15mxAAEVQ/USUwcP++1uNrbERbp8lOA6Fg==",
-              "requires": {
-                "bluebird": "^3.5.0",
-                "cmd-shim": "^2.0.2",
-                "gentle-fs": "^2.0.0",
-                "graceful-fs": "^4.1.11",
-                "write-file-atomic": "^2.3.0"
-              }
-            },
-            "block-stream": {
-              "version": "0.0.9",
-              "resolved": false,
-              "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-              "requires": {
-                "inherits": "~2.0.0"
-              }
-            },
-            "bluebird": {
-              "version": "3.5.1",
-              "resolved": false,
-              "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
-            },
-            "boxen": {
-              "version": "1.3.0",
-              "resolved": false,
-              "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
-              "requires": {
-                "ansi-align": "^2.0.0",
-                "camelcase": "^4.0.0",
-                "chalk": "^2.0.1",
-                "cli-boxes": "^1.0.0",
-                "string-width": "^2.0.0",
-                "term-size": "^1.2.0",
-                "widest-line": "^2.0.0"
-              }
-            },
-            "brace-expansion": {
-              "version": "1.1.11",
-              "resolved": false,
-              "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-              "requires": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-              }
-            },
-            "buffer-from": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
-            },
-            "builtin-modules": {
-              "version": "1.1.1",
-              "resolved": false,
-              "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
-            },
-            "builtins": {
-              "version": "1.0.3",
-              "resolved": false,
-              "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
-            },
-            "byline": {
-              "version": "5.0.0",
-              "resolved": false,
-              "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
-            },
-            "byte-size": {
-              "version": "4.0.3",
-              "resolved": false,
-              "integrity": "sha512-JGC3EV2bCzJH/ENSh3afyJrH4vwxbHTuO5ljLoI5+2iJOcEpMgP8T782jH9b5qGxf2mSUIp1lfGnfKNrRHpvVg=="
-            },
-            "cacache": {
-              "version": "11.2.0",
-              "resolved": false,
-              "integrity": "sha512-IFWl6lfK6wSeYCHUXh+N1lY72UDrpyrYQJNIVQf48paDuWbv5RbAtJYf/4gUQFObTCHZwdZ5sI8Iw7nqwP6nlQ==",
-              "requires": {
-                "bluebird": "^3.5.1",
-                "chownr": "^1.0.1",
-                "figgy-pudding": "^3.1.0",
-                "glob": "^7.1.2",
-                "graceful-fs": "^4.1.11",
-                "lru-cache": "^4.1.3",
-                "mississippi": "^3.0.0",
-                "mkdirp": "^0.5.1",
-                "move-concurrently": "^1.0.1",
-                "promise-inflight": "^1.0.1",
-                "rimraf": "^2.6.2",
-                "ssri": "^6.0.0",
-                "unique-filename": "^1.1.0",
-                "y18n": "^4.0.0"
-              }
-            },
-            "call-limit": {
-              "version": "1.1.0",
-              "resolved": false,
-              "integrity": "sha1-b9YbA/PaQqLNDsK2DwK9DnGZH+o="
-            },
-            "camelcase": {
-              "version": "4.1.0",
-              "resolved": false,
-              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-            },
-            "capture-stack-trace": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "resolved": false,
-              "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-            },
-            "chalk": {
-              "version": "2.4.1",
-              "resolved": false,
-              "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              }
-            },
-            "chownr": {
-              "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
-            },
-            "ci-info": {
-              "version": "1.4.0",
-              "resolved": false,
-              "integrity": "sha512-Oqmw2pVfCl8sCL+1QgMywPfdxPJPkC51y4usw0iiE2S9qnEOAqXy8bwl1CpMpnoU39g4iKJTz6QZj+28FvOnjQ=="
-            },
-            "cidr-regex": {
-              "version": "2.0.9",
-              "resolved": false,
-              "integrity": "sha512-F7/fBRUU45FnvSPjXdpIrc++WRSBdCiSTlyq4ZNhLKOlHFNWgtzZ0Fd+zrqI/J1j0wmlx/f5ZQDmD2GcbrNcmw==",
-              "requires": {
-                "ip-regex": "^2.1.0"
-              }
-            },
-            "cli-boxes": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
-            },
-            "cli-columns": {
-              "version": "3.1.2",
-              "resolved": false,
-              "integrity": "sha1-ZzLZcpee/CrkRKHwjgj6E5yWoY4=",
-              "requires": {
-                "string-width": "^2.0.0",
-                "strip-ansi": "^3.0.1"
-              }
-            },
-            "cli-table3": {
-              "version": "0.5.0",
-              "resolved": false,
-              "integrity": "sha512-c7YHpUyO1SaKaO7kYtxd5NZ8FjAmSK3LpKkuzdwn+2CwpFxBpdoQLm+OAnnCfoEl7onKhN9PKQi1lsHuAIUqGQ==",
-              "requires": {
-                "colors": "^1.1.2",
-                "object-assign": "^4.1.0",
-                "string-width": "^2.1.1"
-              }
-            },
-            "cliui": {
-              "version": "4.1.0",
-              "resolved": false,
-              "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-              "requires": {
-                "string-width": "^2.1.1",
-                "strip-ansi": "^4.0.0",
-                "wrap-ansi": "^2.0.0"
-              },
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "3.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-                },
-                "strip-ansi": {
-                  "version": "4.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                  "requires": {
-                    "ansi-regex": "^3.0.0"
-                  }
-                }
-              }
-            },
-            "clone": {
-              "version": "1.0.4",
-              "resolved": false,
-              "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
-            },
-            "cmd-shim": {
-              "version": "2.0.2",
-              "resolved": false,
-              "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "mkdirp": "~0.5.0"
-              }
-            },
-            "co": {
-              "version": "4.6.0",
-              "resolved": false,
-              "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-            },
-            "code-point-at": {
-              "version": "1.1.0",
-              "resolved": false,
-              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-            },
-            "color-convert": {
-              "version": "1.9.1",
-              "resolved": false,
-              "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-              "requires": {
-                "color-name": "^1.1.1"
-              }
-            },
-            "color-name": {
-              "version": "1.1.3",
-              "resolved": false,
-              "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-            },
-            "colors": {
-              "version": "1.1.2",
-              "resolved": false,
-              "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-              "optional": true
-            },
-            "columnify": {
-              "version": "1.5.4",
-              "resolved": false,
-              "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
-              "requires": {
-                "strip-ansi": "^3.0.0",
-                "wcwidth": "^1.0.0"
-              }
-            },
-            "combined-stream": {
-              "version": "1.0.6",
-              "resolved": false,
-              "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-              "requires": {
-                "delayed-stream": "~1.0.0"
-              }
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "resolved": false,
-              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-            },
-            "concat-stream": {
-              "version": "1.6.2",
-              "resolved": false,
-              "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-              "requires": {
-                "buffer-from": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
-              }
-            },
-            "config-chain": {
-              "version": "1.1.11",
-              "resolved": false,
-              "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
-              "requires": {
-                "ini": "^1.3.4",
-                "proto-list": "~1.2.1"
-              }
-            },
-            "configstore": {
-              "version": "3.1.2",
-              "resolved": false,
-              "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
-              "requires": {
-                "dot-prop": "^4.1.0",
-                "graceful-fs": "^4.1.2",
-                "make-dir": "^1.0.0",
-                "unique-string": "^1.0.0",
-                "write-file-atomic": "^2.0.0",
-                "xdg-basedir": "^3.0.0"
-              }
-            },
-            "console-control-strings": {
-              "version": "1.1.0",
-              "resolved": false,
-              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-            },
-            "copy-concurrently": {
-              "version": "1.0.5",
-              "resolved": false,
-              "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
-              "requires": {
-                "aproba": "^1.1.1",
-                "fs-write-stream-atomic": "^1.0.8",
-                "iferr": "^0.1.5",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.5.4",
-                "run-queue": "^1.0.0"
-              },
-              "dependencies": {
-                "iferr": {
-                  "version": "0.1.5",
-                  "resolved": false,
-                  "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
-                }
-              }
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-            },
-            "create-error-class": {
-              "version": "3.0.2",
-              "resolved": false,
-              "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-              "requires": {
-                "capture-stack-trace": "^1.0.0"
-              }
-            },
-            "cross-spawn": {
-              "version": "5.1.0",
-              "resolved": false,
-              "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-              "requires": {
-                "lru-cache": "^4.0.1",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-              }
-            },
-            "crypto-random-string": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
-            },
-            "cyclist": {
-              "version": "0.2.2",
-              "resolved": false,
-              "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
-            },
-            "dashdash": {
-              "version": "1.14.1",
-              "resolved": false,
-              "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-              "requires": {
-                "assert-plus": "^1.0.0"
-              }
-            },
-            "debug": {
-              "version": "3.1.0",
-              "resolved": false,
-              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-              "requires": {
-                "ms": "2.0.0"
-              },
-              "dependencies": {
-                "ms": {
-                  "version": "2.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-                }
-              }
-            },
-            "debuglog": {
-              "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI="
-            },
-            "decamelize": {
-              "version": "1.2.0",
-              "resolved": false,
-              "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
-            },
-            "decode-uri-component": {
-              "version": "0.2.0",
-              "resolved": false,
-              "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
-            },
-            "deep-extend": {
-              "version": "0.5.1",
-              "resolved": false,
-              "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w=="
-            },
-            "defaults": {
-              "version": "1.0.3",
-              "resolved": false,
-              "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-              "requires": {
-                "clone": "^1.0.2"
-              }
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-            },
-            "delegates": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-            },
-            "detect-indent": {
-              "version": "5.0.0",
-              "resolved": false,
-              "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
-            },
-            "detect-newline": {
-              "version": "2.1.0",
-              "resolved": false,
-              "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
-            },
-            "dezalgo": {
-              "version": "1.0.3",
-              "resolved": false,
-              "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
-              "requires": {
-                "asap": "^2.0.0",
-                "wrappy": "1"
-              }
-            },
-            "dot-prop": {
-              "version": "4.2.0",
-              "resolved": false,
-              "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-              "requires": {
-                "is-obj": "^1.0.0"
-              }
-            },
-            "dotenv": {
-              "version": "5.0.1",
-              "resolved": false,
-              "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
-            },
-            "duplexer3": {
-              "version": "0.1.4",
-              "resolved": false,
-              "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
-            },
-            "duplexify": {
-              "version": "3.6.0",
-              "resolved": false,
-              "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
-              "requires": {
-                "end-of-stream": "^1.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0",
-                "stream-shift": "^1.0.0"
-              }
-            },
-            "ecc-jsbn": {
-              "version": "0.1.2",
-              "resolved": false,
-              "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-              "optional": true,
-              "requires": {
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.1.0"
-              }
-            },
-            "editor": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I="
-            },
-            "encoding": {
-              "version": "0.1.12",
-              "resolved": false,
-              "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-              "requires": {
-                "iconv-lite": "~0.4.13"
-              }
-            },
-            "end-of-stream": {
-              "version": "1.4.1",
-              "resolved": false,
-              "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-              "requires": {
-                "once": "^1.4.0"
-              }
-            },
-            "err-code": {
-              "version": "1.1.2",
-              "resolved": false,
-              "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
-            },
-            "errno": {
-              "version": "0.1.7",
-              "resolved": false,
-              "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
-              "requires": {
-                "prr": "~1.0.1"
-              }
-            },
-            "es6-promise": {
-              "version": "4.2.4",
-              "resolved": false,
-              "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
-            },
-            "es6-promisify": {
-              "version": "5.0.0",
-              "resolved": false,
-              "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-              "requires": {
-                "es6-promise": "^4.0.3"
-              }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": false,
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-            },
-            "execa": {
-              "version": "0.7.0",
-              "resolved": false,
-              "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-              "requires": {
-                "cross-spawn": "^5.0.1",
-                "get-stream": "^3.0.0",
-                "is-stream": "^1.1.0",
-                "npm-run-path": "^2.0.0",
-                "p-finally": "^1.0.0",
-                "signal-exit": "^3.0.0",
-                "strip-eof": "^1.0.0"
-              }
-            },
-            "extend": {
-              "version": "3.0.2",
-              "resolved": false,
-              "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-            },
-            "extsprintf": {
-              "version": "1.3.0",
-              "resolved": false,
-              "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-            },
-            "fast-deep-equal": {
-              "version": "1.1.0",
-              "resolved": false,
-              "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
-            },
-            "fast-json-stable-stringify": {
-              "version": "2.0.0",
-              "resolved": false,
-              "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
-            },
-            "figgy-pudding": {
-              "version": "3.4.1",
-              "resolved": false,
-              "integrity": "sha512-j1SAT641cerGuOvoSBoaE9LbSzh1N/E5ufk9oMpOKuyK8MyW3sGg4rh+4qhLmVTEAzipO5XTHYT4gjb6JYLE8g=="
-            },
-            "find-npm-prefix": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA=="
-            },
-            "find-up": {
-              "version": "2.1.0",
-              "resolved": false,
-              "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-              "requires": {
-                "locate-path": "^2.0.0"
-              }
-            },
-            "flush-write-stream": {
-              "version": "1.0.3",
-              "resolved": false,
-              "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
-              "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.4"
-              }
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "resolved": false,
-              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-            },
-            "form-data": {
-              "version": "2.3.2",
-              "resolved": false,
-              "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
-              "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "1.0.6",
-                "mime-types": "^2.1.12"
-              }
-            },
-            "from2": {
-              "version": "2.3.0",
-              "resolved": false,
-              "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
-              "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0"
-              }
-            },
-            "fs-minipass": {
-              "version": "1.2.5",
-              "resolved": false,
-              "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
-              "requires": {
-                "minipass": "^2.2.1"
-              }
-            },
-            "fs-vacuum": {
-              "version": "1.2.10",
-              "resolved": false,
-              "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "path-is-inside": "^1.0.1",
-                "rimraf": "^2.5.2"
-              }
-            },
-            "fs-write-stream-atomic": {
-              "version": "1.0.10",
-              "resolved": false,
-              "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "iferr": "^0.1.5",
-                "imurmurhash": "^0.1.4",
-                "readable-stream": "1 || 2"
-              },
-              "dependencies": {
-                "iferr": {
-                  "version": "0.1.5",
-                  "resolved": false,
-                  "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
-                }
-              }
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-            },
-            "fstream": {
-              "version": "1.0.11",
-              "resolved": false,
-              "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
-              }
-            },
-            "gauge": {
-              "version": "2.7.4",
-              "resolved": false,
-              "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-              "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
-              },
-              "dependencies": {
-                "string-width": {
-                  "version": "1.0.2",
-                  "resolved": false,
-                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                  "requires": {
-                    "code-point-at": "^1.0.0",
-                    "is-fullwidth-code-point": "^1.0.0",
-                    "strip-ansi": "^3.0.0"
-                  }
-                }
-              }
-            },
-            "genfun": {
-              "version": "4.0.1",
-              "resolved": false,
-              "integrity": "sha1-7RAEHy5KfxsKOEZtF6XD4n3x38E="
-            },
-            "gentle-fs": {
-              "version": "2.0.1",
-              "resolved": false,
-              "integrity": "sha512-cEng5+3fuARewXktTEGbwsktcldA+YsnUEaXZwcK/3pjSE1X9ObnTs+/8rYf8s+RnIcQm2D5x3rwpN7Zom8Bew==",
-              "requires": {
-                "aproba": "^1.1.2",
-                "fs-vacuum": "^1.2.10",
-                "graceful-fs": "^4.1.11",
-                "iferr": "^0.1.5",
-                "mkdirp": "^0.5.1",
-                "path-is-inside": "^1.0.2",
-                "read-cmd-shim": "^1.0.1",
-                "slide": "^1.1.6"
-              },
-              "dependencies": {
-                "iferr": {
-                  "version": "0.1.5",
-                  "resolved": false,
-                  "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
-                }
-              }
-            },
-            "get-caller-file": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
-            },
-            "get-stream": {
-              "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
-            },
-            "getpass": {
-              "version": "0.1.7",
-              "resolved": false,
-              "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-              "requires": {
-                "assert-plus": "^1.0.0"
-              }
-            },
-            "glob": {
-              "version": "7.1.2",
-              "resolved": false,
-              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            },
-            "global-dirs": {
-              "version": "0.1.1",
-              "resolved": false,
-              "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
-              "requires": {
-                "ini": "^1.3.4"
-              }
-            },
-            "got": {
-              "version": "6.7.1",
-              "resolved": false,
-              "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-              "requires": {
-                "create-error-class": "^3.0.0",
-                "duplexer3": "^0.1.4",
-                "get-stream": "^3.0.0",
-                "is-redirect": "^1.0.0",
-                "is-retry-allowed": "^1.0.0",
-                "is-stream": "^1.0.0",
-                "lowercase-keys": "^1.0.0",
-                "safe-buffer": "^5.0.1",
-                "timed-out": "^4.0.0",
-                "unzip-response": "^2.0.1",
-                "url-parse-lax": "^1.0.0"
-              }
-            },
-            "graceful-fs": {
-              "version": "4.1.11",
-              "resolved": false,
-              "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-            },
-            "har-schema": {
-              "version": "2.0.0",
-              "resolved": false,
-              "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-            },
-            "har-validator": {
-              "version": "5.1.0",
-              "resolved": false,
-              "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
-              "requires": {
-                "ajv": "^5.3.0",
-                "har-schema": "^2.0.0"
-              }
-            },
-            "has-flag": {
-              "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-            },
-            "has-unicode": {
-              "version": "2.0.1",
-              "resolved": false,
-              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
-            },
-            "hosted-git-info": {
-              "version": "2.7.1",
-              "resolved": false,
-              "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
-            },
-            "http-cache-semantics": {
-              "version": "3.8.1",
-              "resolved": false,
-              "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
-            },
-            "http-proxy-agent": {
-              "version": "2.1.0",
-              "resolved": false,
-              "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
-              "requires": {
-                "agent-base": "4",
-                "debug": "3.1.0"
-              }
-            },
-            "http-signature": {
-              "version": "1.2.0",
-              "resolved": false,
-              "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-              "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
-              }
-            },
-            "https-proxy-agent": {
-              "version": "2.2.1",
-              "resolved": false,
-              "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
-              "requires": {
-                "agent-base": "^4.1.0",
-                "debug": "^3.1.0"
-              }
-            },
-            "humanize-ms": {
-              "version": "1.2.1",
-              "resolved": false,
-              "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
-              "requires": {
-                "ms": "^2.0.0"
-              }
-            },
-            "iconv-lite": {
-              "version": "0.4.23",
-              "resolved": false,
-              "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-              "requires": {
-                "safer-buffer": ">= 2.1.2 < 3"
-              }
-            },
-            "iferr": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha512-9AfeLfji44r5TKInjhz3W9DyZI1zR1JAf2hVBMGhddAKPqBsupb89jGfbCTHIGZd6fGZl9WlHdn4AObygyMKwg=="
-            },
-            "ignore-walk": {
-              "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
-              "requires": {
-                "minimatch": "^3.0.4"
-              }
-            },
-            "import-lazy": {
-              "version": "2.1.0",
-              "resolved": false,
-              "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
-            },
-            "imurmurhash": {
-              "version": "0.1.4",
-              "resolved": false,
-              "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "resolved": false,
-              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-              "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "resolved": false,
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-            },
-            "ini": {
-              "version": "1.3.5",
-              "resolved": false,
-              "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
-            },
-            "init-package-json": {
-              "version": "1.10.3",
-              "resolved": false,
-              "integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
-              "requires": {
-                "glob": "^7.1.1",
-                "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
-                "promzard": "^0.3.0",
-                "read": "~1.0.1",
-                "read-package-json": "1 || 2",
-                "semver": "2.x || 3.x || 4 || 5",
-                "validate-npm-package-license": "^3.0.1",
-                "validate-npm-package-name": "^3.0.0"
-              }
-            },
-            "invert-kv": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-            },
-            "ip": {
-              "version": "1.1.5",
-              "resolved": false,
-              "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
-            },
-            "ip-regex": {
-              "version": "2.1.0",
-              "resolved": false,
-              "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
-            },
-            "is-builtin-module": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-              "requires": {
-                "builtin-modules": "^1.0.0"
-              }
-            },
-            "is-ci": {
-              "version": "1.1.0",
-              "resolved": false,
-              "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
-              "requires": {
-                "ci-info": "^1.0.0"
-              }
-            },
-            "is-cidr": {
-              "version": "2.0.6",
-              "resolved": false,
-              "integrity": "sha512-A578p1dV22TgPXn6NCaDAPj6vJvYsBgAzUrAd28a4oldeXJjWqEUuSZOLIW3im51mazOKsoyVp8NU/OItlWacw==",
-              "requires": {
-                "cidr-regex": "^2.0.8"
-              }
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "is-installed-globally": {
-              "version": "0.1.0",
-              "resolved": false,
-              "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
-              "requires": {
-                "global-dirs": "^0.1.0",
-                "is-path-inside": "^1.0.0"
-              }
-            },
-            "is-npm": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
-            },
-            "is-obj": {
-              "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
-            },
-            "is-path-inside": {
-              "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-              "requires": {
-                "path-is-inside": "^1.0.1"
-              }
-            },
-            "is-redirect": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
-            },
-            "is-retry-allowed": {
-              "version": "1.1.0",
-              "resolved": false,
-              "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
-            },
-            "is-stream": {
-              "version": "1.1.0",
-              "resolved": false,
-              "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-            },
-            "isexe": {
-              "version": "2.0.0",
-              "resolved": false,
-              "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "resolved": false,
-              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-            },
-            "jsbn": {
-              "version": "0.1.1",
-              "resolved": false,
-              "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-              "optional": true
-            },
-            "json-parse-better-errors": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
-            },
-            "json-schema": {
-              "version": "0.2.3",
-              "resolved": false,
-              "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-            },
-            "json-schema-traverse": {
-              "version": "0.3.1",
-              "resolved": false,
-              "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "resolved": false,
-              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-            },
-            "jsonparse": {
-              "version": "1.3.1",
-              "resolved": false,
-              "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
-            },
-            "jsprim": {
-              "version": "1.4.1",
-              "resolved": false,
-              "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-              "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
-                "verror": "1.10.0"
-              }
-            },
-            "latest-version": {
-              "version": "3.1.0",
-              "resolved": false,
-              "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
-              "requires": {
-                "package-json": "^4.0.0"
-              }
-            },
-            "lazy-property": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc="
-            },
-            "lcid": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-              "requires": {
-                "invert-kv": "^1.0.0"
-              }
-            },
-            "libcipm": {
-              "version": "2.0.2",
-              "resolved": false,
-              "integrity": "sha512-9uZ6/LAflVEijksTRq/RX0e+pGA4mr8tND9Cmk2JMg7j2fFUBrs8PpFX2DOAJR/XoxPzz+5h8bkWmtIYLunKAg==",
-              "requires": {
-                "bin-links": "^1.1.2",
-                "bluebird": "^3.5.1",
-                "find-npm-prefix": "^1.0.2",
-                "graceful-fs": "^4.1.11",
-                "lock-verify": "^2.0.2",
-                "mkdirp": "^0.5.1",
-                "npm-lifecycle": "^2.0.3",
-                "npm-logical-tree": "^1.2.1",
-                "npm-package-arg": "^6.1.0",
-                "pacote": "^8.1.6",
-                "protoduck": "^5.0.0",
-                "read-package-json": "^2.0.13",
-                "rimraf": "^2.6.2",
-                "worker-farm": "^1.6.0"
-              }
-            },
-            "libnpmhook": {
-              "version": "4.0.1",
-              "resolved": false,
-              "integrity": "sha512-3qqpfqvBD1712WA6iGe0stkG40WwAeoWcujA6BlC0Be1JArQbqwabnEnZ0CRcD05Tf1fPYJYdCbSfcfedEJCOg==",
-              "requires": {
-                "figgy-pudding": "^3.1.0",
-                "npm-registry-fetch": "^3.0.0"
-              },
-              "dependencies": {
-                "npm-registry-fetch": {
-                  "version": "3.1.1",
-                  "resolved": false,
-                  "integrity": "sha512-xBobENeenvjIG8PgQ1dy77AXTI25IbYhmA3DusMIfw/4EL5BaQ5e1V9trkPrqHvyjR3/T0cnH6o0Wt/IzcI5Ag==",
-                  "requires": {
-                    "bluebird": "^3.5.1",
-                    "figgy-pudding": "^3.1.0",
-                    "lru-cache": "^4.1.2",
-                    "make-fetch-happen": "^4.0.0",
-                    "npm-package-arg": "^6.0.0"
-                  }
-                }
-              }
-            },
-            "libnpx": {
-              "version": "10.2.0",
-              "resolved": false,
-              "integrity": "sha512-X28coei8/XRCt15cYStbLBph+KGhFra4VQhRBPuH/HHMkC5dxM8v24RVgUsvODKCrUZ0eTgiTqJp6zbl0sskQQ==",
-              "requires": {
-                "dotenv": "^5.0.1",
-                "npm-package-arg": "^6.0.0",
-                "rimraf": "^2.6.2",
-                "safe-buffer": "^5.1.0",
-                "update-notifier": "^2.3.0",
-                "which": "^1.3.0",
-                "y18n": "^4.0.0",
-                "yargs": "^11.0.0"
-              }
-            },
-            "locate-path": {
-              "version": "2.0.0",
-              "resolved": false,
-              "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-              "requires": {
-                "p-locate": "^2.0.0",
-                "path-exists": "^3.0.0"
-              }
-            },
-            "lock-verify": {
-              "version": "2.0.2",
-              "resolved": false,
-              "integrity": "sha512-QNVwK0EGZBS4R3YQ7F1Ox8p41Po9VGl2QG/2GsuvTbkJZYSsPeWHKMbbH6iZMCHWSMww5nrJroZYnGzI4cePuw==",
-              "requires": {
-                "npm-package-arg": "^5.1.2 || 6",
-                "semver": "^5.4.1"
-              }
-            },
-            "lockfile": {
-              "version": "1.0.4",
-              "resolved": false,
-              "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
-              "requires": {
-                "signal-exit": "^3.0.2"
-              }
-            },
-            "lodash._baseindexof": {
-              "version": "3.1.0",
-              "resolved": false,
-              "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw="
-            },
-            "lodash._baseuniq": {
-              "version": "4.6.0",
-              "resolved": false,
-              "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
-              "requires": {
-                "lodash._createset": "~4.0.0",
-                "lodash._root": "~3.0.0"
-              }
-            },
-            "lodash._bindcallback": {
-              "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
-            },
-            "lodash._cacheindexof": {
-              "version": "3.0.2",
-              "resolved": false,
-              "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI="
-            },
-            "lodash._createcache": {
-              "version": "3.1.2",
-              "resolved": false,
-              "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
-              "requires": {
-                "lodash._getnative": "^3.0.0"
-              }
-            },
-            "lodash._createset": {
-              "version": "4.0.3",
-              "resolved": false,
-              "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY="
-            },
-            "lodash._getnative": {
-              "version": "3.9.1",
-              "resolved": false,
-              "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
-            },
-            "lodash._root": {
-              "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
-            },
-            "lodash.clonedeep": {
-              "version": "4.5.0",
-              "resolved": false,
-              "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-            },
-            "lodash.restparam": {
-              "version": "3.6.1",
-              "resolved": false,
-              "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
-            },
-            "lodash.union": {
-              "version": "4.6.0",
-              "resolved": false,
-              "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
-            },
-            "lodash.uniq": {
-              "version": "4.5.0",
-              "resolved": false,
-              "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
-            },
-            "lodash.without": {
-              "version": "4.4.0",
-              "resolved": false,
-              "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw="
-            },
-            "lowercase-keys": {
-              "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
-            },
-            "lru-cache": {
-              "version": "4.1.3",
-              "resolved": false,
-              "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
-              "requires": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
-              }
-            },
-            "make-dir": {
-              "version": "1.3.0",
-              "resolved": false,
-              "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-              "requires": {
-                "pify": "^3.0.0"
-              }
-            },
-            "make-fetch-happen": {
-              "version": "4.0.1",
-              "resolved": false,
-              "integrity": "sha512-7R5ivfy9ilRJ1EMKIOziwrns9fGeAD4bAha8EB7BIiBBLHm2KeTUGCrICFt2rbHfzheTLynv50GnNTK1zDTrcQ==",
-              "requires": {
-                "agentkeepalive": "^3.4.1",
-                "cacache": "^11.0.1",
-                "http-cache-semantics": "^3.8.1",
-                "http-proxy-agent": "^2.1.0",
-                "https-proxy-agent": "^2.2.1",
-                "lru-cache": "^4.1.2",
-                "mississippi": "^3.0.0",
-                "node-fetch-npm": "^2.0.2",
-                "promise-retry": "^1.1.1",
-                "socks-proxy-agent": "^4.0.0",
-                "ssri": "^6.0.0"
-              }
-            },
-            "meant": {
-              "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha512-UakVLFjKkbbUwNWJ2frVLnnAtbb7D7DsloxRd3s/gDpI8rdv8W5Hp3NaDb+POBI1fQdeussER6NB8vpcRURvlg=="
-            },
-            "mem": {
-              "version": "1.1.0",
-              "resolved": false,
-              "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-              "requires": {
-                "mimic-fn": "^1.0.0"
-              }
-            },
-            "mime-db": {
-              "version": "1.35.0",
-              "resolved": false,
-              "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg=="
-            },
-            "mime-types": {
-              "version": "2.1.19",
-              "resolved": false,
-              "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
-              "requires": {
-                "mime-db": "~1.35.0"
-              }
-            },
-            "mimic-fn": {
-              "version": "1.2.0",
-              "resolved": false,
-              "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "resolved": false,
-              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              }
-            },
-            "minimist": {
-              "version": "0.0.8",
-              "resolved": false,
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-            },
-            "minipass": {
-              "version": "2.3.3",
-              "resolved": false,
-              "integrity": "sha512-/jAn9/tEX4gnpyRATxgHEOV6xbcyxgT7iUnxo9Y3+OB0zX00TgKIv/2FZCf5brBbICcwbLqVv2ImjvWWrQMSYw==",
-              "requires": {
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.0"
-              },
-              "dependencies": {
-                "yallist": {
-                  "version": "3.0.2",
-                  "resolved": false,
-                  "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
-                }
-              }
-            },
-            "minizlib": {
-              "version": "1.1.0",
-              "resolved": false,
-              "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
-              "requires": {
-                "minipass": "^2.2.1"
-              }
-            },
-            "mississippi": {
-              "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
-              "requires": {
-                "concat-stream": "^1.5.0",
-                "duplexify": "^3.4.2",
-                "end-of-stream": "^1.1.0",
-                "flush-write-stream": "^1.0.0",
-                "from2": "^2.1.0",
-                "parallel-transform": "^1.1.0",
-                "pump": "^3.0.0",
-                "pumpify": "^1.3.3",
-                "stream-each": "^1.1.0",
-                "through2": "^2.0.0"
-              }
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "resolved": false,
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            },
-            "move-concurrently": {
-              "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
-              "requires": {
-                "aproba": "^1.1.1",
-                "copy-concurrently": "^1.0.0",
-                "fs-write-stream-atomic": "^1.0.8",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.5.4",
-                "run-queue": "^1.0.3"
-              }
-            },
-            "ms": {
-              "version": "2.1.1",
-              "resolved": false,
-              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-            },
-            "mute-stream": {
-              "version": "0.0.7",
-              "resolved": false,
-              "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
-            },
-            "node-fetch-npm": {
-              "version": "2.0.2",
-              "resolved": false,
-              "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
-              "requires": {
-                "encoding": "^0.1.11",
-                "json-parse-better-errors": "^1.0.0",
-                "safe-buffer": "^5.1.1"
-              }
-            },
-            "node-gyp": {
-              "version": "3.8.0",
-              "resolved": false,
-              "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
-              "requires": {
-                "fstream": "^1.0.0",
-                "glob": "^7.0.3",
-                "graceful-fs": "^4.1.2",
-                "mkdirp": "^0.5.0",
-                "nopt": "2 || 3",
-                "npmlog": "0 || 1 || 2 || 3 || 4",
-                "osenv": "0",
-                "request": "^2.87.0",
-                "rimraf": "2",
-                "semver": "~5.3.0",
-                "tar": "^2.0.0",
-                "which": "1"
-              },
-              "dependencies": {
-                "nopt": {
-                  "version": "3.0.6",
-                  "resolved": false,
-                  "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-                  "requires": {
-                    "abbrev": "1"
-                  }
-                },
-                "semver": {
-                  "version": "5.3.0",
-                  "resolved": false,
-                  "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
-                },
-                "tar": {
-                  "version": "2.2.1",
-                  "resolved": false,
-                  "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-                  "requires": {
-                    "block-stream": "*",
-                    "fstream": "^1.0.2",
-                    "inherits": "2"
-                  }
-                }
-              }
-            },
-            "nopt": {
-              "version": "4.0.1",
-              "resolved": false,
-              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-              "requires": {
-                "abbrev": "1",
-                "osenv": "^0.1.4"
-              }
-            },
-            "normalize-package-data": {
-              "version": "2.4.0",
-              "resolved": false,
-              "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-              "requires": {
-                "hosted-git-info": "^2.1.4",
-                "is-builtin-module": "^1.0.0",
-                "semver": "2 || 3 || 4 || 5",
-                "validate-npm-package-license": "^3.0.1"
-              }
-            },
-            "npm-audit-report": {
-              "version": "1.3.1",
-              "resolved": false,
-              "integrity": "sha512-SjTF8ZP4rOu3JiFrTMi4M1CmVo2tni2sP4TzhyCMHwnMGf6XkdGLZKt9cdZ12esKf0mbQqFyU9LtY0SoeahL7g==",
-              "requires": {
-                "cli-table3": "^0.5.0",
-                "console-control-strings": "^1.1.0"
-              }
-            },
-            "npm-bundled": {
-              "version": "1.0.5",
-              "resolved": false,
-              "integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g=="
-            },
-            "npm-cache-filename": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE="
-            },
-            "npm-install-checks": {
-              "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
-              "requires": {
-                "semver": "^2.3.0 || 3.x || 4 || 5"
-              }
-            },
-            "npm-lifecycle": {
-              "version": "2.1.0",
-              "resolved": false,
-              "integrity": "sha512-QbBfLlGBKsktwBZLj6AviHC6Q9Y3R/AY4a2PYSIRhSKSS0/CxRyD/PfxEX6tPeOCXQgMSNdwGeECacstgptc+g==",
-              "requires": {
-                "byline": "^5.0.0",
-                "graceful-fs": "^4.1.11",
-                "node-gyp": "^3.8.0",
-                "resolve-from": "^4.0.0",
-                "slide": "^1.1.6",
-                "uid-number": "0.0.6",
-                "umask": "^1.1.0",
-                "which": "^1.3.1"
-              }
-            },
-            "npm-logical-tree": {
-              "version": "1.2.1",
-              "resolved": false,
-              "integrity": "sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg=="
-            },
-            "npm-package-arg": {
-              "version": "6.1.0",
-              "resolved": false,
-              "integrity": "sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==",
-              "requires": {
-                "hosted-git-info": "^2.6.0",
-                "osenv": "^0.1.5",
-                "semver": "^5.5.0",
-                "validate-npm-package-name": "^3.0.0"
-              }
-            },
-            "npm-packlist": {
-              "version": "1.1.11",
-              "resolved": false,
-              "integrity": "sha512-CxKlZ24urLkJk+9kCm48RTQ7L4hsmgSVzEk0TLGPzzyuFxD7VNgy5Sl24tOLMzQv773a/NeJ1ce1DKeacqffEA==",
-              "requires": {
-                "ignore-walk": "^3.0.1",
-                "npm-bundled": "^1.0.1"
-              }
-            },
-            "npm-pick-manifest": {
-              "version": "2.1.0",
-              "resolved": false,
-              "integrity": "sha512-q9zLP8cTr8xKPmMZN3naxp1k/NxVFsjxN6uWuO1tiw9gxg7wZWQ/b5UTfzD0ANw2q1lQxdLKTeCCksq+bPSgbQ==",
-              "requires": {
-                "npm-package-arg": "^6.0.0",
-                "semver": "^5.4.1"
-              }
-            },
-            "npm-profile": {
-              "version": "3.0.2",
-              "resolved": false,
-              "integrity": "sha512-rEJOFR6PbwOvvhGa2YTNOJQKNuc6RovJ6T50xPU7pS9h/zKPNCJ+VHZY2OFXyZvEi+UQYtHRTp8O/YM3tUD20A==",
-              "requires": {
-                "aproba": "^1.1.2 || 2",
-                "make-fetch-happen": "^2.5.0 || 3 || 4"
-              }
-            },
-            "npm-registry-client": {
-              "version": "8.6.0",
-              "resolved": false,
-              "integrity": "sha512-Qs6P6nnopig+Y8gbzpeN/dkt+n7IyVd8f45NTMotGk6Qo7GfBmzwYx6jRLoOOgKiMnaQfYxsuyQlD8Mc3guBhg==",
-              "requires": {
-                "concat-stream": "^1.5.2",
-                "graceful-fs": "^4.1.6",
-                "normalize-package-data": "~1.0.1 || ^2.0.0",
-                "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
-                "npmlog": "2 || ^3.1.0 || ^4.0.0",
-                "once": "^1.3.3",
-                "request": "^2.74.0",
-                "retry": "^0.10.0",
-                "safe-buffer": "^5.1.1",
-                "semver": "2 >=2.2.1 || 3.x || 4 || 5",
-                "slide": "^1.1.3",
-                "ssri": "^5.2.4"
-              },
-              "dependencies": {
-                "retry": {
-                  "version": "0.10.1",
-                  "resolved": false,
-                  "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
-                },
-                "ssri": {
-                  "version": "5.3.0",
-                  "resolved": false,
-                  "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
-                  "requires": {
-                    "safe-buffer": "^5.1.1"
-                  }
-                }
-              }
-            },
-            "npm-registry-fetch": {
-              "version": "1.1.0",
-              "resolved": false,
-              "integrity": "sha512-XJPIBfMtgaooRtZmuA42xCeLf3tkxdIX0xqRsGWwNrcVvJ9UYFccD7Ho7QWCzvkM3i/QrkUC37Hu0a+vDBmt5g==",
-              "requires": {
-                "bluebird": "^3.5.1",
-                "figgy-pudding": "^2.0.1",
-                "lru-cache": "^4.1.2",
-                "make-fetch-happen": "^3.0.0",
-                "npm-package-arg": "^6.0.0",
-                "safe-buffer": "^5.1.1"
-              },
-              "dependencies": {
-                "cacache": {
-                  "version": "10.0.4",
-                  "resolved": false,
-                  "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
-                  "requires": {
-                    "bluebird": "^3.5.1",
-                    "chownr": "^1.0.1",
-                    "glob": "^7.1.2",
-                    "graceful-fs": "^4.1.11",
-                    "lru-cache": "^4.1.1",
-                    "mississippi": "^2.0.0",
-                    "mkdirp": "^0.5.1",
-                    "move-concurrently": "^1.0.1",
-                    "promise-inflight": "^1.0.1",
-                    "rimraf": "^2.6.2",
-                    "ssri": "^5.2.4",
-                    "unique-filename": "^1.1.0",
-                    "y18n": "^4.0.0"
-                  },
-                  "dependencies": {
-                    "mississippi": {
-                      "version": "2.0.0",
-                      "resolved": false,
-                      "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
-                      "requires": {
-                        "concat-stream": "^1.5.0",
-                        "duplexify": "^3.4.2",
-                        "end-of-stream": "^1.1.0",
-                        "flush-write-stream": "^1.0.0",
-                        "from2": "^2.1.0",
-                        "parallel-transform": "^1.1.0",
-                        "pump": "^2.0.1",
-                        "pumpify": "^1.3.3",
-                        "stream-each": "^1.1.0",
-                        "through2": "^2.0.0"
-                      }
-                    }
-                  }
-                },
-                "figgy-pudding": {
-                  "version": "2.0.1",
-                  "resolved": false,
-                  "integrity": "sha512-yIJPhIBi/oFdU/P+GSXjmk/rmGjuZkm7A5LTXZxNrEprXJXRK012FiI1BR1Pga+0d/d6taWWD+B5d2ozqaxHig=="
-                },
-                "make-fetch-happen": {
-                  "version": "3.0.0",
-                  "resolved": false,
-                  "integrity": "sha512-FmWY7gC0mL6Z4N86vE14+m719JKE4H0A+pyiOH18B025gF/C113pyfb4gHDDYP5cqnRMHOz06JGdmffC/SES+w==",
-                  "requires": {
-                    "agentkeepalive": "^3.4.1",
-                    "cacache": "^10.0.4",
-                    "http-cache-semantics": "^3.8.1",
-                    "http-proxy-agent": "^2.1.0",
-                    "https-proxy-agent": "^2.2.0",
-                    "lru-cache": "^4.1.2",
-                    "mississippi": "^3.0.0",
-                    "node-fetch-npm": "^2.0.2",
-                    "promise-retry": "^1.1.1",
-                    "socks-proxy-agent": "^3.0.1",
-                    "ssri": "^5.2.4"
-                  }
-                },
-                "pump": {
-                  "version": "2.0.1",
-                  "resolved": false,
-                  "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-                  "requires": {
-                    "end-of-stream": "^1.1.0",
-                    "once": "^1.3.1"
-                  }
-                },
-                "smart-buffer": {
-                  "version": "1.1.15",
-                  "resolved": false,
-                  "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY="
-                },
-                "socks": {
-                  "version": "1.1.10",
-                  "resolved": false,
-                  "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
-                  "requires": {
-                    "ip": "^1.1.4",
-                    "smart-buffer": "^1.0.13"
-                  }
-                },
-                "socks-proxy-agent": {
-                  "version": "3.0.1",
-                  "resolved": false,
-                  "integrity": "sha512-ZwEDymm204mTzvdqyUqOdovVr2YRd2NYskrYrF2LXyZ9qDiMAoFESGK8CRphiO7rtbo2Y757k2Nia3x2hGtalA==",
-                  "requires": {
-                    "agent-base": "^4.1.0",
-                    "socks": "^1.1.10"
-                  }
-                },
-                "ssri": {
-                  "version": "5.3.0",
-                  "resolved": false,
-                  "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
-                  "requires": {
-                    "safe-buffer": "^5.1.1"
-                  }
-                }
-              }
-            },
-            "npm-run-path": {
-              "version": "2.0.2",
-              "resolved": false,
-              "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-              "requires": {
-                "path-key": "^2.0.0"
-              }
-            },
-            "npm-user-validate": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE="
-            },
-            "npmlog": {
-              "version": "4.1.2",
-              "resolved": false,
-              "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-              "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
-              }
-            },
-            "number-is-nan": {
-              "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-            },
-            "oauth-sign": {
-              "version": "0.9.0",
-              "resolved": false,
-              "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "resolved": false,
-              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-            },
-            "once": {
-              "version": "1.4.0",
-              "resolved": false,
-              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-              "requires": {
-                "wrappy": "1"
-              }
-            },
-            "opener": {
-              "version": "1.5.0",
-              "resolved": false,
-              "integrity": "sha512-MD4s/o61y2slS27zm2s4229V2gAUHX0/e3/XOmY/jsXwhysjjCIHN8lx7gqZCrZk19ym+HjCUWHeMKD7YJtKCQ=="
-            },
-            "os-homedir": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-            },
-            "os-locale": {
-              "version": "2.1.0",
-              "resolved": false,
-              "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-              "requires": {
-                "execa": "^0.7.0",
-                "lcid": "^1.0.0",
-                "mem": "^1.1.0"
-              }
-            },
-            "os-tmpdir": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-            },
-            "osenv": {
-              "version": "0.1.5",
-              "resolved": false,
-              "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-              "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.0"
-              }
-            },
-            "p-finally": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-            },
-            "p-limit": {
-              "version": "1.2.0",
-              "resolved": false,
-              "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
-              "requires": {
-                "p-try": "^1.0.0"
-              }
-            },
-            "p-locate": {
-              "version": "2.0.0",
-              "resolved": false,
-              "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-              "requires": {
-                "p-limit": "^1.1.0"
-              }
-            },
-            "p-try": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
-            },
-            "package-json": {
-              "version": "4.0.1",
-              "resolved": false,
-              "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-              "requires": {
-                "got": "^6.7.1",
-                "registry-auth-token": "^3.0.1",
-                "registry-url": "^3.0.3",
-                "semver": "^5.1.0"
-              }
-            },
-            "pacote": {
-              "version": "8.1.6",
-              "resolved": false,
-              "integrity": "sha512-wTOOfpaAQNEQNtPEx92x9Y9kRWVu45v583XT8x2oEV2xRB74+xdqMZIeGW4uFvAyZdmSBtye+wKdyyLaT8pcmw==",
-              "requires": {
-                "bluebird": "^3.5.1",
-                "cacache": "^11.0.2",
-                "get-stream": "^3.0.0",
-                "glob": "^7.1.2",
-                "lru-cache": "^4.1.3",
-                "make-fetch-happen": "^4.0.1",
-                "minimatch": "^3.0.4",
-                "minipass": "^2.3.3",
-                "mississippi": "^3.0.0",
-                "mkdirp": "^0.5.1",
-                "normalize-package-data": "^2.4.0",
-                "npm-package-arg": "^6.1.0",
-                "npm-packlist": "^1.1.10",
-                "npm-pick-manifest": "^2.1.0",
-                "osenv": "^0.1.5",
-                "promise-inflight": "^1.0.1",
-                "promise-retry": "^1.1.1",
-                "protoduck": "^5.0.0",
-                "rimraf": "^2.6.2",
-                "safe-buffer": "^5.1.2",
-                "semver": "^5.5.0",
-                "ssri": "^6.0.0",
-                "tar": "^4.4.3",
-                "unique-filename": "^1.1.0",
-                "which": "^1.3.0"
-              }
-            },
-            "parallel-transform": {
-              "version": "1.1.0",
-              "resolved": false,
-              "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
-              "requires": {
-                "cyclist": "~0.2.2",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.1.5"
-              }
-            },
-            "path-exists": {
-              "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-            },
-            "path-is-inside": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
-            },
-            "path-key": {
-              "version": "2.0.1",
-              "resolved": false,
-              "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
-            },
-            "performance-now": {
-              "version": "2.1.0",
-              "resolved": false,
-              "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-            },
-            "pify": {
-              "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-            },
-            "prepend-http": {
-              "version": "1.0.4",
-              "resolved": false,
-              "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
-            },
-            "process-nextick-args": {
-              "version": "2.0.0",
-              "resolved": false,
-              "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
-            },
-            "promise-inflight": {
-              "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
-            },
-            "promise-retry": {
-              "version": "1.1.1",
-              "resolved": false,
-              "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
-              "requires": {
-                "err-code": "^1.0.0",
-                "retry": "^0.10.0"
-              },
-              "dependencies": {
-                "retry": {
-                  "version": "0.10.1",
-                  "resolved": false,
-                  "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
-                }
-              }
-            },
-            "promzard": {
-              "version": "0.3.0",
-              "resolved": false,
-              "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
-              "requires": {
-                "read": "1"
-              }
-            },
-            "proto-list": {
-              "version": "1.2.4",
-              "resolved": false,
-              "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
-            },
-            "protoduck": {
-              "version": "5.0.0",
-              "resolved": false,
-              "integrity": "sha512-agsGWD8/RZrS4ga6v82Fxb0RHIS2RZnbsSue6A9/MBRhB/jcqOANAMNrqM9900b8duj+Gx+T/JMy5IowDoO/hQ==",
-              "requires": {
-                "genfun": "^4.0.1"
-              }
-            },
-            "prr": {
-              "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
-            },
-            "pseudomap": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-            },
-            "psl": {
-              "version": "1.1.29",
-              "resolved": false,
-              "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
-            },
-            "pump": {
-              "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-              "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-              }
-            },
-            "pumpify": {
-              "version": "1.5.1",
-              "resolved": false,
-              "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
-              "requires": {
-                "duplexify": "^3.6.0",
-                "inherits": "^2.0.3",
-                "pump": "^2.0.0"
-              },
-              "dependencies": {
-                "pump": {
-                  "version": "2.0.1",
-                  "resolved": false,
-                  "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-                  "requires": {
-                    "end-of-stream": "^1.1.0",
-                    "once": "^1.3.1"
-                  }
-                }
-              }
-            },
-            "punycode": {
-              "version": "1.4.1",
-              "resolved": false,
-              "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-            },
-            "qrcode-terminal": {
-              "version": "0.12.0",
-              "resolved": false,
-              "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ=="
-            },
-            "qs": {
-              "version": "6.5.2",
-              "resolved": false,
-              "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
-            },
-            "query-string": {
-              "version": "6.1.0",
-              "resolved": false,
-              "integrity": "sha512-pNB/Gr8SA8ff8KpUFM36o/WFAlthgaThka5bV19AD9PNTH20Pwq5Zxodif2YyHwrctp6SkL4GqlOot0qR/wGaw==",
-              "requires": {
-                "decode-uri-component": "^0.2.0",
-                "strict-uri-encode": "^2.0.0"
-              }
-            },
-            "qw": {
-              "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-77/cdA+a0FQwRCassYNBLMi5ltQ="
-            },
-            "rc": {
-              "version": "1.2.7",
-              "resolved": false,
-              "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
-              "requires": {
-                "deep-extend": "^0.5.1",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "1.2.0",
-                  "resolved": false,
-                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-                }
-              }
-            },
-            "read": {
-              "version": "1.0.7",
-              "resolved": false,
-              "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
-              "requires": {
-                "mute-stream": "~0.0.4"
-              }
-            },
-            "read-cmd-shim": {
-              "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
-              "requires": {
-                "graceful-fs": "^4.1.2"
-              }
-            },
-            "read-installed": {
-              "version": "4.0.3",
-              "resolved": false,
-              "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
-              "requires": {
-                "debuglog": "^1.0.1",
-                "graceful-fs": "^4.1.2",
-                "read-package-json": "^2.0.0",
-                "readdir-scoped-modules": "^1.0.0",
-                "semver": "2 || 3 || 4 || 5",
-                "slide": "~1.1.3",
-                "util-extend": "^1.0.1"
-              }
-            },
-            "read-package-json": {
-              "version": "2.0.13",
-              "resolved": false,
-              "integrity": "sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==",
-              "requires": {
-                "glob": "^7.1.1",
-                "graceful-fs": "^4.1.2",
-                "json-parse-better-errors": "^1.0.1",
-                "normalize-package-data": "^2.0.0",
-                "slash": "^1.0.0"
-              }
-            },
-            "read-package-tree": {
-              "version": "5.2.1",
-              "resolved": false,
-              "integrity": "sha512-2CNoRoh95LxY47LvqrehIAfUVda2JbuFE/HaGYs42bNrGG+ojbw1h3zOcPcQ+1GQ3+rkzNndZn85u1XyZ3UsIA==",
-              "requires": {
-                "debuglog": "^1.0.1",
-                "dezalgo": "^1.0.0",
-                "once": "^1.3.0",
-                "read-package-json": "^2.0.0",
-                "readdir-scoped-modules": "^1.0.0"
-              }
-            },
-            "readable-stream": {
-              "version": "2.3.6",
-              "resolved": false,
-              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "readdir-scoped-modules": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
-              "requires": {
-                "debuglog": "^1.0.1",
-                "dezalgo": "^1.0.0",
-                "graceful-fs": "^4.1.2",
-                "once": "^1.3.0"
-              }
-            },
-            "registry-auth-token": {
-              "version": "3.3.2",
-              "resolved": false,
-              "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
-              "requires": {
-                "rc": "^1.1.6",
-                "safe-buffer": "^5.0.1"
-              }
-            },
-            "registry-url": {
-              "version": "3.1.0",
-              "resolved": false,
-              "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-              "requires": {
-                "rc": "^1.0.1"
-              }
-            },
-            "request": {
-              "version": "2.88.0",
-              "resolved": false,
-              "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-              "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.8.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.6",
-                "extend": "~3.0.2",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "har-validator": "~5.1.0",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.19",
-                "oauth-sign": "~0.9.0",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.2",
-                "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.4.3",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.3.2"
-              }
-            },
-            "require-directory": {
-              "version": "2.1.1",
-              "resolved": false,
-              "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-            },
-            "require-main-filename": {
-              "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
-            },
-            "resolve-from": {
-              "version": "4.0.0",
-              "resolved": false,
-              "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
-            },
-            "retry": {
-              "version": "0.12.0",
-              "resolved": false,
-              "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
-            },
-            "rimraf": {
-              "version": "2.6.2",
-              "resolved": false,
-              "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-              "requires": {
-                "glob": "^7.0.5"
-              }
-            },
-            "run-queue": {
-              "version": "1.0.3",
-              "resolved": false,
-              "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
-              "requires": {
-                "aproba": "^1.1.1"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.2",
-              "resolved": false,
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-            },
-            "safer-buffer": {
-              "version": "2.1.2",
-              "resolved": false,
-              "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-            },
-            "semver": {
-              "version": "5.5.0",
-              "resolved": false,
-              "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
-            },
-            "semver-diff": {
-              "version": "2.1.0",
-              "resolved": false,
-              "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-              "requires": {
-                "semver": "^5.0.3"
-              }
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "resolved": false,
-              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-            },
-            "sha": {
-              "version": "2.0.1",
-              "resolved": false,
-              "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "readable-stream": "^2.0.2"
-              }
-            },
-            "shebang-command": {
-              "version": "1.2.0",
-              "resolved": false,
-              "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-              "requires": {
-                "shebang-regex": "^1.0.0"
-              }
-            },
-            "shebang-regex": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-            },
-            "signal-exit": {
-              "version": "3.0.2",
-              "resolved": false,
-              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-            },
-            "slash": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
-            },
-            "slide": {
-              "version": "1.1.6",
-              "resolved": false,
-              "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
-            },
-            "smart-buffer": {
-              "version": "4.0.1",
-              "resolved": false,
-              "integrity": "sha512-RFqinRVJVcCAL9Uh1oVqE6FZkqsyLiVOYEZ20TqIOjuX7iFVJ+zsbs4RIghnw/pTs7mZvt8ZHhvm1ZUrR4fykg=="
-            },
-            "socks": {
-              "version": "2.2.0",
-              "resolved": false,
-              "integrity": "sha512-uRKV9uXQ9ytMbGm2+DilS1jB7N3AC0mmusmW5TVWjNuBZjxS8+lX38fasKVY9I4opv/bY/iqTbcpFFaTwpfwRg==",
-              "requires": {
-                "ip": "^1.1.5",
-                "smart-buffer": "^4.0.1"
-              }
-            },
-            "socks-proxy-agent": {
-              "version": "4.0.1",
-              "resolved": false,
-              "integrity": "sha512-Kezx6/VBguXOsEe5oU3lXYyKMi4+gva72TwJ7pQY5JfqUx2nMk7NXA6z/mpNqIlfQjWYVfeuNvQjexiTaTn6Nw==",
-              "requires": {
-                "agent-base": "~4.2.0",
-                "socks": "~2.2.0"
-              }
-            },
-            "sorted-object": {
-              "version": "2.0.1",
-              "resolved": false,
-              "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw="
-            },
-            "sorted-union-stream": {
-              "version": "2.1.3",
-              "resolved": false,
-              "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
-              "requires": {
-                "from2": "^1.3.0",
-                "stream-iterate": "^1.1.0"
-              },
-              "dependencies": {
-                "from2": {
-                  "version": "1.3.0",
-                  "resolved": false,
-                  "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
-                  "requires": {
-                    "inherits": "~2.0.1",
-                    "readable-stream": "~1.1.10"
-                  }
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "resolved": false,
-                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-                },
-                "readable-stream": {
-                  "version": "1.1.14",
-                  "resolved": false,
-                  "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-                  "requires": {
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.1",
-                    "isarray": "0.0.1",
-                    "string_decoder": "~0.10.x"
-                  }
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "resolved": false,
-                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-                }
-              }
-            },
-            "spdx-correct": {
-              "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
-              "requires": {
-                "spdx-expression-parse": "^3.0.0",
-                "spdx-license-ids": "^3.0.0"
-              }
-            },
-            "spdx-exceptions": {
-              "version": "2.1.0",
-              "resolved": false,
-              "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
-            },
-            "spdx-expression-parse": {
-              "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-              "requires": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
-              }
-            },
-            "spdx-license-ids": {
-              "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
-            },
-            "sshpk": {
-              "version": "1.14.2",
-              "resolved": false,
-              "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
-              "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
-              }
-            },
-            "ssri": {
-              "version": "6.0.0",
-              "resolved": false,
-              "integrity": "sha512-zYOGfVHPhxyzwi8MdtdNyxv3IynWCIM4jYReR48lqu0VngxgH1c+C6CmipRdJ55eVByTJV/gboFEEI7TEQI8DA=="
-            },
-            "stream-each": {
-              "version": "1.2.2",
-              "resolved": false,
-              "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
-              "requires": {
-                "end-of-stream": "^1.1.0",
-                "stream-shift": "^1.0.0"
-              }
-            },
-            "stream-iterate": {
-              "version": "1.2.0",
-              "resolved": false,
-              "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
-              "requires": {
-                "readable-stream": "^2.1.5",
-                "stream-shift": "^1.0.0"
-              }
-            },
-            "stream-shift": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
-            },
-            "strict-uri-encode": {
-              "version": "2.0.0",
-              "resolved": false,
-              "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
-            },
-            "string-width": {
-              "version": "2.1.1",
-              "resolved": false,
-              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-              "requires": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
-              },
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "3.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-                },
-                "is-fullwidth-code-point": {
-                  "version": "2.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-                },
-                "strip-ansi": {
-                  "version": "4.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                  "requires": {
-                    "ansi-regex": "^3.0.0"
-                  }
-                }
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "resolved": false,
-              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            },
-            "stringify-package": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha512-JIQqiWmLiEozOC0b0BtxZ/AOUtdUZHCBPgqIZ2kSJJqGwgb9neo44XdTHUC4HZSGqi03hOeB7W/E8rAlKnGe9g=="
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            },
-            "strip-eof": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
-            },
-            "strip-json-comments": {
-              "version": "2.0.1",
-              "resolved": false,
-              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-            },
-            "supports-color": {
-              "version": "5.4.0",
-              "resolved": false,
-              "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            },
-            "tar": {
-              "version": "4.4.6",
-              "resolved": false,
-              "integrity": "sha512-tMkTnh9EdzxyfW+6GK6fCahagXsnYk6kE6S9Gr9pjVdys769+laCTbodXDhPAjzVtEBazRgP0gYqOjnk9dQzLg==",
-              "requires": {
-                "chownr": "^1.0.1",
-                "fs-minipass": "^1.2.5",
-                "minipass": "^2.3.3",
-                "minizlib": "^1.1.0",
-                "mkdirp": "^0.5.0",
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.2"
-              },
-              "dependencies": {
-                "yallist": {
-                  "version": "3.0.2",
-                  "resolved": false,
-                  "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
-                }
-              }
-            },
-            "term-size": {
-              "version": "1.2.0",
-              "resolved": false,
-              "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-              "requires": {
-                "execa": "^0.7.0"
-              }
-            },
-            "text-table": {
-              "version": "0.2.0",
-              "resolved": false,
-              "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
-            },
-            "through": {
-              "version": "2.3.8",
-              "resolved": false,
-              "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-            },
-            "through2": {
-              "version": "2.0.3",
-              "resolved": false,
-              "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-              "requires": {
-                "readable-stream": "^2.1.5",
-                "xtend": "~4.0.1"
-              }
-            },
-            "timed-out": {
-              "version": "4.0.1",
-              "resolved": false,
-              "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
-            },
-            "tiny-relative-date": {
-              "version": "1.3.0",
-              "resolved": false,
-              "integrity": "sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A=="
-            },
-            "tough-cookie": {
-              "version": "2.4.3",
-              "resolved": false,
-              "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-              "requires": {
-                "psl": "^1.1.24",
-                "punycode": "^1.4.1"
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "resolved": false,
-              "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-              "requires": {
-                "safe-buffer": "^5.0.1"
-              }
-            },
-            "tweetnacl": {
-              "version": "0.14.5",
-              "resolved": false,
-              "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-              "optional": true
-            },
-            "typedarray": {
-              "version": "0.0.6",
-              "resolved": false,
-              "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-            },
-            "uid-number": {
-              "version": "0.0.6",
-              "resolved": false,
-              "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
-            },
-            "umask": {
-              "version": "1.1.0",
-              "resolved": false,
-              "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0="
-            },
-            "unique-filename": {
-              "version": "1.1.0",
-              "resolved": false,
-              "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
-              "requires": {
-                "unique-slug": "^2.0.0"
-              }
-            },
-            "unique-slug": {
-              "version": "2.0.0",
-              "resolved": false,
-              "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
-              "requires": {
-                "imurmurhash": "^0.1.4"
-              }
-            },
-            "unique-string": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-              "requires": {
-                "crypto-random-string": "^1.0.0"
-              }
-            },
-            "unpipe": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
-            },
-            "unzip-response": {
-              "version": "2.0.1",
-              "resolved": false,
-              "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
-            },
-            "update-notifier": {
-              "version": "2.5.0",
-              "resolved": false,
-              "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
-              "requires": {
-                "boxen": "^1.2.1",
-                "chalk": "^2.0.1",
-                "configstore": "^3.0.0",
-                "import-lazy": "^2.1.0",
-                "is-ci": "^1.0.10",
-                "is-installed-globally": "^0.1.0",
-                "is-npm": "^1.0.0",
-                "latest-version": "^3.0.0",
-                "semver-diff": "^2.0.0",
-                "xdg-basedir": "^3.0.0"
-              }
-            },
-            "url-parse-lax": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-              "requires": {
-                "prepend-http": "^1.0.1"
-              }
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-            },
-            "util-extend": {
-              "version": "1.0.3",
-              "resolved": false,
-              "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8="
-            },
-            "uuid": {
-              "version": "3.3.2",
-              "resolved": false,
-              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-            },
-            "validate-npm-package-license": {
-              "version": "3.0.4",
-              "resolved": false,
-              "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-              "requires": {
-                "spdx-correct": "^3.0.0",
-                "spdx-expression-parse": "^3.0.0"
-              }
-            },
-            "validate-npm-package-name": {
-              "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
-              "requires": {
-                "builtins": "^1.0.3"
-              }
-            },
-            "verror": {
-              "version": "1.10.0",
-              "resolved": false,
-              "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-              "requires": {
-                "assert-plus": "^1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
-              }
-            },
-            "wcwidth": {
-              "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
-              "requires": {
-                "defaults": "^1.0.3"
-              }
-            },
-            "which": {
-              "version": "1.3.1",
-              "resolved": false,
-              "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-              "requires": {
-                "isexe": "^2.0.0"
-              }
-            },
-            "which-module": {
-              "version": "2.0.0",
-              "resolved": false,
-              "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-            },
-            "wide-align": {
-              "version": "1.1.2",
-              "resolved": false,
-              "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-              "requires": {
-                "string-width": "^1.0.2"
-              },
-              "dependencies": {
-                "string-width": {
-                  "version": "1.0.2",
-                  "resolved": false,
-                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                  "requires": {
-                    "code-point-at": "^1.0.0",
-                    "is-fullwidth-code-point": "^1.0.0",
-                    "strip-ansi": "^3.0.0"
-                  }
-                }
-              }
-            },
-            "widest-line": {
-              "version": "2.0.0",
-              "resolved": false,
-              "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
-              "requires": {
-                "string-width": "^2.1.1"
-              }
-            },
-            "worker-farm": {
-              "version": "1.6.0",
-              "resolved": false,
-              "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
-              "requires": {
-                "errno": "~0.1.7"
-              }
-            },
-            "wrap-ansi": {
-              "version": "2.1.0",
-              "resolved": false,
-              "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-              "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1"
-              },
-              "dependencies": {
-                "string-width": {
-                  "version": "1.0.2",
-                  "resolved": false,
-                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                  "requires": {
-                    "code-point-at": "^1.0.0",
-                    "is-fullwidth-code-point": "^1.0.0",
-                    "strip-ansi": "^3.0.0"
-                  }
-                }
-              }
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-            },
-            "write-file-atomic": {
-              "version": "2.3.0",
-              "resolved": false,
-              "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
-              "requires": {
-                "graceful-fs": "^4.1.11",
-                "imurmurhash": "^0.1.4",
-                "signal-exit": "^3.0.2"
-              }
-            },
-            "xdg-basedir": {
-              "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "resolved": false,
-              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-            },
-            "y18n": {
-              "version": "4.0.0",
-              "resolved": false,
-              "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
-            },
-            "yallist": {
-              "version": "2.1.2",
-              "resolved": false,
-              "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-            },
-            "yargs": {
-              "version": "11.0.0",
-              "resolved": false,
-              "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
-              "requires": {
-                "cliui": "^4.0.0",
-                "decamelize": "^1.1.1",
-                "find-up": "^2.1.0",
-                "get-caller-file": "^1.0.1",
-                "os-locale": "^2.0.0",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^1.0.1",
-                "set-blocking": "^2.0.0",
-                "string-width": "^2.0.0",
-                "which-module": "^2.0.0",
-                "y18n": "^3.2.1",
-                "yargs-parser": "^9.0.2"
-              },
-              "dependencies": {
-                "y18n": {
-                  "version": "3.2.1",
-                  "resolved": false,
-                  "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-                }
-              }
-            },
-            "yargs-parser": {
-              "version": "9.0.2",
-              "resolved": false,
-              "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
-              "requires": {
-                "camelcase": "^4.1.0"
-              }
-            }
-          }
-        },
         "object-assign": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "os-locale": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.0.1.tgz",
-          "integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+          "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
           "requires": {
-            "execa": "^0.10.0",
+            "execa": "^1.0.0",
             "lcid": "^2.0.0",
             "mem": "^4.0.0"
           },
           "dependencies": {
             "execa": {
-              "version": "0.10.0",
-              "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-              "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+              "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
               "requires": {
                 "cross-spawn": "^6.0.0",
-                "get-stream": "^3.0.0",
+                "get-stream": "^4.0.0",
                 "is-stream": "^1.1.0",
                 "npm-run-path": "^2.0.0",
                 "p-finally": "^1.0.0",
@@ -4617,21 +1251,19 @@
               }
             },
             "get-stream": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+              "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+              "requires": {
+                "pump": "^3.0.0"
+              }
             }
           }
         },
-        "p-is-promise": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
-          "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg=="
-        },
         "p-limit": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
-          "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+          "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
           "requires": {
             "p-try": "^2.0.0"
           }
@@ -4694,39 +1326,6 @@
             "once": "^1.3.1"
           }
         },
-        "rc": {
-          "version": "1.2.8",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-          "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          }
-        },
-        "react": {
-          "version": "16.5.2",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.5.2.tgz",
-          "integrity": "sha512-FDCSVd3DjVTmbEAjUNX6FgfAmQ+ypJfHUsqUJOYNCBUp1h8lqmtC+0mXJ+JjsWx4KAVTkk1vKd1hLQPvEviSuw==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "schedule": "^0.5.0"
-          }
-        },
-        "react-dom": {
-          "version": "16.5.2",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.5.2.tgz",
-          "integrity": "sha512-RC8LDw8feuZOHVgzEf7f+cxBr/DnKdqp56VU0lAs1f4UfKc4cU8wU4fTq/mgnvynLQo8OtlPC19NUFh/zjZPuA==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "schedule": "^0.5.0"
-          }
-        },
         "react-transition-group": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.5.0.tgz",
@@ -4736,16 +1335,6 @@
             "loose-envify": "^1.4.0",
             "prop-types": "^15.6.2",
             "react-lifecycles-compat": "^3.0.4"
-          },
-          "dependencies": {
-            "loose-envify": {
-              "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-              "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-              "requires": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
-              }
-            }
           }
         },
         "read-pkg": {
@@ -4765,48 +1354,6 @@
           "requires": {
             "find-up": "^3.0.0",
             "read-pkg": "^3.0.0"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-              "requires": {
-                "locate-path": "^3.0.0"
-              }
-            },
-            "locate-path": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-              "requires": {
-                "p-locate": "^3.0.0",
-                "path-exists": "^3.0.0"
-              }
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "redent": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
-          "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-          "requires": {
-            "indent-string": "^3.0.0",
-            "strip-indent": "^2.0.0"
           }
         },
         "resolve-from": {
@@ -4815,28 +1362,29 @@
           "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
         },
         "semantic-release": {
-          "version": "15.12.1",
-          "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-15.12.1.tgz",
-          "integrity": "sha512-HySTv+k3gKHM7/LWluz/2nZbDRI5zZpsOQ+GTVPLVepRMm5SdWzi4L+I7z5wBwN/JNSPHU7UF4CDSFeGYK1/Mg==",
+          "version": "15.9.6",
+          "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-15.9.6.tgz",
+          "integrity": "sha512-+CVbhqrbtIXEbOs4jUwSlx5bTcaKRK1OlV9vL1OiYSI2VSqdZOJVVn7GCR/XTmaLh8bYKBu9aBOIn5QqVwRU/A==",
           "requires": {
-            "@semantic-release/commit-analyzer": "^6.1.0",
+            "@semantic-release/commit-analyzer": "^6.0.0",
             "@semantic-release/error": "^2.2.0",
-            "@semantic-release/github": "^5.1.0",
-            "@semantic-release/npm": "^5.0.5",
-            "@semantic-release/release-notes-generator": "^7.1.2",
+            "@semantic-release/github": "^5.0.0",
+            "@semantic-release/npm": "^5.0.1",
+            "@semantic-release/release-notes-generator": "^7.0.0",
             "aggregate-error": "^1.0.0",
             "cosmiconfig": "^5.0.1",
-            "debug": "^4.0.0",
-            "env-ci": "^3.0.0",
-            "execa": "^1.0.0",
+            "debug": "^3.1.0",
+            "env-ci": "^2.0.0",
+            "execa": "^0.10.0",
             "figures": "^2.0.0",
-            "find-versions": "^3.0.0",
-            "get-stream": "^4.0.0",
+            "find-versions": "^2.0.0",
+            "get-stream": "^3.0.0",
             "git-log-parser": "^1.2.0",
+            "git-url-parse": "^10.0.1",
             "hook-std": "^1.1.0",
             "hosted-git-info": "^2.7.1",
             "lodash": "^4.17.4",
-            "marked": "^0.5.0",
+            "marked": "^0.4.0",
             "marked-terminal": "^3.0.0",
             "p-locate": "^3.0.0",
             "p-reduce": "^1.0.0",
@@ -4847,11 +1395,6 @@
             "yargs": "^12.0.0"
           }
         },
-        "semver-regex": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-2.0.0.tgz",
-          "integrity": "sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw=="
-        },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -4859,14 +1402,6 @@
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
@@ -4881,30 +1416,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-        },
-        "strip-indent": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        },
-        "trim-newlines": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-          "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
-        },
-        "url-join": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.0.tgz",
-          "integrity": "sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo="
         },
         "which-module": {
           "version": "2.0.0",
@@ -4928,25 +1439,6 @@
             "which-module": "^2.0.0",
             "y18n": "^3.2.1 || ^4.0.0",
             "yargs-parser": "^11.1.1"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-              "requires": {
-                "locate-path": "^3.0.0"
-              }
-            },
-            "locate-path": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-              "requires": {
-                "p-locate": "^3.0.0",
-                "path-exists": "^3.0.0"
-              }
-            }
           }
         },
         "yargs-parser": {
@@ -4956,13 +1448,6 @@
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-              "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
-            }
           }
         }
       }
@@ -5570,32 +2055,10 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.0.tgz",
       "integrity": "sha512-LAQ1d4OPfSJ/BMbI2DuizmYrrkD9JMaTdi2hQTlI53lQ4kRQPyZQRS4CYQ7O66bnBBnP/oYdRxbk++X0xuFU6A=="
     },
-    "@octokit/endpoint": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-3.0.1.tgz",
-      "integrity": "sha512-P2XHdgNG50U7+pqiHa3BpCHbG/n5FFmhrT89zfFunvBcB8ww7cuPNqwevkh1vLtOCUUMiNsE5WG9VHuGyzrivQ==",
-      "requires": {
-        "deepmerge": "2.2.1",
-        "is-plain-object": "^2.0.4",
-        "universal-user-agent": "^2.0.1",
-        "url-template": "^2.0.8"
-      }
-    },
-    "@octokit/request": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-2.1.1.tgz",
-      "integrity": "sha512-N0I01iWwbogadLyCbVJ048hDMet3uGrB93VeJgB+jeuugRUr1DXncEu2tpiWgSk1azGDFPe5RTRvfx4Uadf+Fw==",
-      "requires": {
-        "@octokit/endpoint": "^3.0.0",
-        "is-plain-object": "^2.0.4",
-        "universal-user-agent": "^2.0.1"
-      }
-    },
     "@octokit/rest": {
       "version": "15.9.5",
       "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.9.5.tgz",
       "integrity": "sha512-vJEHSTnI4UAbCDTjVSQljPeX81zsQVNj2ruM5Oj5gxOttHD0TcfWeElcJYoITCMxQTgN6Y+bJFo6/+/0CqoacA==",
-      "dev": true,
       "requires": {
         "before-after-hook": "^1.1.0",
         "btoa-lite": "^1.0.0",
@@ -5611,7 +2074,6 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -5619,14 +2081,12 @@
         "lodash": {
           "version": "4.17.10",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-          "dev": true
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         },
         "node-fetch": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
-          "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA==",
-          "dev": true
+          "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA=="
         }
       }
     },
@@ -5634,7 +2094,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-6.0.0.tgz",
       "integrity": "sha512-LEBEg5Ek3PCVv8srHRA8uuwu0t9nAXuBQ9ixjBiMYCqCCUsCezUi5wRdmXnJkXs5/yQkd4Dzx8OJ1zIAL2Pqeg==",
-      "dev": true,
       "requires": {
         "conventional-changelog-angular": "^5.0.0",
         "conventional-commits-filter": "^2.0.0",
@@ -5647,14 +2106,12 @@
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         },
         "camelcase-keys": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
-          "dev": true,
           "requires": {
             "camelcase": "^4.1.0",
             "map-obj": "^2.0.0",
@@ -5665,7 +2122,6 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.0.tgz",
           "integrity": "sha512-R75W1aOI9FNhnxLu9wz+jlGM+VSZLZvV10LBBLyx73S12RatSI5s3fUwlstKNybWolXZgBb6qvdkCfrRVqddZQ==",
-          "dev": true,
           "requires": {
             "compare-func": "^1.3.1",
             "q": "^1.5.1"
@@ -5675,7 +2131,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.0.tgz",
           "integrity": "sha512-GWh71U26BLWgMykCp+VghZ4s64wVbtseECcKQ/PvcPZR2cUnz+FUc2J9KjxNl7/ZbCxST8R03c9fc+Vi0umS9Q==",
-          "dev": true,
           "requires": {
             "JSONStream": "^1.0.4",
             "is-text-path": "^1.0.0",
@@ -5690,7 +2145,6 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -5699,7 +2153,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
           "requires": {
             "locate-path": "^2.0.0"
           }
@@ -5707,20 +2160,17 @@
         "indent-string": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-          "dev": true
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
         },
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "load-json-file": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "parse-json": "^4.0.0",
@@ -5731,20 +2181,17 @@
         "lodash": {
           "version": "4.17.10",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-          "dev": true
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         },
         "map-obj": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-          "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
-          "dev": true
+          "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
         },
         "meow": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
           "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
-          "dev": true,
           "requires": {
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
@@ -5761,7 +2208,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-          "dev": true,
           "requires": {
             "error-ex": "^1.3.1",
             "json-parse-better-errors": "^1.0.1"
@@ -5771,7 +2217,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-          "dev": true,
           "requires": {
             "pify": "^3.0.0"
           }
@@ -5779,14 +2224,12 @@
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         },
         "read-pkg": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-          "dev": true,
           "requires": {
             "load-json-file": "^4.0.0",
             "normalize-package-data": "^2.3.2",
@@ -5797,7 +2240,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-          "dev": true,
           "requires": {
             "find-up": "^2.0.0",
             "read-pkg": "^3.0.0"
@@ -5807,7 +2249,6 @@
           "version": "2.3.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -5822,7 +2263,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-          "dev": true,
           "requires": {
             "indent-string": "^3.0.0",
             "strip-indent": "^2.0.0"
@@ -5832,7 +2272,6 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -5840,20 +2279,17 @@
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
         },
         "strip-indent": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
-          "dev": true
+          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
         },
         "through2": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-          "dev": true,
           "requires": {
             "readable-stream": "^2.1.5",
             "xtend": "~4.0.1"
@@ -5862,8 +2298,7 @@
         "trim-newlines": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-          "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-          "dev": true
+          "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
         }
       }
     },
@@ -5944,7 +2379,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-5.0.2.tgz",
       "integrity": "sha512-YySh2iBDXcsU5Mtaseo9L3wsCgTNj2wDMxi8L6hLxFayJy3YqiZ9Yym/jf+Fh8J/Afy8IxyVaz8Re5AfjnoyOg==",
-      "dev": true,
       "requires": {
         "@octokit/rest": "^15.2.0",
         "@semantic-release/error": "^2.2.0",
@@ -5969,7 +2403,6 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -5978,7 +2411,6 @@
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
           "integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
-          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "jsonfile": "^4.0.0",
@@ -5989,7 +2421,6 @@
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -6003,7 +2434,6 @@
           "version": "8.0.1",
           "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
           "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
-          "dev": true,
           "requires": {
             "array-union": "^1.0.1",
             "dir-glob": "^2.0.0",
@@ -6018,7 +2448,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6"
           }
@@ -6026,20 +2455,17 @@
         "lodash": {
           "version": "4.17.10",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-          "dev": true
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         },
         "mime": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
-          "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==",
-          "dev": true
+          "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
         },
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6047,14 +2473,12 @@
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         },
         "url-join": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.0.tgz",
-          "integrity": "sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo=",
-          "dev": true
+          "integrity": "sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo="
         }
       }
     },
@@ -6062,7 +2486,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-5.0.1.tgz",
       "integrity": "sha512-K5mMeWrY986/aPMf0us3Ww7MIR0Ls8cZqvNK25yuz4OtzUM5hxOm4Y/tfPyEjRJV4VASVKRP8EVKxTqKVcUDrg==",
-      "dev": true,
       "requires": {
         "@semantic-release/error": "^2.2.0",
         "aggregate-error": "^1.0.0",
@@ -6084,7 +2507,6 @@
           "version": "6.0.5",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
           "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-          "dev": true,
           "requires": {
             "nice-try": "^1.0.4",
             "path-key": "^2.0.1",
@@ -6096,20 +2518,17 @@
         "deep-extend": {
           "version": "0.6.0",
           "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-          "dev": true
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
         },
         "detect-indent": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
-          "dev": true
+          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
         },
         "execa": {
           "version": "0.10.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
           "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
-          "dev": true,
           "requires": {
             "cross-spawn": "^6.0.0",
             "get-stream": "^3.0.0",
@@ -6124,7 +2543,6 @@
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
           "integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
-          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "jsonfile": "^4.0.0",
@@ -6135,7 +2553,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6"
           }
@@ -6143,20 +2560,17 @@
         "lodash": {
           "version": "4.17.10",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-          "dev": true
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         },
         "normalize-url": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.2.0.tgz",
-          "integrity": "sha512-WvF3Myk0NhXkG8S9bygFM4IC1KOvnVJGq0QoGeoqOYOBeinBZp5ybW3QuYbTc89lkWBMM9ZBO4QGRoc0353kKA==",
-          "dev": true
+          "integrity": "sha512-WvF3Myk0NhXkG8S9bygFM4IC1KOvnVJGq0QoGeoqOYOBeinBZp5ybW3QuYbTc89lkWBMM9ZBO4QGRoc0353kKA=="
         },
         "npm": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/npm/-/npm-6.3.0.tgz",
           "integrity": "sha512-oDtLFo3wXue/xe3pU/oks9VHS5501OAWlYrZrApZkFv7l2LXk+9CfPMbjbfZWK7Jqlc1jbNcJMkB6KZC7K/vEA==",
-          "dev": true,
           "requires": {
             "JSONStream": "^1.3.3",
             "abbrev": "~1.1.1",
@@ -6279,9 +2693,8 @@
           "dependencies": {
             "JSONStream": {
               "version": "1.3.3",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.3.tgz",
+              "resolved": false,
               "integrity": "sha512-3Sp6WZZ/lXl+nTDoGpGWHEpTnnC6X5fnkolYZR6nwIfzbxxvA8utPWe1gCt7i0m9uVGsSz2IS8K8mJ7HmlduMg==",
-              "dev": true,
               "requires": {
                 "jsonparse": "^1.2.0",
                 "through": ">=2.2.7 <3"
@@ -6289,81 +2702,70 @@
             },
             "abbrev": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-              "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
             },
             "agent-base": {
               "version": "4.2.0",
-              "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
+              "resolved": false,
               "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
-              "dev": true,
               "requires": {
                 "es6-promisify": "^5.0.0"
               }
             },
             "agentkeepalive": {
               "version": "3.4.1",
-              "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.4.1.tgz",
+              "resolved": false,
               "integrity": "sha512-MPIwsZU9PP9kOrZpyu2042kYA8Fdt/AedQYkYXucHgF9QoD9dXVp0ypuGnHXSR0hTstBxdt85Xkh4JolYfK5wg==",
-              "dev": true,
               "requires": {
                 "humanize-ms": "^1.2.1"
               }
             },
             "ansi-align": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+              "resolved": false,
               "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
-              "dev": true,
               "requires": {
                 "string-width": "^2.0.0"
               }
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
             },
             "ansi-styles": {
               "version": "3.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+              "resolved": false,
               "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-              "dev": true,
               "requires": {
                 "color-convert": "^1.9.0"
               }
             },
             "ansicolors": {
               "version": "0.3.2",
-              "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-              "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk="
             },
             "ansistyles": {
               "version": "0.1.3",
-              "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
-              "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk="
             },
             "aproba": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
             },
             "archy": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-              "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
             },
             "are-we-there-yet": {
               "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+              "resolved": false,
               "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-              "dev": true,
               "requires": {
                 "delegates": "^1.0.0",
                 "readable-stream": "^2.0.6"
@@ -6371,51 +2773,43 @@
             },
             "asap": {
               "version": "2.0.6",
-              "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-              "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
             },
             "asn1": {
               "version": "0.2.3",
-              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-              "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
             },
             "assert-plus": {
               "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-              "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
             },
             "asynckit": {
               "version": "0.4.0",
-              "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-              "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
             },
             "aws-sign2": {
               "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
             },
             "aws4": {
               "version": "1.7.0",
-              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-              "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
             },
             "balanced-match": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
             },
             "bcrypt-pbkdf": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+              "resolved": false,
               "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-              "dev": true,
               "optional": true,
               "requires": {
                 "tweetnacl": "^0.14.3"
@@ -6423,9 +2817,8 @@
             },
             "bin-links": {
               "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-1.1.2.tgz",
+              "resolved": false,
               "integrity": "sha512-8eEHVgYP03nILphilltWjeIjMbKyJo3wvp9K816pHbhP301ismzw15mxAAEVQ/USUwcP++1uNrbERbp8lOA6Fg==",
-              "dev": true,
               "requires": {
                 "bluebird": "^3.5.0",
                 "cmd-shim": "^2.0.2",
@@ -6436,33 +2829,29 @@
             },
             "block-stream": {
               "version": "0.0.9",
-              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+              "resolved": false,
               "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-              "dev": true,
               "requires": {
                 "inherits": "~2.0.0"
               }
             },
             "bluebird": {
               "version": "3.5.1",
-              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-              "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
             },
             "boom": {
               "version": "2.10.1",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+              "resolved": false,
               "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-              "dev": true,
               "requires": {
                 "hoek": "2.x.x"
               }
             },
             "boxen": {
               "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+              "resolved": false,
               "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
-              "dev": true,
               "requires": {
                 "ansi-align": "^2.0.0",
                 "camelcase": "^4.0.0",
@@ -6475,9 +2864,8 @@
             },
             "brace-expansion": {
               "version": "1.1.11",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+              "resolved": false,
               "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-              "dev": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -6485,39 +2873,33 @@
             },
             "buffer-from": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-              "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
             },
             "builtin-modules": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-              "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
             },
             "builtins": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-              "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
             },
             "byline": {
               "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
-              "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
             },
             "byte-size": {
               "version": "4.0.3",
-              "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-4.0.3.tgz",
-              "integrity": "sha512-JGC3EV2bCzJH/ENSh3afyJrH4vwxbHTuO5ljLoI5+2iJOcEpMgP8T782jH9b5qGxf2mSUIp1lfGnfKNrRHpvVg==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-JGC3EV2bCzJH/ENSh3afyJrH4vwxbHTuO5ljLoI5+2iJOcEpMgP8T782jH9b5qGxf2mSUIp1lfGnfKNrRHpvVg=="
             },
             "cacache": {
               "version": "11.1.0",
-              "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.1.0.tgz",
+              "resolved": false,
               "integrity": "sha512-wFLexxfPdlvoUlpHIaU4y4Vm+Im/otOPCg1ov5g9/HRfUhVA8GpDdQL66SWBgRpgNC+5ebMT1Vr1RyPaFrJVqw==",
-              "dev": true,
               "requires": {
                 "bluebird": "^3.5.1",
                 "chownr": "^1.0.1",
@@ -6537,33 +2919,28 @@
             },
             "call-limit": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/call-limit/-/call-limit-1.1.0.tgz",
-              "integrity": "sha1-b9YbA/PaQqLNDsK2DwK9DnGZH+o=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-b9YbA/PaQqLNDsK2DwK9DnGZH+o="
             },
             "camelcase": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
             },
             "capture-stack-trace": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-              "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
             },
             "caseless": {
               "version": "0.12.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-              "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
             },
             "chalk": {
               "version": "2.4.1",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+              "resolved": false,
               "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-              "dev": true,
               "requires": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -6572,36 +2949,31 @@
             },
             "chownr": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-              "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
             },
             "ci-info": {
               "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
-              "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg=="
             },
             "cidr-regex": {
               "version": "2.0.9",
-              "resolved": "https://registry.npmjs.org/cidr-regex/-/cidr-regex-2.0.9.tgz",
+              "resolved": false,
               "integrity": "sha512-F7/fBRUU45FnvSPjXdpIrc++WRSBdCiSTlyq4ZNhLKOlHFNWgtzZ0Fd+zrqI/J1j0wmlx/f5ZQDmD2GcbrNcmw==",
-              "dev": true,
               "requires": {
                 "ip-regex": "^2.1.0"
               }
             },
             "cli-boxes": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-              "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
             },
             "cli-columns": {
               "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/cli-columns/-/cli-columns-3.1.2.tgz",
+              "resolved": false,
               "integrity": "sha1-ZzLZcpee/CrkRKHwjgj6E5yWoY4=",
-              "dev": true,
               "requires": {
                 "string-width": "^2.0.0",
                 "strip-ansi": "^3.0.1"
@@ -6609,9 +2981,8 @@
             },
             "cli-table3": {
               "version": "0.5.0",
-              "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.0.tgz",
+              "resolved": false,
               "integrity": "sha512-c7YHpUyO1SaKaO7kYtxd5NZ8FjAmSK3LpKkuzdwn+2CwpFxBpdoQLm+OAnnCfoEl7onKhN9PKQi1lsHuAIUqGQ==",
-              "dev": true,
               "requires": {
                 "colors": "^1.1.2",
                 "object-assign": "^4.1.0",
@@ -6620,9 +2991,8 @@
             },
             "cliui": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+              "resolved": false,
               "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-              "dev": true,
               "requires": {
                 "string-width": "^2.1.1",
                 "strip-ansi": "^4.0.0",
@@ -6631,15 +3001,13 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                  "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                  "dev": true
+                  "resolved": false,
+                  "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
                 },
                 "strip-ansi": {
                   "version": "4.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                  "resolved": false,
                   "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                  "dev": true,
                   "requires": {
                     "ansi-regex": "^3.0.0"
                   }
@@ -6648,15 +3016,13 @@
             },
             "clone": {
               "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-              "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
             },
             "cmd-shim": {
               "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
+              "resolved": false,
               "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
-              "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
                 "mkdirp": "~0.5.0"
@@ -6664,43 +3030,37 @@
             },
             "co": {
               "version": "4.6.0",
-              "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-              "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
             },
             "code-point-at": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
             },
             "color-convert": {
               "version": "1.9.1",
-              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+              "resolved": false,
               "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-              "dev": true,
               "requires": {
                 "color-name": "^1.1.1"
               }
             },
             "color-name": {
               "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-              "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
             },
             "colors": {
               "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.0.tgz",
+              "resolved": false,
               "integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw==",
-              "dev": true,
               "optional": true
             },
             "columnify": {
               "version": "1.5.4",
-              "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+              "resolved": false,
               "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
-              "dev": true,
               "requires": {
                 "strip-ansi": "^3.0.0",
                 "wcwidth": "^1.0.0"
@@ -6708,24 +3068,21 @@
             },
             "combined-stream": {
               "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+              "resolved": false,
               "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-              "dev": true,
               "requires": {
                 "delayed-stream": "~1.0.0"
               }
             },
             "concat-map": {
               "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
             },
             "concat-stream": {
               "version": "1.6.2",
-              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+              "resolved": false,
               "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-              "dev": true,
               "requires": {
                 "buffer-from": "^1.0.0",
                 "inherits": "^2.0.3",
@@ -6735,9 +3092,8 @@
             },
             "config-chain": {
               "version": "1.1.11",
-              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+              "resolved": false,
               "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
-              "dev": true,
               "requires": {
                 "ini": "^1.3.4",
                 "proto-list": "~1.2.1"
@@ -6745,9 +3101,8 @@
             },
             "configstore": {
               "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+              "resolved": false,
               "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
-              "dev": true,
               "requires": {
                 "dot-prop": "^4.1.0",
                 "graceful-fs": "^4.1.2",
@@ -6759,15 +3114,13 @@
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
             },
             "copy-concurrently": {
               "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+              "resolved": false,
               "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
-              "dev": true,
               "requires": {
                 "aproba": "^1.1.1",
                 "fs-write-stream-atomic": "^1.0.8",
@@ -6779,32 +3132,28 @@
               "dependencies": {
                 "iferr": {
                   "version": "0.1.5",
-                  "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-                  "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
-                  "dev": true
+                  "resolved": false,
+                  "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
                 }
               }
             },
             "core-util-is": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
             },
             "create-error-class": {
               "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+              "resolved": false,
               "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-              "dev": true,
               "requires": {
                 "capture-stack-trace": "^1.0.0"
               }
             },
             "cross-spawn": {
               "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+              "resolved": false,
               "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-              "dev": true,
               "requires": {
                 "lru-cache": "^4.0.1",
                 "shebang-command": "^1.2.0",
@@ -6813,121 +3162,104 @@
             },
             "cryptiles": {
               "version": "2.0.5",
-              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+              "resolved": false,
               "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-              "dev": true,
               "requires": {
                 "boom": "2.x.x"
               }
             },
             "crypto-random-string": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-              "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
             },
             "cyclist": {
               "version": "0.2.2",
-              "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
-              "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
             },
             "dashdash": {
               "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+              "resolved": false,
               "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-              "dev": true,
               "requires": {
                 "assert-plus": "^1.0.0"
               },
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                  "dev": true
+                  "resolved": false,
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
                 }
               }
             },
             "debug": {
               "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "resolved": false,
               "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-              "dev": true,
               "requires": {
                 "ms": "2.0.0"
               },
               "dependencies": {
                 "ms": {
                   "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                  "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                  "dev": true
+                  "resolved": false,
+                  "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 }
               }
             },
             "debuglog": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-              "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI="
             },
             "decamelize": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-              "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
             },
             "decode-uri-component": {
               "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-              "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
             },
             "deep-extend": {
               "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
-              "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w=="
             },
             "defaults": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+              "resolved": false,
               "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-              "dev": true,
               "requires": {
                 "clone": "^1.0.2"
               }
             },
             "delayed-stream": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-              "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
             },
             "delegates": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-              "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
             },
             "detect-indent": {
               "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-              "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
             },
             "detect-newline": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-              "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
             },
             "dezalgo": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+              "resolved": false,
               "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
-              "dev": true,
               "requires": {
                 "asap": "^2.0.0",
                 "wrappy": "1"
@@ -6935,30 +3267,26 @@
             },
             "dot-prop": {
               "version": "4.2.0",
-              "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+              "resolved": false,
               "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-              "dev": true,
               "requires": {
                 "is-obj": "^1.0.0"
               }
             },
             "dotenv": {
               "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
-              "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
             },
             "duplexer3": {
               "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-              "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
             },
             "duplexify": {
               "version": "3.6.0",
-              "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+              "resolved": false,
               "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
-              "dev": true,
               "requires": {
                 "end-of-stream": "^1.0.0",
                 "inherits": "^2.0.1",
@@ -6968,9 +3296,8 @@
             },
             "ecc-jsbn": {
               "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+              "resolved": false,
               "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-              "dev": true,
               "optional": true,
               "requires": {
                 "jsbn": "~0.1.0"
@@ -6978,69 +3305,60 @@
             },
             "editor": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
-              "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I="
             },
             "encoding": {
               "version": "0.1.12",
-              "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+              "resolved": false,
               "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-              "dev": true,
               "requires": {
                 "iconv-lite": "~0.4.13"
               }
             },
             "end-of-stream": {
               "version": "1.4.1",
-              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+              "resolved": false,
               "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-              "dev": true,
               "requires": {
                 "once": "^1.4.0"
               }
             },
             "err-code": {
               "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-              "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
             },
             "errno": {
               "version": "0.1.7",
-              "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+              "resolved": false,
               "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
-              "dev": true,
               "requires": {
                 "prr": "~1.0.1"
               }
             },
             "es6-promise": {
               "version": "4.2.4",
-              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-              "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
             },
             "es6-promisify": {
               "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+              "resolved": false,
               "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-              "dev": true,
               "requires": {
                 "es6-promise": "^4.0.3"
               }
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
             },
             "execa": {
               "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+              "resolved": false,
               "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-              "dev": true,
               "requires": {
                 "cross-spawn": "^5.0.1",
                 "get-stream": "^3.0.0",
@@ -7053,42 +3371,36 @@
             },
             "extend": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-              "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
             },
             "extsprintf": {
               "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-              "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
             },
             "figgy-pudding": {
               "version": "3.2.0",
-              "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.2.0.tgz",
-              "integrity": "sha512-S2gSvqcqkI4sk+dI3ykKllfEg88dL5cXM0QPT4z9UbOkNygqec8/99d0VB3ikZ7u1/QC5l4e1YJPWvoUFuRVkg==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-S2gSvqcqkI4sk+dI3ykKllfEg88dL5cXM0QPT4z9UbOkNygqec8/99d0VB3ikZ7u1/QC5l4e1YJPWvoUFuRVkg=="
             },
             "find-npm-prefix": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/find-npm-prefix/-/find-npm-prefix-1.0.2.tgz",
-              "integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA=="
             },
             "find-up": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+              "resolved": false,
               "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-              "dev": true,
               "requires": {
                 "locate-path": "^2.0.0"
               }
             },
             "flush-write-stream": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
+              "resolved": false,
               "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
-              "dev": true,
               "requires": {
                 "inherits": "^2.0.1",
                 "readable-stream": "^2.0.4"
@@ -7096,15 +3408,13 @@
             },
             "forever-agent": {
               "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
             },
             "form-data": {
               "version": "2.1.4",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+              "resolved": false,
               "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-              "dev": true,
               "requires": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.5",
@@ -7113,9 +3423,8 @@
             },
             "from2": {
               "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+              "resolved": false,
               "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
-              "dev": true,
               "requires": {
                 "inherits": "^2.0.1",
                 "readable-stream": "^2.0.0"
@@ -7123,18 +3432,16 @@
             },
             "fs-minipass": {
               "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+              "resolved": false,
               "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
-              "dev": true,
               "requires": {
                 "minipass": "^2.2.1"
               }
             },
             "fs-vacuum": {
               "version": "1.2.10",
-              "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz",
+              "resolved": false,
               "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
-              "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
                 "path-is-inside": "^1.0.1",
@@ -7143,9 +3450,8 @@
             },
             "fs-write-stream-atomic": {
               "version": "1.0.10",
-              "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+              "resolved": false,
               "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
-              "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
                 "iferr": "^0.1.5",
@@ -7155,23 +3461,20 @@
               "dependencies": {
                 "iferr": {
                   "version": "0.1.5",
-                  "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-                  "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
-                  "dev": true
+                  "resolved": false,
+                  "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
                 }
               }
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
             },
             "fstream": {
               "version": "1.0.11",
-              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+              "resolved": false,
               "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-              "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
                 "inherits": "~2.0.0",
@@ -7181,9 +3484,8 @@
             },
             "gauge": {
               "version": "2.7.4",
-              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+              "resolved": false,
               "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-              "dev": true,
               "requires": {
                 "aproba": "^1.0.3",
                 "console-control-strings": "^1.0.0",
@@ -7197,9 +3499,8 @@
               "dependencies": {
                 "string-width": {
                   "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                  "resolved": false,
                   "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                  "dev": true,
                   "requires": {
                     "code-point-at": "^1.0.0",
                     "is-fullwidth-code-point": "^1.0.0",
@@ -7210,15 +3511,13 @@
             },
             "genfun": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/genfun/-/genfun-4.0.1.tgz",
-              "integrity": "sha1-7RAEHy5KfxsKOEZtF6XD4n3x38E=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-7RAEHy5KfxsKOEZtF6XD4n3x38E="
             },
             "gentle-fs": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/gentle-fs/-/gentle-fs-2.0.1.tgz",
+              "resolved": false,
               "integrity": "sha512-cEng5+3fuARewXktTEGbwsktcldA+YsnUEaXZwcK/3pjSE1X9ObnTs+/8rYf8s+RnIcQm2D5x3rwpN7Zom8Bew==",
-              "dev": true,
               "requires": {
                 "aproba": "^1.1.2",
                 "fs-vacuum": "^1.2.10",
@@ -7232,46 +3531,40 @@
               "dependencies": {
                 "iferr": {
                   "version": "0.1.5",
-                  "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-                  "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
-                  "dev": true
+                  "resolved": false,
+                  "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
                 }
               }
             },
             "get-caller-file": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-              "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
             },
             "get-stream": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
             },
             "getpass": {
               "version": "0.1.7",
-              "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+              "resolved": false,
               "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-              "dev": true,
               "requires": {
                 "assert-plus": "^1.0.0"
               },
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                  "dev": true
+                  "resolved": false,
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
                 }
               }
             },
             "glob": {
               "version": "7.1.2",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+              "resolved": false,
               "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-              "dev": true,
               "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -7283,18 +3576,16 @@
             },
             "global-dirs": {
               "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+              "resolved": false,
               "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
-              "dev": true,
               "requires": {
                 "ini": "^1.3.4"
               }
             },
             "got": {
               "version": "6.7.1",
-              "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+              "resolved": false,
               "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-              "dev": true,
               "requires": {
                 "create-error-class": "^3.0.0",
                 "duplexer3": "^0.1.4",
@@ -7311,21 +3602,18 @@
             },
             "graceful-fs": {
               "version": "4.1.11",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-              "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
             },
             "har-schema": {
               "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-              "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
             },
             "har-validator": {
               "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+              "resolved": false,
               "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-              "dev": true,
               "requires": {
                 "ajv": "^4.9.1",
                 "har-schema": "^1.0.5"
@@ -7333,9 +3621,8 @@
               "dependencies": {
                 "ajv": {
                   "version": "4.11.8",
-                  "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+                  "resolved": false,
                   "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-                  "dev": true,
                   "requires": {
                     "co": "^4.6.0",
                     "json-stable-stringify": "^1.0.1"
@@ -7345,21 +3632,18 @@
             },
             "has-flag": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
             },
             "has-unicode": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
             },
             "hawk": {
               "version": "3.1.3",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+              "resolved": false,
               "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-              "dev": true,
               "requires": {
                 "boom": "2.x.x",
                 "cryptiles": "2.x.x",
@@ -7369,27 +3653,23 @@
             },
             "hoek": {
               "version": "2.16.3",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-              "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
             },
             "hosted-git-info": {
               "version": "2.6.0",
-              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-              "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
             },
             "http-cache-semantics": {
               "version": "3.8.1",
-              "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
-              "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
             },
             "http-proxy-agent": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+              "resolved": false,
               "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
-              "dev": true,
               "requires": {
                 "agent-base": "4",
                 "debug": "3.1.0"
@@ -7397,9 +3677,8 @@
             },
             "http-signature": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+              "resolved": false,
               "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-              "dev": true,
               "requires": {
                 "assert-plus": "^0.2.0",
                 "jsprim": "^1.2.2",
@@ -7408,9 +3687,8 @@
             },
             "https-proxy-agent": {
               "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+              "resolved": false,
               "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
-              "dev": true,
               "requires": {
                 "agent-base": "^4.1.0",
                 "debug": "^3.1.0"
@@ -7418,54 +3696,47 @@
             },
             "humanize-ms": {
               "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+              "resolved": false,
               "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
-              "dev": true,
               "requires": {
                 "ms": "^2.0.0"
               }
             },
             "iconv-lite": {
               "version": "0.4.23",
-              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+              "resolved": false,
               "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-              "dev": true,
               "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
               }
             },
             "iferr": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/iferr/-/iferr-1.0.0.tgz",
-              "integrity": "sha512-0+ecqiP/cxgnNBIPi+TgJlaxE7sFp2N3kBFg17klQUdf24YKiaEV6b9QgEqOlD5vCVCE0U7OV9lPSN2OfS4zoQ==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-0+ecqiP/cxgnNBIPi+TgJlaxE7sFp2N3kBFg17klQUdf24YKiaEV6b9QgEqOlD5vCVCE0U7OV9lPSN2OfS4zoQ=="
             },
             "ignore-walk": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+              "resolved": false,
               "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
-              "dev": true,
               "requires": {
                 "minimatch": "^3.0.4"
               }
             },
             "import-lazy": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-              "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
             },
             "imurmurhash": {
               "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-              "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
             },
             "inflight": {
               "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "resolved": false,
               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-              "dev": true,
               "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -7473,21 +3744,18 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             },
             "ini": {
               "version": "1.3.5",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-              "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
             },
             "init-package-json": {
               "version": "1.10.3",
-              "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.3.tgz",
+              "resolved": false,
               "integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
-              "dev": true,
               "requires": {
                 "glob": "^7.1.1",
                 "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
@@ -7501,63 +3769,55 @@
             },
             "invert-kv": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-              "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
             },
             "ip": {
               "version": "1.1.5",
-              "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-              "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
             },
             "ip-regex": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-              "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
             },
             "is-builtin-module": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+              "resolved": false,
               "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-              "dev": true,
               "requires": {
                 "builtin-modules": "^1.0.0"
               }
             },
             "is-ci": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+              "resolved": false,
               "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
-              "dev": true,
               "requires": {
                 "ci-info": "^1.0.0"
               }
             },
             "is-cidr": {
               "version": "2.0.6",
-              "resolved": "https://registry.npmjs.org/is-cidr/-/is-cidr-2.0.6.tgz",
+              "resolved": false,
               "integrity": "sha512-A578p1dV22TgPXn6NCaDAPj6vJvYsBgAzUrAd28a4oldeXJjWqEUuSZOLIW3im51mazOKsoyVp8NU/OItlWacw==",
-              "dev": true,
               "requires": {
                 "cidr-regex": "^2.0.8"
               }
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "resolved": false,
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-              "dev": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
             },
             "is-installed-globally": {
               "version": "0.1.0",
-              "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+              "resolved": false,
               "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
-              "dev": true,
               "requires": {
                 "global-dirs": "^0.1.0",
                 "is-path-inside": "^1.0.0"
@@ -7565,118 +3825,100 @@
             },
             "is-npm": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-              "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
             },
             "is-obj": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-              "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
             },
             "is-path-inside": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+              "resolved": false,
               "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-              "dev": true,
               "requires": {
                 "path-is-inside": "^1.0.1"
               }
             },
             "is-redirect": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-              "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
             },
             "is-retry-allowed": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-              "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
             },
             "is-stream": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-              "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
             },
             "is-typedarray": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
             },
             "isarray": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
             },
             "isexe": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-              "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
             },
             "isstream": {
               "version": "0.1.2",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
             },
             "jsbn": {
               "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+              "resolved": false,
               "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-              "dev": true,
               "optional": true
             },
             "json-parse-better-errors": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-              "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
             },
             "json-schema": {
               "version": "0.2.3",
-              "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-              "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
             },
             "json-stable-stringify": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+              "resolved": false,
               "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-              "dev": true,
               "requires": {
                 "jsonify": "~0.0.0"
               }
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
             },
             "jsonify": {
               "version": "0.0.0",
-              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
             },
             "jsonparse": {
               "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-              "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
             },
             "jsprim": {
               "version": "1.4.1",
-              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+              "resolved": false,
               "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-              "dev": true,
               "requires": {
                 "assert-plus": "1.0.0",
                 "extsprintf": "1.3.0",
@@ -7686,41 +3928,36 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                  "dev": true
+                  "resolved": false,
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
                 }
               }
             },
             "latest-version": {
               "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+              "resolved": false,
               "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
-              "dev": true,
               "requires": {
                 "package-json": "^4.0.0"
               }
             },
             "lazy-property": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/lazy-property/-/lazy-property-1.0.0.tgz",
-              "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc="
             },
             "lcid": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+              "resolved": false,
               "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-              "dev": true,
               "requires": {
                 "invert-kv": "^1.0.0"
               }
             },
             "libcipm": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/libcipm/-/libcipm-2.0.0.tgz",
+              "resolved": false,
               "integrity": "sha512-yTWR7Ch7Mg891KZj+1yhcWhztO6tuAcBLdmCvBXv2pbCzV5/DOEDjDQdZmmYn5mFwI96kOSu+OIMRTmLsxrNZw==",
-              "dev": true,
               "requires": {
                 "bin-links": "^1.1.2",
                 "bluebird": "^3.5.1",
@@ -7739,9 +3976,8 @@
             },
             "libnpmhook": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/libnpmhook/-/libnpmhook-4.0.1.tgz",
+              "resolved": false,
               "integrity": "sha512-3qqpfqvBD1712WA6iGe0stkG40WwAeoWcujA6BlC0Be1JArQbqwabnEnZ0CRcD05Tf1fPYJYdCbSfcfedEJCOg==",
-              "dev": true,
               "requires": {
                 "figgy-pudding": "^3.1.0",
                 "npm-registry-fetch": "^3.0.0"
@@ -7749,9 +3985,8 @@
               "dependencies": {
                 "npm-registry-fetch": {
                   "version": "3.1.1",
-                  "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-3.1.1.tgz",
+                  "resolved": false,
                   "integrity": "sha512-xBobENeenvjIG8PgQ1dy77AXTI25IbYhmA3DusMIfw/4EL5BaQ5e1V9trkPrqHvyjR3/T0cnH6o0Wt/IzcI5Ag==",
-                  "dev": true,
                   "requires": {
                     "bluebird": "^3.5.1",
                     "figgy-pudding": "^3.1.0",
@@ -7764,9 +3999,8 @@
             },
             "libnpx": {
               "version": "10.2.0",
-              "resolved": "https://registry.npmjs.org/libnpx/-/libnpx-10.2.0.tgz",
+              "resolved": false,
               "integrity": "sha512-X28coei8/XRCt15cYStbLBph+KGhFra4VQhRBPuH/HHMkC5dxM8v24RVgUsvODKCrUZ0eTgiTqJp6zbl0sskQQ==",
-              "dev": true,
               "requires": {
                 "dotenv": "^5.0.1",
                 "npm-package-arg": "^6.0.0",
@@ -7780,9 +4014,8 @@
             },
             "locate-path": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+              "resolved": false,
               "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-              "dev": true,
               "requires": {
                 "p-locate": "^2.0.0",
                 "path-exists": "^3.0.0"
@@ -7790,9 +4023,8 @@
             },
             "lock-verify": {
               "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/lock-verify/-/lock-verify-2.0.2.tgz",
+              "resolved": false,
               "integrity": "sha512-QNVwK0EGZBS4R3YQ7F1Ox8p41Po9VGl2QG/2GsuvTbkJZYSsPeWHKMbbH6iZMCHWSMww5nrJroZYnGzI4cePuw==",
-              "dev": true,
               "requires": {
                 "npm-package-arg": "^5.1.2 || 6",
                 "semver": "^5.4.1"
@@ -7800,24 +4032,21 @@
             },
             "lockfile": {
               "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
+              "resolved": false,
               "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
-              "dev": true,
               "requires": {
                 "signal-exit": "^3.0.2"
               }
             },
             "lodash._baseindexof": {
               "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
-              "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw="
             },
             "lodash._baseuniq": {
               "version": "4.6.0",
-              "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
+              "resolved": false,
               "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
-              "dev": true,
               "requires": {
                 "lodash._createset": "~4.0.0",
                 "lodash._root": "~3.0.0"
@@ -7825,84 +4054,71 @@
             },
             "lodash._bindcallback": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-              "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
             },
             "lodash._cacheindexof": {
               "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
-              "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI="
             },
             "lodash._createcache": {
               "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+              "resolved": false,
               "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
-              "dev": true,
               "requires": {
                 "lodash._getnative": "^3.0.0"
               }
             },
             "lodash._createset": {
               "version": "4.0.3",
-              "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
-              "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY="
             },
             "lodash._getnative": {
               "version": "3.9.1",
-              "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-              "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
             },
             "lodash._root": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-              "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
             },
             "lodash.clonedeep": {
               "version": "4.5.0",
-              "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-              "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
             },
             "lodash.restparam": {
               "version": "3.6.1",
-              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-              "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
             },
             "lodash.union": {
               "version": "4.6.0",
-              "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-              "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
             },
             "lodash.uniq": {
               "version": "4.5.0",
-              "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-              "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
             },
             "lodash.without": {
               "version": "4.4.0",
-              "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
-              "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw="
             },
             "lowercase-keys": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-              "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
             },
             "lru-cache": {
               "version": "4.1.3",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+              "resolved": false,
               "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
-              "dev": true,
               "requires": {
                 "pseudomap": "^1.0.2",
                 "yallist": "^2.1.2"
@@ -7910,18 +4126,16 @@
             },
             "make-dir": {
               "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+              "resolved": false,
               "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-              "dev": true,
               "requires": {
                 "pify": "^3.0.0"
               }
             },
             "make-fetch-happen": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-4.0.1.tgz",
+              "resolved": false,
               "integrity": "sha512-7R5ivfy9ilRJ1EMKIOziwrns9fGeAD4bAha8EB7BIiBBLHm2KeTUGCrICFt2rbHfzheTLynv50GnNTK1zDTrcQ==",
-              "dev": true,
               "requires": {
                 "agentkeepalive": "^3.4.1",
                 "cacache": "^11.0.1",
@@ -7938,60 +4152,52 @@
             },
             "meant": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/meant/-/meant-1.0.1.tgz",
-              "integrity": "sha512-UakVLFjKkbbUwNWJ2frVLnnAtbb7D7DsloxRd3s/gDpI8rdv8W5Hp3NaDb+POBI1fQdeussER6NB8vpcRURvlg==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-UakVLFjKkbbUwNWJ2frVLnnAtbb7D7DsloxRd3s/gDpI8rdv8W5Hp3NaDb+POBI1fQdeussER6NB8vpcRURvlg=="
             },
             "mem": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+              "resolved": false,
               "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-              "dev": true,
               "requires": {
                 "mimic-fn": "^1.0.0"
               }
             },
             "mime-db": {
               "version": "1.33.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-              "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
             },
             "mime-types": {
               "version": "2.1.18",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+              "resolved": false,
               "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
-              "dev": true,
               "requires": {
                 "mime-db": "~1.33.0"
               }
             },
             "mimic-fn": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-              "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
             },
             "minimatch": {
               "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "resolved": false,
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-              "dev": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
             },
             "minipass": {
               "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.3.tgz",
+              "resolved": false,
               "integrity": "sha512-/jAn9/tEX4gnpyRATxgHEOV6xbcyxgT7iUnxo9Y3+OB0zX00TgKIv/2FZCf5brBbICcwbLqVv2ImjvWWrQMSYw==",
-              "dev": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -7999,26 +4205,23 @@
               "dependencies": {
                 "yallist": {
                   "version": "3.0.2",
-                  "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-                  "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-                  "dev": true
+                  "resolved": false,
+                  "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
                 }
               }
             },
             "minizlib": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+              "resolved": false,
               "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
-              "dev": true,
               "requires": {
                 "minipass": "^2.2.1"
               }
             },
             "mississippi": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
+              "resolved": false,
               "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
-              "dev": true,
               "requires": {
                 "concat-stream": "^1.5.0",
                 "duplexify": "^3.4.2",
@@ -8034,18 +4237,16 @@
             },
             "mkdirp": {
               "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "resolved": false,
               "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-              "dev": true,
               "requires": {
                 "minimist": "0.0.8"
               }
             },
             "move-concurrently": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+              "resolved": false,
               "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
-              "dev": true,
               "requires": {
                 "aproba": "^1.1.1",
                 "copy-concurrently": "^1.0.0",
@@ -8057,21 +4258,18 @@
             },
             "ms": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
             },
             "mute-stream": {
               "version": "0.0.7",
-              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-              "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
             },
             "node-fetch-npm": {
               "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
+              "resolved": false,
               "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
-              "dev": true,
               "requires": {
                 "encoding": "^0.1.11",
                 "json-parse-better-errors": "^1.0.0",
@@ -8080,9 +4278,8 @@
             },
             "node-gyp": {
               "version": "3.7.0",
-              "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.7.0.tgz",
+              "resolved": false,
               "integrity": "sha512-qDQE/Ft9xXP6zphwx4sD0t+VhwV7yFaloMpfbL2QnnDZcyaiakWlLdtFGGQfTAwpFHdpbRhRxVhIHN1OKAjgbg==",
-              "dev": true,
               "requires": {
                 "fstream": "^1.0.0",
                 "glob": "^7.0.3",
@@ -8100,24 +4297,21 @@
               "dependencies": {
                 "nopt": {
                   "version": "3.0.6",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+                  "resolved": false,
                   "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-                  "dev": true,
                   "requires": {
                     "abbrev": "1"
                   }
                 },
                 "semver": {
                   "version": "5.3.0",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-                  "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-                  "dev": true
+                  "resolved": false,
+                  "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
                 },
                 "tar": {
                   "version": "2.2.1",
-                  "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+                  "resolved": false,
                   "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-                  "dev": true,
                   "requires": {
                     "block-stream": "*",
                     "fstream": "^1.0.2",
@@ -8128,9 +4322,8 @@
             },
             "nopt": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+              "resolved": false,
               "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-              "dev": true,
               "requires": {
                 "abbrev": "1",
                 "osenv": "^0.1.4"
@@ -8138,9 +4331,8 @@
             },
             "normalize-package-data": {
               "version": "2.4.0",
-              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+              "resolved": false,
               "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-              "dev": true,
               "requires": {
                 "hosted-git-info": "^2.1.4",
                 "is-builtin-module": "^1.0.0",
@@ -8150,9 +4342,8 @@
             },
             "npm-audit-report": {
               "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/npm-audit-report/-/npm-audit-report-1.3.1.tgz",
+              "resolved": false,
               "integrity": "sha512-SjTF8ZP4rOu3JiFrTMi4M1CmVo2tni2sP4TzhyCMHwnMGf6XkdGLZKt9cdZ12esKf0mbQqFyU9LtY0SoeahL7g==",
-              "dev": true,
               "requires": {
                 "cli-table3": "^0.5.0",
                 "console-control-strings": "^1.1.0"
@@ -8160,30 +4351,26 @@
             },
             "npm-bundled": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
-              "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow=="
             },
             "npm-cache-filename": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
-              "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE="
             },
             "npm-install-checks": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-3.0.0.tgz",
+              "resolved": false,
               "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
-              "dev": true,
               "requires": {
                 "semver": "^2.3.0 || 3.x || 4 || 5"
               }
             },
             "npm-lifecycle": {
               "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-2.0.3.tgz",
+              "resolved": false,
               "integrity": "sha512-0U4Iim5ix2NHUT672G7FBpldJX0N2xKBjJqRTAzioEJjb6I6KpQXq+y1sB5EDSjKaAX8VCC9qPK31Jy+p3ix5A==",
-              "dev": true,
               "requires": {
                 "byline": "^5.0.0",
                 "graceful-fs": "^4.1.11",
@@ -8197,15 +4384,13 @@
             },
             "npm-logical-tree": {
               "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/npm-logical-tree/-/npm-logical-tree-1.2.1.tgz",
-              "integrity": "sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg=="
             },
             "npm-package-arg": {
               "version": "6.1.0",
-              "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.0.tgz",
+              "resolved": false,
               "integrity": "sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==",
-              "dev": true,
               "requires": {
                 "hosted-git-info": "^2.6.0",
                 "osenv": "^0.1.5",
@@ -8215,9 +4400,8 @@
             },
             "npm-packlist": {
               "version": "1.1.10",
-              "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
+              "resolved": false,
               "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
-              "dev": true,
               "requires": {
                 "ignore-walk": "^3.0.1",
                 "npm-bundled": "^1.0.1"
@@ -8225,9 +4409,8 @@
             },
             "npm-pick-manifest": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-2.1.0.tgz",
+              "resolved": false,
               "integrity": "sha512-q9zLP8cTr8xKPmMZN3naxp1k/NxVFsjxN6uWuO1tiw9gxg7wZWQ/b5UTfzD0ANw2q1lQxdLKTeCCksq+bPSgbQ==",
-              "dev": true,
               "requires": {
                 "npm-package-arg": "^6.0.0",
                 "semver": "^5.4.1"
@@ -8235,9 +4418,8 @@
             },
             "npm-profile": {
               "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/npm-profile/-/npm-profile-3.0.2.tgz",
+              "resolved": false,
               "integrity": "sha512-rEJOFR6PbwOvvhGa2YTNOJQKNuc6RovJ6T50xPU7pS9h/zKPNCJ+VHZY2OFXyZvEi+UQYtHRTp8O/YM3tUD20A==",
-              "dev": true,
               "requires": {
                 "aproba": "^1.1.2 || 2",
                 "make-fetch-happen": "^2.5.0 || 3 || 4"
@@ -8245,9 +4427,8 @@
             },
             "npm-registry-client": {
               "version": "8.5.1",
-              "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.5.1.tgz",
+              "resolved": false,
               "integrity": "sha512-7rjGF2eA7hKDidGyEWmHTiKfXkbrcQAsGL/Rh4Rt3x3YNRNHhwaTzVJfW3aNvvlhg4G62VCluif0sLCb/i51Hg==",
-              "dev": true,
               "requires": {
                 "concat-stream": "^1.5.2",
                 "graceful-fs": "^4.1.6",
@@ -8265,15 +4446,13 @@
               "dependencies": {
                 "retry": {
                   "version": "0.10.1",
-                  "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-                  "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
-                  "dev": true
+                  "resolved": false,
+                  "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
                 },
                 "ssri": {
                   "version": "5.3.0",
-                  "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
+                  "resolved": false,
                   "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
-                  "dev": true,
                   "requires": {
                     "safe-buffer": "^5.1.1"
                   }
@@ -8282,9 +4461,8 @@
             },
             "npm-registry-fetch": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-1.1.0.tgz",
+              "resolved": false,
               "integrity": "sha512-XJPIBfMtgaooRtZmuA42xCeLf3tkxdIX0xqRsGWwNrcVvJ9UYFccD7Ho7QWCzvkM3i/QrkUC37Hu0a+vDBmt5g==",
-              "dev": true,
               "requires": {
                 "bluebird": "^3.5.1",
                 "figgy-pudding": "^2.0.1",
@@ -8296,9 +4474,8 @@
               "dependencies": {
                 "cacache": {
                   "version": "10.0.4",
-                  "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+                  "resolved": false,
                   "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
-                  "dev": true,
                   "requires": {
                     "bluebird": "^3.5.1",
                     "chownr": "^1.0.1",
@@ -8317,9 +4494,8 @@
                   "dependencies": {
                     "mississippi": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
+                      "resolved": false,
                       "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
-                      "dev": true,
                       "requires": {
                         "concat-stream": "^1.5.0",
                         "duplexify": "^3.4.2",
@@ -8337,15 +4513,13 @@
                 },
                 "figgy-pudding": {
                   "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-2.0.1.tgz",
-                  "integrity": "sha512-yIJPhIBi/oFdU/P+GSXjmk/rmGjuZkm7A5LTXZxNrEprXJXRK012FiI1BR1Pga+0d/d6taWWD+B5d2ozqaxHig==",
-                  "dev": true
+                  "resolved": false,
+                  "integrity": "sha512-yIJPhIBi/oFdU/P+GSXjmk/rmGjuZkm7A5LTXZxNrEprXJXRK012FiI1BR1Pga+0d/d6taWWD+B5d2ozqaxHig=="
                 },
                 "make-fetch-happen": {
                   "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-3.0.0.tgz",
+                  "resolved": false,
                   "integrity": "sha512-FmWY7gC0mL6Z4N86vE14+m719JKE4H0A+pyiOH18B025gF/C113pyfb4gHDDYP5cqnRMHOz06JGdmffC/SES+w==",
-                  "dev": true,
                   "requires": {
                     "agentkeepalive": "^3.4.1",
                     "cacache": "^10.0.4",
@@ -8362,9 +4536,8 @@
                 },
                 "pump": {
                   "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+                  "resolved": false,
                   "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-                  "dev": true,
                   "requires": {
                     "end-of-stream": "^1.1.0",
                     "once": "^1.3.1"
@@ -8372,15 +4545,13 @@
                 },
                 "smart-buffer": {
                   "version": "1.1.15",
-                  "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
-                  "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY=",
-                  "dev": true
+                  "resolved": false,
+                  "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY="
                 },
                 "socks": {
                   "version": "1.1.10",
-                  "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
+                  "resolved": false,
                   "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
-                  "dev": true,
                   "requires": {
                     "ip": "^1.1.4",
                     "smart-buffer": "^1.0.13"
@@ -8388,9 +4559,8 @@
                 },
                 "socks-proxy-agent": {
                   "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-3.0.1.tgz",
+                  "resolved": false,
                   "integrity": "sha512-ZwEDymm204mTzvdqyUqOdovVr2YRd2NYskrYrF2LXyZ9qDiMAoFESGK8CRphiO7rtbo2Y757k2Nia3x2hGtalA==",
-                  "dev": true,
                   "requires": {
                     "agent-base": "^4.1.0",
                     "socks": "^1.1.10"
@@ -8398,9 +4568,8 @@
                 },
                 "ssri": {
                   "version": "5.3.0",
-                  "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
+                  "resolved": false,
                   "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
-                  "dev": true,
                   "requires": {
                     "safe-buffer": "^5.1.1"
                   }
@@ -8409,24 +4578,21 @@
             },
             "npm-run-path": {
               "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+              "resolved": false,
               "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-              "dev": true,
               "requires": {
                 "path-key": "^2.0.0"
               }
             },
             "npm-user-validate": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-1.0.0.tgz",
-              "integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE="
             },
             "npmlog": {
               "version": "4.1.2",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+              "resolved": false,
               "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-              "dev": true,
               "requires": {
                 "are-we-there-yet": "~1.1.2",
                 "console-control-strings": "~1.1.0",
@@ -8436,48 +4602,41 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
             },
             "oauth-sign": {
               "version": "0.8.2",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
             },
             "object-assign": {
               "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
             },
             "once": {
               "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "resolved": false,
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-              "dev": true,
               "requires": {
                 "wrappy": "1"
               }
             },
             "opener": {
               "version": "1.4.3",
-              "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
-              "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg="
             },
             "os-homedir": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
             },
             "os-locale": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+              "resolved": false,
               "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-              "dev": true,
               "requires": {
                 "execa": "^0.7.0",
                 "lcid": "^1.0.0",
@@ -8486,15 +4645,13 @@
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
             },
             "osenv": {
               "version": "0.1.5",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+              "resolved": false,
               "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-              "dev": true,
               "requires": {
                 "os-homedir": "^1.0.0",
                 "os-tmpdir": "^1.0.0"
@@ -8502,39 +4659,34 @@
             },
             "p-finally": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-              "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
             },
             "p-limit": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+              "resolved": false,
               "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
-              "dev": true,
               "requires": {
                 "p-try": "^1.0.0"
               }
             },
             "p-locate": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+              "resolved": false,
               "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-              "dev": true,
               "requires": {
                 "p-limit": "^1.1.0"
               }
             },
             "p-try": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-              "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
             },
             "package-json": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+              "resolved": false,
               "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-              "dev": true,
               "requires": {
                 "got": "^6.7.1",
                 "registry-auth-token": "^3.0.1",
@@ -8544,9 +4696,8 @@
             },
             "pacote": {
               "version": "8.1.6",
-              "resolved": "https://registry.npmjs.org/pacote/-/pacote-8.1.6.tgz",
+              "resolved": false,
               "integrity": "sha512-wTOOfpaAQNEQNtPEx92x9Y9kRWVu45v583XT8x2oEV2xRB74+xdqMZIeGW4uFvAyZdmSBtye+wKdyyLaT8pcmw==",
-              "dev": true,
               "requires": {
                 "bluebird": "^3.5.1",
                 "cacache": "^11.0.2",
@@ -8577,9 +4728,8 @@
             },
             "parallel-transform": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+              "resolved": false,
               "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
-              "dev": true,
               "requires": {
                 "cyclist": "~0.2.2",
                 "inherits": "^2.0.3",
@@ -8588,63 +4738,53 @@
             },
             "path-exists": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
             },
             "path-is-inside": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-              "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
             },
             "path-key": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-              "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
             },
             "performance-now": {
               "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-              "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
             },
             "pify": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
             },
             "prepend-http": {
               "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-              "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
             },
             "process-nextick-args": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-              "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
             },
             "promise-inflight": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-              "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
             },
             "promise-retry": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+              "resolved": false,
               "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
-              "dev": true,
               "requires": {
                 "err-code": "^1.0.0",
                 "retry": "^0.10.0"
@@ -8652,53 +4792,46 @@
               "dependencies": {
                 "retry": {
                   "version": "0.10.1",
-                  "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-                  "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
-                  "dev": true
+                  "resolved": false,
+                  "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
                 }
               }
             },
             "promzard": {
               "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
+              "resolved": false,
               "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
-              "dev": true,
               "requires": {
                 "read": "1"
               }
             },
             "proto-list": {
               "version": "1.2.4",
-              "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-              "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
             },
             "protoduck": {
               "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/protoduck/-/protoduck-5.0.0.tgz",
+              "resolved": false,
               "integrity": "sha512-agsGWD8/RZrS4ga6v82Fxb0RHIS2RZnbsSue6A9/MBRhB/jcqOANAMNrqM9900b8duj+Gx+T/JMy5IowDoO/hQ==",
-              "dev": true,
               "requires": {
                 "genfun": "^4.0.1"
               }
             },
             "prr": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-              "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
             },
             "pseudomap": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-              "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
             },
             "pump": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+              "resolved": false,
               "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-              "dev": true,
               "requires": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -8706,9 +4839,8 @@
             },
             "pumpify": {
               "version": "1.5.1",
-              "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+              "resolved": false,
               "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
-              "dev": true,
               "requires": {
                 "duplexify": "^3.6.0",
                 "inherits": "^2.0.3",
@@ -8717,9 +4849,8 @@
               "dependencies": {
                 "pump": {
                   "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+                  "resolved": false,
                   "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-                  "dev": true,
                   "requires": {
                     "end-of-stream": "^1.1.0",
                     "once": "^1.3.1"
@@ -8729,27 +4860,23 @@
             },
             "punycode": {
               "version": "1.4.1",
-              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-              "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
             },
             "qrcode-terminal": {
               "version": "0.12.0",
-              "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
-              "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ=="
             },
             "qs": {
               "version": "6.4.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-              "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
             },
             "query-string": {
               "version": "6.1.0",
-              "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.1.0.tgz",
+              "resolved": false,
               "integrity": "sha512-pNB/Gr8SA8ff8KpUFM36o/WFAlthgaThka5bV19AD9PNTH20Pwq5Zxodif2YyHwrctp6SkL4GqlOot0qR/wGaw==",
-              "dev": true,
               "requires": {
                 "decode-uri-component": "^0.2.0",
                 "strict-uri-encode": "^2.0.0"
@@ -8757,15 +4884,13 @@
             },
             "qw": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/qw/-/qw-1.0.1.tgz",
-              "integrity": "sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-77/cdA+a0FQwRCassYNBLMi5ltQ="
             },
             "rc": {
               "version": "1.2.7",
-              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
+              "resolved": false,
               "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
-              "dev": true,
               "requires": {
                 "deep-extend": "^0.5.1",
                 "ini": "~1.3.0",
@@ -8775,35 +4900,31 @@
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                  "dev": true
+                  "resolved": false,
+                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
                 }
               }
             },
             "read": {
               "version": "1.0.7",
-              "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+              "resolved": false,
               "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
-              "dev": true,
               "requires": {
                 "mute-stream": "~0.0.4"
               }
             },
             "read-cmd-shim": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
+              "resolved": false,
               "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
-              "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2"
               }
             },
             "read-installed": {
               "version": "4.0.3",
-              "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
+              "resolved": false,
               "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
-              "dev": true,
               "requires": {
                 "debuglog": "^1.0.1",
                 "graceful-fs": "^4.1.2",
@@ -8816,9 +4937,8 @@
             },
             "read-package-json": {
               "version": "2.0.13",
-              "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.13.tgz",
+              "resolved": false,
               "integrity": "sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==",
-              "dev": true,
               "requires": {
                 "glob": "^7.1.1",
                 "graceful-fs": "^4.1.2",
@@ -8829,9 +4949,8 @@
             },
             "read-package-tree": {
               "version": "5.2.1",
-              "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.2.1.tgz",
+              "resolved": false,
               "integrity": "sha512-2CNoRoh95LxY47LvqrehIAfUVda2JbuFE/HaGYs42bNrGG+ojbw1h3zOcPcQ+1GQ3+rkzNndZn85u1XyZ3UsIA==",
-              "dev": true,
               "requires": {
                 "debuglog": "^1.0.1",
                 "dezalgo": "^1.0.0",
@@ -8842,9 +4961,8 @@
             },
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "resolved": false,
               "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-              "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -8857,9 +4975,8 @@
             },
             "readdir-scoped-modules": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
+              "resolved": false,
               "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
-              "dev": true,
               "requires": {
                 "debuglog": "^1.0.1",
                 "dezalgo": "^1.0.0",
@@ -8869,9 +4986,8 @@
             },
             "registry-auth-token": {
               "version": "3.3.2",
-              "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+              "resolved": false,
               "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
-              "dev": true,
               "requires": {
                 "rc": "^1.1.6",
                 "safe-buffer": "^5.0.1"
@@ -8879,18 +4995,16 @@
             },
             "registry-url": {
               "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+              "resolved": false,
               "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-              "dev": true,
               "requires": {
                 "rc": "^1.0.1"
               }
             },
             "request": {
               "version": "2.81.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+              "resolved": false,
               "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-              "dev": true,
               "requires": {
                 "aws-sign2": "~0.6.0",
                 "aws4": "^1.2.1",
@@ -8918,84 +5032,72 @@
             },
             "require-directory": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-              "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
             },
             "require-main-filename": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-              "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
             },
             "resolve-from": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-              "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
             },
             "retry": {
               "version": "0.12.0",
-              "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-              "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
             },
             "rimraf": {
               "version": "2.6.2",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+              "resolved": false,
               "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-              "dev": true,
               "requires": {
                 "glob": "^7.0.5"
               }
             },
             "run-queue": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+              "resolved": false,
               "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
-              "dev": true,
               "requires": {
                 "aproba": "^1.1.1"
               }
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
             },
             "safer-buffer": {
               "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-              "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
             },
             "semver": {
               "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-              "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
             },
             "semver-diff": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+              "resolved": false,
               "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-              "dev": true,
               "requires": {
                 "semver": "^5.0.3"
               }
             },
             "set-blocking": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
             },
             "sha": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
+              "resolved": false,
               "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
-              "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
                 "readable-stream": "^2.0.2"
@@ -9003,57 +5105,49 @@
             },
             "shebang-command": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+              "resolved": false,
               "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-              "dev": true,
               "requires": {
                 "shebang-regex": "^1.0.0"
               }
             },
             "shebang-regex": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-              "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
             },
             "signal-exit": {
               "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
             },
             "slash": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-              "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
             },
             "slide": {
               "version": "1.1.6",
-              "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-              "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
             },
             "smart-buffer": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.1.tgz",
-              "integrity": "sha512-RFqinRVJVcCAL9Uh1oVqE6FZkqsyLiVOYEZ20TqIOjuX7iFVJ+zsbs4RIghnw/pTs7mZvt8ZHhvm1ZUrR4fykg==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-RFqinRVJVcCAL9Uh1oVqE6FZkqsyLiVOYEZ20TqIOjuX7iFVJ+zsbs4RIghnw/pTs7mZvt8ZHhvm1ZUrR4fykg=="
             },
             "sntp": {
               "version": "1.0.9",
-              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+              "resolved": false,
               "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-              "dev": true,
               "requires": {
                 "hoek": "2.x.x"
               }
             },
             "socks": {
               "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/socks/-/socks-2.2.0.tgz",
+              "resolved": false,
               "integrity": "sha512-uRKV9uXQ9ytMbGm2+DilS1jB7N3AC0mmusmW5TVWjNuBZjxS8+lX38fasKVY9I4opv/bY/iqTbcpFFaTwpfwRg==",
-              "dev": true,
               "requires": {
                 "ip": "^1.1.5",
                 "smart-buffer": "^4.0.1"
@@ -9061,9 +5155,8 @@
             },
             "socks-proxy-agent": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.1.tgz",
+              "resolved": false,
               "integrity": "sha512-Kezx6/VBguXOsEe5oU3lXYyKMi4+gva72TwJ7pQY5JfqUx2nMk7NXA6z/mpNqIlfQjWYVfeuNvQjexiTaTn6Nw==",
-              "dev": true,
               "requires": {
                 "agent-base": "~4.2.0",
                 "socks": "~2.2.0"
@@ -9071,15 +5164,13 @@
             },
             "sorted-object": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.1.tgz",
-              "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw="
             },
             "sorted-union-stream": {
               "version": "2.1.3",
-              "resolved": "https://registry.npmjs.org/sorted-union-stream/-/sorted-union-stream-2.1.3.tgz",
+              "resolved": false,
               "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
-              "dev": true,
               "requires": {
                 "from2": "^1.3.0",
                 "stream-iterate": "^1.1.0"
@@ -9087,9 +5178,8 @@
               "dependencies": {
                 "from2": {
                   "version": "1.3.0",
-                  "resolved": "https://registry.npmjs.org/from2/-/from2-1.3.0.tgz",
+                  "resolved": false,
                   "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
-                  "dev": true,
                   "requires": {
                     "inherits": "~2.0.1",
                     "readable-stream": "~1.1.10"
@@ -9097,15 +5187,13 @@
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                  "dev": true
+                  "resolved": false,
+                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
                 },
                 "readable-stream": {
                   "version": "1.1.14",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                  "resolved": false,
                   "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-                  "dev": true,
                   "requires": {
                     "core-util-is": "~1.0.0",
                     "inherits": "~2.0.1",
@@ -9115,17 +5203,15 @@
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                  "dev": true
+                  "resolved": false,
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                 }
               }
             },
             "spdx-correct": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+              "resolved": false,
               "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
-              "dev": true,
               "requires": {
                 "spdx-expression-parse": "^3.0.0",
                 "spdx-license-ids": "^3.0.0"
@@ -9133,15 +5219,13 @@
             },
             "spdx-exceptions": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-              "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
             },
             "spdx-expression-parse": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+              "resolved": false,
               "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-              "dev": true,
               "requires": {
                 "spdx-exceptions": "^2.1.0",
                 "spdx-license-ids": "^3.0.0"
@@ -9149,15 +5233,13 @@
             },
             "spdx-license-ids": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-              "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
             },
             "sshpk": {
               "version": "1.14.2",
-              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+              "resolved": false,
               "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
-              "dev": true,
               "requires": {
                 "asn1": "~0.2.3",
                 "assert-plus": "^1.0.0",
@@ -9172,23 +5254,20 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                  "dev": true
+                  "resolved": false,
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
                 }
               }
             },
             "ssri": {
               "version": "6.0.0",
-              "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.0.tgz",
-              "integrity": "sha512-zYOGfVHPhxyzwi8MdtdNyxv3IynWCIM4jYReR48lqu0VngxgH1c+C6CmipRdJ55eVByTJV/gboFEEI7TEQI8DA==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-zYOGfVHPhxyzwi8MdtdNyxv3IynWCIM4jYReR48lqu0VngxgH1c+C6CmipRdJ55eVByTJV/gboFEEI7TEQI8DA=="
             },
             "stream-each": {
               "version": "1.2.2",
-              "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
+              "resolved": false,
               "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
-              "dev": true,
               "requires": {
                 "end-of-stream": "^1.1.0",
                 "stream-shift": "^1.0.0"
@@ -9196,9 +5275,8 @@
             },
             "stream-iterate": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/stream-iterate/-/stream-iterate-1.2.0.tgz",
+              "resolved": false,
               "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
-              "dev": true,
               "requires": {
                 "readable-stream": "^2.1.5",
                 "stream-shift": "^1.0.0"
@@ -9206,21 +5284,18 @@
             },
             "stream-shift": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-              "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
             },
             "strict-uri-encode": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-              "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
             },
             "string-width": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+              "resolved": false,
               "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-              "dev": true,
               "requires": {
                 "is-fullwidth-code-point": "^2.0.0",
                 "strip-ansi": "^4.0.0"
@@ -9228,21 +5303,18 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                  "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                  "dev": true
+                  "resolved": false,
+                  "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
                 },
                 "is-fullwidth-code-point": {
                   "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                  "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                  "dev": true
+                  "resolved": false,
+                  "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
                 },
                 "strip-ansi": {
                   "version": "4.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                  "resolved": false,
                   "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                  "dev": true,
                   "requires": {
                     "ansi-regex": "^3.0.0"
                   }
@@ -9251,60 +5323,52 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "resolved": false,
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-              "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
             },
             "stringify-package": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.0.tgz",
-              "integrity": "sha512-JIQqiWmLiEozOC0b0BtxZ/AOUtdUZHCBPgqIZ2kSJJqGwgb9neo44XdTHUC4HZSGqi03hOeB7W/E8rAlKnGe9g==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-JIQqiWmLiEozOC0b0BtxZ/AOUtdUZHCBPgqIZ2kSJJqGwgb9neo44XdTHUC4HZSGqi03hOeB7W/E8rAlKnGe9g=="
             },
             "stringstream": {
               "version": "0.0.6",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-              "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": false,
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
             },
             "strip-eof": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-              "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
             },
             "strip-json-comments": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
             },
             "supports-color": {
               "version": "5.4.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+              "resolved": false,
               "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-              "dev": true,
               "requires": {
                 "has-flag": "^3.0.0"
               }
             },
             "tar": {
               "version": "4.4.4",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.4.tgz",
+              "resolved": false,
               "integrity": "sha512-mq9ixIYfNF9SK0IS/h2HKMu8Q2iaCuhDDsZhdEag/FHv8fOaYld4vN7ouMgcSSt5WKZzPs8atclTcJm36OTh4w==",
-              "dev": true,
               "requires": {
                 "chownr": "^1.0.1",
                 "fs-minipass": "^1.2.5",
@@ -9317,38 +5381,33 @@
               "dependencies": {
                 "yallist": {
                   "version": "3.0.2",
-                  "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-                  "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-                  "dev": true
+                  "resolved": false,
+                  "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
                 }
               }
             },
             "term-size": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+              "resolved": false,
               "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-              "dev": true,
               "requires": {
                 "execa": "^0.7.0"
               }
             },
             "text-table": {
               "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-              "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
             },
             "through": {
               "version": "2.3.8",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-              "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
             },
             "through2": {
               "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+              "resolved": false,
               "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-              "dev": true,
               "requires": {
                 "readable-stream": "^2.1.5",
                 "xtend": "~4.0.1"
@@ -9356,103 +5415,89 @@
             },
             "timed-out": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-              "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
             },
             "tiny-relative-date": {
               "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/tiny-relative-date/-/tiny-relative-date-1.3.0.tgz",
-              "integrity": "sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A=="
             },
             "tough-cookie": {
               "version": "2.3.4",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+              "resolved": false,
               "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-              "dev": true,
               "requires": {
                 "punycode": "^1.4.1"
               }
             },
             "tunnel-agent": {
               "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+              "resolved": false,
               "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-              "dev": true,
               "requires": {
                 "safe-buffer": "^5.0.1"
               }
             },
             "tweetnacl": {
               "version": "0.14.5",
-              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+              "resolved": false,
               "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-              "dev": true,
               "optional": true
             },
             "typedarray": {
               "version": "0.0.6",
-              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-              "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
             },
             "uid-number": {
               "version": "0.0.6",
-              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-              "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
             },
             "umask": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
-              "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0="
             },
             "unique-filename": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
+              "resolved": false,
               "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
-              "dev": true,
               "requires": {
                 "unique-slug": "^2.0.0"
               }
             },
             "unique-slug": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
+              "resolved": false,
               "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
-              "dev": true,
               "requires": {
                 "imurmurhash": "^0.1.4"
               }
             },
             "unique-string": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+              "resolved": false,
               "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-              "dev": true,
               "requires": {
                 "crypto-random-string": "^1.0.0"
               }
             },
             "unpipe": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-              "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
             },
             "unzip-response": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-              "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
             },
             "update-notifier": {
               "version": "2.5.0",
-              "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
+              "resolved": false,
               "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
-              "dev": true,
               "requires": {
                 "boxen": "^1.2.1",
                 "chalk": "^2.0.1",
@@ -9468,36 +5513,31 @@
             },
             "url-parse-lax": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+              "resolved": false,
               "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-              "dev": true,
               "requires": {
                 "prepend-http": "^1.0.1"
               }
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
             },
             "util-extend": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
-              "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8="
             },
             "uuid": {
               "version": "3.3.2",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
             },
             "validate-npm-package-license": {
               "version": "3.0.3",
-              "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+              "resolved": false,
               "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
-              "dev": true,
               "requires": {
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
@@ -9505,18 +5545,16 @@
             },
             "validate-npm-package-name": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+              "resolved": false,
               "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
-              "dev": true,
               "requires": {
                 "builtins": "^1.0.3"
               }
             },
             "verror": {
               "version": "1.10.0",
-              "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+              "resolved": false,
               "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-              "dev": true,
               "requires": {
                 "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
@@ -9525,50 +5563,44 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                  "dev": true
+                  "resolved": false,
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
                 }
               }
             },
             "wcwidth": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+              "resolved": false,
               "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
-              "dev": true,
               "requires": {
                 "defaults": "^1.0.3"
               }
             },
             "which": {
               "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+              "resolved": false,
               "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-              "dev": true,
               "requires": {
                 "isexe": "^2.0.0"
               }
             },
             "which-module": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-              "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
             },
             "wide-align": {
               "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+              "resolved": false,
               "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-              "dev": true,
               "requires": {
                 "string-width": "^1.0.2"
               },
               "dependencies": {
                 "string-width": {
                   "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                  "resolved": false,
                   "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                  "dev": true,
                   "requires": {
                     "code-point-at": "^1.0.0",
                     "is-fullwidth-code-point": "^1.0.0",
@@ -9579,27 +5611,24 @@
             },
             "widest-line": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
+              "resolved": false,
               "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
-              "dev": true,
               "requires": {
                 "string-width": "^2.1.1"
               }
             },
             "worker-farm": {
               "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
+              "resolved": false,
               "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
-              "dev": true,
               "requires": {
                 "errno": "~0.1.7"
               }
             },
             "wrap-ansi": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+              "resolved": false,
               "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-              "dev": true,
               "requires": {
                 "string-width": "^1.0.1",
                 "strip-ansi": "^3.0.1"
@@ -9607,9 +5636,8 @@
               "dependencies": {
                 "string-width": {
                   "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                  "resolved": false,
                   "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                  "dev": true,
                   "requires": {
                     "code-point-at": "^1.0.0",
                     "is-fullwidth-code-point": "^1.0.0",
@@ -9620,15 +5648,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
             },
             "write-file-atomic": {
               "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+              "resolved": false,
               "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
-              "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.11",
                 "imurmurhash": "^0.1.4",
@@ -9637,33 +5663,28 @@
             },
             "xdg-basedir": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-              "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
             },
             "xtend": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
             },
             "y18n": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-              "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
             },
             "yallist": {
               "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-              "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-              "dev": true
+              "resolved": false,
+              "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
             },
             "yargs": {
               "version": "11.0.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
+              "resolved": false,
               "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
-              "dev": true,
               "requires": {
                 "cliui": "^4.0.0",
                 "decamelize": "^1.1.1",
@@ -9681,17 +5702,15 @@
               "dependencies": {
                 "y18n": {
                   "version": "3.2.1",
-                  "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-                  "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-                  "dev": true
+                  "resolved": false,
+                  "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
                 }
               }
             },
             "yargs-parser": {
               "version": "9.0.2",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+              "resolved": false,
               "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
-              "dev": true,
               "requires": {
                 "camelcase": "^4.1.0"
               }
@@ -9702,7 +5721,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-          "dev": true,
           "requires": {
             "error-ex": "^1.3.1",
             "json-parse-better-errors": "^1.0.1"
@@ -9711,14 +5729,12 @@
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         },
         "rc": {
           "version": "1.2.8",
           "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-          "dev": true,
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
@@ -9730,7 +5746,6 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-4.0.1.tgz",
           "integrity": "sha1-ljYlN48+HE1IyFhytabsfV0JMjc=",
-          "dev": true,
           "requires": {
             "normalize-package-data": "^2.3.2",
             "parse-json": "^4.0.0",
@@ -9743,7 +5758,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-7.0.0.tgz",
       "integrity": "sha512-Sp7kHPrTLdQQBTLHq88rTbM5WImtBs844FfTRNs5mgdS6jEwbKTnQCwUM5h9xoXCsNkzIfVnSwRTB9EL5xbNfw==",
-      "dev": true,
       "requires": {
         "conventional-changelog-angular": "^5.0.0",
         "conventional-changelog-writer": "^4.0.0",
@@ -9760,14 +5774,12 @@
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         },
         "camelcase-keys": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
-          "dev": true,
           "requires": {
             "camelcase": "^4.1.0",
             "map-obj": "^2.0.0",
@@ -9778,7 +5790,6 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.0.tgz",
           "integrity": "sha512-R75W1aOI9FNhnxLu9wz+jlGM+VSZLZvV10LBBLyx73S12RatSI5s3fUwlstKNybWolXZgBb6qvdkCfrRVqddZQ==",
-          "dev": true,
           "requires": {
             "compare-func": "^1.3.1",
             "q": "^1.5.1"
@@ -9788,7 +5799,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.0.tgz",
           "integrity": "sha512-GWh71U26BLWgMykCp+VghZ4s64wVbtseECcKQ/PvcPZR2cUnz+FUc2J9KjxNl7/ZbCxST8R03c9fc+Vi0umS9Q==",
-          "dev": true,
           "requires": {
             "JSONStream": "^1.0.4",
             "is-text-path": "^1.0.0",
@@ -9803,7 +5813,6 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -9812,7 +5821,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
           "requires": {
             "locate-path": "^2.0.0"
           }
@@ -9820,20 +5828,17 @@
         "indent-string": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-          "dev": true
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
         },
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "load-json-file": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "parse-json": "^4.0.0",
@@ -9844,20 +5849,17 @@
         "lodash": {
           "version": "4.17.10",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-          "dev": true
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         },
         "map-obj": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-          "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
-          "dev": true
+          "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
         },
         "meow": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
           "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
-          "dev": true,
           "requires": {
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
@@ -9874,7 +5876,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-          "dev": true,
           "requires": {
             "error-ex": "^1.3.1",
             "json-parse-better-errors": "^1.0.1"
@@ -9884,7 +5885,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-          "dev": true,
           "requires": {
             "pify": "^3.0.0"
           }
@@ -9892,14 +5892,12 @@
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         },
         "read-pkg": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-          "dev": true,
           "requires": {
             "load-json-file": "^4.0.0",
             "normalize-package-data": "^2.3.2",
@@ -9910,7 +5908,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-          "dev": true,
           "requires": {
             "find-up": "^2.0.0",
             "read-pkg": "^3.0.0"
@@ -9920,7 +5917,6 @@
           "version": "2.3.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -9935,7 +5931,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-          "dev": true,
           "requires": {
             "indent-string": "^3.0.0",
             "strip-indent": "^2.0.0"
@@ -9945,7 +5940,6 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -9953,20 +5947,17 @@
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
         },
         "strip-indent": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
-          "dev": true
+          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
         },
         "through2": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-          "dev": true,
           "requires": {
             "readable-stream": "^2.1.5",
             "xtend": "~4.0.1"
@@ -9975,8 +5966,7 @@
         "trim-newlines": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-          "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-          "dev": true
+          "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
         }
       }
     },
@@ -12296,8 +8286,7 @@
     "before-after-hook": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.1.0.tgz",
-      "integrity": "sha512-VOMDtYPwLbIncTxNoSzRyvaMxtXmLWLUqr8k5AfC1BzLk34HvBXaQX8snOwQZ4c0aX8aSERqtJSiI9/m2u5kuA==",
-      "dev": true
+      "integrity": "sha512-VOMDtYPwLbIncTxNoSzRyvaMxtXmLWLUqr8k5AfC1BzLk34HvBXaQX8snOwQZ4c0aX8aSERqtJSiI9/m2u5kuA=="
     },
     "big.js": {
       "version": "3.2.0",
@@ -12398,7 +8387,7 @@
     },
     "bl": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "dev": true,
       "requires": {
@@ -12794,7 +8783,7 @@
         },
         "uuid": {
           "version": "2.0.3",
-          "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
           "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
           "dev": true
         }
@@ -15818,9 +11807,9 @@
       }
     },
     "csstype": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.5.7.tgz",
-      "integrity": "sha512-Nt5VDyOTIIV4/nRFswoCKps1R5CD1hkiyjBE9/thNaNZILLEviVw9yWQw15+O+CpNjQKB/uvdcxFFOrSflY3Yw=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.1.tgz",
+      "integrity": "sha512-wv7IRqCGsL7WGKB8gPvrl+++HlFM9kxAM6jL1EXNPNTshEJYilMkbfS2SnuHha77uosp/YVK0wAp2jmlBzn1tg=="
     },
     "csurf": {
       "version": "1.8.3",
@@ -16381,7 +12370,7 @@
             },
             "readable-stream": {
               "version": "1.0.34",
-              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "dev": true,
               "requires": {
@@ -16732,11 +12721,6 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
-    "deepmerge": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
-      "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA=="
-    },
     "default-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/default-compare/-/default-compare-1.0.0.tgz",
@@ -16943,8 +12927,7 @@
     "detect-newline": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
-      "dev": true
+      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
     },
     "detect-node": {
       "version": "2.0.4",
@@ -17291,7 +13274,7 @@
             },
             "readable-stream": {
               "version": "1.0.34",
-              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "dev": true,
               "requires": {
@@ -17603,6 +13586,21 @@
         "create-emotion": "^9.2.12"
       }
     },
+    "emotion-theming": {
+      "version": "9.2.9",
+      "resolved": "https://registry.npmjs.org/emotion-theming/-/emotion-theming-9.2.9.tgz",
+      "integrity": "sha512-Ncyr1WocmDDrTbuYAzklIUC5iKiGtHy3e5ymoFXcka6SuvZl/EDMawegk4wVp72Agrcm1xemab3QOHfnOkpoMA==",
+      "requires": {
+        "hoist-non-react-statics": "^2.3.1"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+        }
+      }
+    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -17665,7 +13663,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-2.1.1.tgz",
       "integrity": "sha512-7KVsNirTANngtXZkKzbO/9xtHB51rNzauhuKRKBj2itgATsD/N9ZjyfWNmfiUF9aZIaoqrZ8x0HS8M7Bsk7dBQ==",
-      "dev": true,
       "requires": {
         "execa": "^0.10.0",
         "java-properties": "^0.2.9"
@@ -17675,7 +13672,6 @@
           "version": "6.0.5",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
           "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-          "dev": true,
           "requires": {
             "nice-try": "^1.0.4",
             "path-key": "^2.0.1",
@@ -17688,7 +13684,6 @@
           "version": "0.10.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
           "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
-          "dev": true,
           "requires": {
             "cross-spawn": "^6.0.0",
             "get-stream": "^3.0.0",
@@ -20010,6 +16005,23 @@
         "immutable": "^3.7.4"
       }
     },
+    "focus-trap": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-3.0.0.tgz",
+      "integrity": "sha512-jTFblf0tLWbleGjj2JZsAKbgtZTdL1uC48L8FcmSDl4c2vDoU4NycN1kgV5vJhuq1mxNFkw7uWZ1JAGlINWvyw==",
+      "requires": {
+        "tabbable": "^3.1.0",
+        "xtend": "^4.0.1"
+      }
+    },
+    "focus-trap-react": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-4.0.1.tgz",
+      "integrity": "sha512-UUZKVEn5cFbF6yUnW7lbXNW0iqN617ShSqYKgxctUvWw1wuylLtyVmC0RmPQNnJ/U+zoKc/djb0tZMs0uN/0QQ==",
+      "requires": {
+        "focus-trap": "^3.0.0"
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -20205,15 +16217,13 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -20230,22 +16240,19 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -20376,8 +16383,7 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -20391,7 +16397,6 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -20408,7 +16413,6 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -20417,15 +16421,13 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": false,
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -20446,7 +16448,6 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -20535,8 +16536,7 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -20550,7 +16550,6 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -20646,8 +16645,7 @@
           "version": "5.1.1",
           "resolved": false,
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -20689,7 +16687,6 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -20760,15 +16757,13 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": false,
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -21058,7 +17053,6 @@
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/git-up/-/git-up-2.0.10.tgz",
       "integrity": "sha512-2v4UN3qV2RGypD9QpmUjpk+4+RlYpW8GFuiZqQnKmvei08HsFPd0RfbDvEhnE4wBvnYs8ORVtYpOFuuCEmBVBw==",
-      "dev": true,
       "requires": {
         "is-ssh": "^1.3.0",
         "parse-url": "^1.3.0"
@@ -21068,7 +17062,6 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-10.0.1.tgz",
       "integrity": "sha512-Tq2u8UPXc/FawC/dO8bvh8jcck0Lkor5OhuZvmVSeyJGRucDBfw9y2zy/GNCx28lMYh1N12IzPwDexjUNFyAeg==",
-      "dev": true,
       "requires": {
         "git-up": "^2.0.0"
       }
@@ -21315,7 +17308,7 @@
     },
     "got": {
       "version": "5.7.1",
-      "resolved": "http://registry.npmjs.org/got/-/got-5.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
       "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
       "dev": true,
       "requires": {
@@ -23298,7 +19291,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
-      "dev": true,
       "requires": {
         "from2": "^2.1.1",
         "p-is-promise": "^1.1.0"
@@ -23806,7 +19798,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.0.tgz",
       "integrity": "sha1-6+oRaaJhTaOSpjdANmw84EnY3/Y=",
-      "dev": true,
       "requires": {
         "protocols": "^1.1.0"
       }
@@ -23964,7 +19955,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-2.2.0.tgz",
       "integrity": "sha512-qBm9P//mcpIosDX0GU29TJkOcIIyF4PMnetfU6yfWsukLRQJPUWdJuYFjEkHlW5bxCbmEkpBnkaAPiTmCYCNDQ==",
-      "dev": true,
       "requires": {
         "lodash.capitalize": "^4.2.1",
         "lodash.escaperegexp": "^4.1.2",
@@ -26423,7 +22413,8 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -26535,7 +22526,8 @@
     "lodash.pick": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
+      "dev": true
     },
     "lodash.pluck": {
       "version": "3.1.2",
@@ -26553,11 +22545,6 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
       "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
-    },
-    "lodash.set": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
     },
     "lodash.snakecase": {
       "version": "4.1.1",
@@ -26626,12 +22613,8 @@
     "lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
-    },
-    "lodash.uniqby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
-      "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI="
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+      "dev": true
     },
     "lodash.upperfirst": {
       "version": "4.3.1",
@@ -26765,11 +22748,6 @@
       "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
       "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
       "dev": true
-    },
-    "macos-release": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.0.0.tgz",
-      "integrity": "sha512-iCM3ZGeqIzlrH7KxYK+fphlJpCCczyHXc+HhRVbEu9uNTCrzYJjvvtefzeKTCVHd5AP/aD/fzC80JZ4ZP+dQ/A=="
     },
     "make-dir": {
       "version": "1.2.0",
@@ -32267,11 +28245,6 @@
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true
     },
-    "octokit-pagination-methods": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
-      "integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ=="
-    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -32734,15 +28707,6 @@
         "lcid": "^1.0.0"
       }
     },
-    "os-name": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.0.0.tgz",
-      "integrity": "sha512-7c74tib2FsdFbQ3W+qj8Tyd1R3Z6tuVRNNxXjJcZ4NgjIEQU9N/prVMqcW29XZPXGACqaXN3jq58/6hoaoXH6g==",
-      "requires": {
-        "macos-release": "^2.0.0",
-        "windows-release": "^3.1.0"
-      }
-    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -32810,8 +28774,7 @@
     "p-is-promise": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
-      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
-      "dev": true
+      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
     },
     "p-limit": {
       "version": "1.2.0",
@@ -33039,7 +29002,6 @@
       "version": "1.3.11",
       "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-1.3.11.tgz",
       "integrity": "sha1-V8FUKKuKiSsfQ4aWRccR0OFEtVQ=",
-      "dev": true,
       "requires": {
         "is-ssh": "^1.3.0",
         "protocols": "^1.4.0"
@@ -35834,8 +31796,7 @@
     "protocols": {
       "version": "1.4.6",
       "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.6.tgz",
-      "integrity": "sha1-+LsmPqG1/Xp2BNJri+Ob13Z4v4o=",
-      "dev": true
+      "integrity": "sha1-+LsmPqG1/Xp2BNJri+Ob13Z4v4o="
     },
     "proxy-addr": {
       "version": "2.0.4",
@@ -36548,11 +32509,34 @@
         }
       }
     },
+    "react-click-outside": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/react-click-outside/-/react-click-outside-3.0.1.tgz",
+      "integrity": "sha512-d0KWFvBt+esoZUF15rL2UBB7jkeAqLU8L/Ny35oLK6fW6mIbOv/ChD+ExF4sR9PD26kVx+9hNfD0FTIqRZEyRQ==",
+      "requires": {
+        "hoist-non-react-statics": "^2.1.1"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+        }
+      }
+    },
     "react-deep-force-update": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/react-deep-force-update/-/react-deep-force-update-1.1.1.tgz",
       "integrity": "sha1-vNMUeAJ7ZLMznxCJIatSC0MT3Cw=",
       "dev": true
+    },
+    "react-delegate-component": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/react-delegate-component/-/react-delegate-component-1.0.0.tgz",
+      "integrity": "sha512-xdpNHPoiBQF0Ob4z5EqQUEK2sBjy0ooXe9xqsLlaA19l5dUASu3mIkfXMdBmMLCSfByPa0NluEN6BUDaI5EnlQ==",
+      "requires": {
+        "prop-types": "^15.6.0"
+      }
     },
     "react-dom": {
       "version": "15.4.1",
@@ -36838,6 +32822,11 @@
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-15.4.1.tgz",
       "integrity": "sha1-44zXBXho1KZV03ZGiXNbS5cmBwY=",
       "dev": true
+    },
+    "react-toggled": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/react-toggled/-/react-toggled-1.2.7.tgz",
+      "integrity": "sha512-3am1uA5ZzDwUkReEuUkK+fJ0DAYcGiLraWEPqXfL1kKD/NHbbB7fB/t+5FflMGd+FA6n9hih1es4pui1yzKi0w=="
     },
     "react-transform-catch-errors": {
       "version": "1.0.2",
@@ -38080,21 +34069,6 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
-    "schedule": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/schedule/-/schedule-0.5.0.tgz",
-      "integrity": "sha512-HUcJicG5Ou8xfR//c2rPT0lPIRR09vVvN81T9fqfVgBmhERUbDEQoYKjpBxbueJnCPpSu2ujXzOnRQt6x9o/jw==",
-      "requires": {
-        "object-assign": "^4.1.1"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-        }
-      }
-    },
     "schema-utils": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
@@ -38129,7 +34103,7 @@
       "dependencies": {
         "commander": {
           "version": "2.8.1",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "dev": true,
           "requires": {
@@ -38597,8 +34571,7 @@
     "semver-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz",
-      "integrity": "sha1-kqSWkGX5xwxpR1PVUkj8aPj2Usk=",
-      "dev": true
+      "integrity": "sha1-kqSWkGX5xwxpR1PVUkj8aPj2Usk="
     },
     "semver-truncate": {
       "version": "1.1.2",
@@ -39693,7 +35666,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -39964,7 +35937,7 @@
     },
     "strip-dirs": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
       "integrity": "sha1-lgu9EoeETzl1pFWKoQOoJV4kVqA=",
       "dev": true,
       "requires": {
@@ -40521,6 +36494,11 @@
           "dev": true
         }
       }
+    },
+    "tabbable": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-3.1.2.tgz",
+      "integrity": "sha512-wjB6puVXTYO0BSFtCmWQubA/KIn7Xvajw0x0l6eJUudMG/EAiJvIUnyNX6xO4NpGrJ16lbD0eUseB9WxW0vlpQ=="
     },
     "table": {
       "version": "3.8.3",
@@ -42631,7 +38609,7 @@
         },
         "buffer": {
           "version": "3.6.0",
-          "resolved": "http://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
           "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
           "dev": true,
           "requires": {
@@ -42753,14 +38731,6 @@
       "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
       "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs=",
       "dev": true
-    },
-    "universal-user-agent": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.0.2.tgz",
-      "integrity": "sha512-nOwvHWLH3dBazyuzbECPA5uVFNd7AlgviXRHgR4yf48QqitIvpdncRrxMbZNMpPPEfgz30I9ubd1XmiJiqsTrg==",
-      "requires": {
-        "os-name": "^3.0.0"
-      }
     },
     "universalify": {
       "version": "0.1.1",
@@ -45384,42 +41354,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
-    },
-    "windows-release": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.1.0.tgz",
-      "integrity": "sha512-hBb7m7acFgQPQc222uEQTmdcGLeBmQLNLFIh0rDk3CwFOBrfjefLzEfEfmpMq8Af/n/GnFf3eYf203FY1PmudA==",
-      "requires": {
-        "execa": "^0.10.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-          "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "execa": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
-          "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        }
-      }
     },
     "winston": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@dcos/http-service": "1.1.0",
     "@dcos/mesos-client": "0.2.6",
     "@dcos/tslint-config": "0.1.1",
-    "@dcos/ui-kit": "1.17.1",
+    "@dcos/ui-kit": "1.26.0",
     "@lingui/react": "2.7.2",
     "@types/classnames": "2.2.6",
     "array-sort": "1.0.0",

--- a/plugins/nodes/src/js/columns/NodesTableCPUColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableCPUColumn.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import sort from "array-sort";
+import { Cell } from "@dcos/ui-kit";
+
 import Node from "#SRC/js/structs/Node";
 import * as ResourcesUtil from "#SRC/js/utils/ResourcesUtil";
-import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
-import { Cell } from "@dcos/ui-kit";
 import ProgressBar from "#SRC/js/components/ProgressBar";
 
 function getCpuUsage(data: Node): number {
@@ -14,17 +14,19 @@ function getCpuUsage(data: Node): number {
 export function cpuRenderer(data: Node): React.ReactNode {
   return (
     <Cell>
-      <ProgressBar
-        data={[
-          {
-            value: data.getUsageStats("cpus").percentage,
-            className: `color-${ResourcesUtil.getResourceColor("cpus")}`
-          }
-        ]}
-        total={100}
-      />
+      <div>
+        <ProgressBar
+          data={[
+            {
+              value: data.getUsageStats("cpus").percentage,
+              className: `color-${ResourcesUtil.getResourceColor("cpus")}`
+            }
+          ]}
+          total={100}
+        />
 
-      <span className="table-content-spacing-left">{getCpuUsage(data)}%</span>
+        <span className="table-content-spacing-left">{getCpuUsage(data)}%</span>
+      </div>
     </Cell>
   );
 }
@@ -44,8 +46,4 @@ const comparators = [compareNodesByCpuUsage, compareNodesByHostname];
 export function cpuSorter(data: Node[], sortDirection: SortDirection): Node[] {
   const reverse = sortDirection !== "ASC";
   return sort(data, comparators, { reverse });
-}
-
-export function cpuSizer(_args: WidthArgs): number {
-  return 110;
 }

--- a/plugins/nodes/src/js/columns/NodesTableDiskColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableDiskColumn.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import sort from "array-sort";
+import { Cell } from "@dcos/ui-kit";
+
 import Node from "#SRC/js/structs/Node";
 import * as ResourcesUtil from "#SRC/js/utils/ResourcesUtil";
-import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
-import { Cell } from "@dcos/ui-kit";
 import ProgressBar from "#SRC/js/components/ProgressBar";
 
 function getDiskUsage(data: Node) {
@@ -14,17 +14,21 @@ function getDiskUsage(data: Node) {
 export function diskRenderer(data: Node): React.ReactNode {
   return (
     <Cell>
-      <ProgressBar
-        data={[
-          {
-            value: data.getUsageStats("disk").percentage,
-            className: `color-${ResourcesUtil.getResourceColor("disk")}`
-          }
-        ]}
-        total={100}
-      />
+      <div>
+        <ProgressBar
+          data={[
+            {
+              value: data.getUsageStats("disk").percentage,
+              className: `color-${ResourcesUtil.getResourceColor("disk")}`
+            }
+          ]}
+          total={100}
+        />
 
-      <span className="table-content-spacing-left">{getDiskUsage(data)}%</span>
+        <span className="table-content-spacing-left">
+          {getDiskUsage(data)}%
+        </span>
+      </div>
     </Cell>
   );
 }
@@ -44,7 +48,4 @@ const comparators = [compareNodesByDiskUsage, compareNodesByHostname];
 export function diskSorter(data: Node[], sortDirection: SortDirection): Node[] {
   const reverse = sortDirection !== "ASC";
   return sort(data, comparators, { reverse });
-}
-export function diskSizer(_args: WidthArgs): number {
-  return 110;
 }

--- a/plugins/nodes/src/js/columns/NodesTableGPUColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableGPUColumn.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import sort from "array-sort";
+import { Cell } from "@dcos/ui-kit";
+
 import Node from "#SRC/js/structs/Node";
 import * as ResourcesUtil from "#SRC/js/utils/ResourcesUtil";
-import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 import ProgressBar from "#SRC/js/components/ProgressBar";
-import { Cell } from "@dcos/ui-kit";
 
 function getGpuUsage(data: Node): number {
   return data.getUsageStats("gpus").percentage;
@@ -14,16 +14,18 @@ function getGpuUsage(data: Node): number {
 export function gpuRenderer(data: Node): React.ReactNode {
   return (
     <Cell>
-      <ProgressBar
-        data={[
-          {
-            value: data.getUsageStats("gpus").percentage,
-            className: `color-${ResourcesUtil.getResourceColor("gpus")}`
-          }
-        ]}
-        total={100}
-      />
-      <span className="table-content-spacing-left">{getGpuUsage(data)}%</span>
+      <div>
+        <ProgressBar
+          data={[
+            {
+              value: data.getUsageStats("gpus").percentage,
+              className: `color-${ResourcesUtil.getResourceColor("gpus")}`
+            }
+          ]}
+          total={100}
+        />
+        <span className="table-content-spacing-left">{getGpuUsage(data)}%</span>
+      </div>
     </Cell>
   );
 }
@@ -44,8 +46,4 @@ const comparators = [compareNodesByGpuUsage, compareNodesByHostname];
 export function gpuSorter(data: Node[], sortDirection: SortDirection): Node[] {
   const reverse = sortDirection !== "ASC";
   return sort(data, comparators, { reverse });
-}
-
-export function gpuSizer(_args: WidthArgs): number {
-  return 110;
 }

--- a/plugins/nodes/src/js/columns/NodesTableHealthColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableHealthColumn.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
+import { TextCell } from "@dcos/ui-kit";
+
 import UnitHealthUtil from "#SRC/js/utils/UnitHealthUtil";
 import Node from "#SRC/js/structs/Node";
-import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
-import { TextCell } from "@dcos/ui-kit";
 
 export function healthRenderer(data: Node): React.ReactNode {
   const health = data.getHealth();
@@ -20,9 +20,4 @@ export function healthSorter(
 ): Node[] {
   const sortedData = data.sort(UnitHealthUtil.getHealthSortFunction);
   return sortDirection === "ASC" ? sortedData : sortedData.reverse();
-}
-
-export function healthSizer(_args: WidthArgs): number {
-  // TODO: DCOS-38827
-  return 120;
 }

--- a/plugins/nodes/src/js/columns/NodesTableIpColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableIpColumn.tsx
@@ -1,14 +1,14 @@
 import * as React from "react";
 import sort from "array-sort";
 import { Trans } from "@lingui/macro";
-import Node from "#SRC/js/structs/Node";
-import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
-import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 import { Link } from "react-router";
 import { Tooltip } from "reactjs-components";
-import Icon from "#SRC/js/components/Icon";
 import { TextCell } from "@dcos/ui-kit";
 import ipToInt from "ip-to-int";
+
+import Node from "#SRC/js/structs/Node";
+import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
+import Icon from "#SRC/js/components/Icon";
 
 export function ipRenderer(data: Node): React.ReactNode {
   const nodeID = data.get("id");
@@ -65,8 +65,4 @@ const comparators = [compareNodesByIp];
 export function ipSorter(data: Node[], sortDirection: SortDirection): Node[] {
   const reverse = sortDirection !== "ASC";
   return sort(data, comparators, { reverse });
-}
-
-export function ipSizer(args: WidthArgs): number {
-  return Math.max(150, args.width / args.totalColumns);
 }

--- a/plugins/nodes/src/js/columns/NodesTableMemColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableMemColumn.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import sort from "array-sort";
+import { Cell } from "@dcos/ui-kit";
+
 import Node from "#SRC/js/structs/Node";
 import * as ResourcesUtil from "#SRC/js/utils/ResourcesUtil";
-import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 import ProgressBar from "#SRC/js/components/ProgressBar";
-import { Cell } from "@dcos/ui-kit";
 
 function getMemUsage(data: Node): number {
   return data.getUsageStats("mem").percentage;
@@ -14,17 +14,19 @@ function getMemUsage(data: Node): number {
 export function memRenderer(data: Node): React.ReactNode {
   return (
     <Cell>
-      <ProgressBar
-        data={[
-          {
-            value: data.getUsageStats("mem").percentage,
-            className: `color-${ResourcesUtil.getResourceColor("mem")}`
-          }
-        ]}
-        total={100}
-      />
+      <div>
+        <ProgressBar
+          data={[
+            {
+              value: data.getUsageStats("mem").percentage,
+              className: `color-${ResourcesUtil.getResourceColor("mem")}`
+            }
+          ]}
+          total={100}
+        />
 
-      <span className="table-content-spacing-left">{getMemUsage(data)}%</span>
+        <span className="table-content-spacing-left">{getMemUsage(data)}%</span>
+      </div>
     </Cell>
   );
 }
@@ -44,8 +46,4 @@ const comparators = [compareNodesByMemUsage, compareNodesByHostname];
 export function memSorter(data: Node[], sortDirection: SortDirection): Node[] {
   const reverse = sortDirection !== "ASC";
   return sort(data, comparators, { reverse });
-}
-
-export function memSizer(_args: WidthArgs): number {
-  return 110;
 }

--- a/plugins/nodes/src/js/columns/NodesTableRegionColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableRegionColumn.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 import sort from "array-sort";
-import Node from "#SRC/js/structs/Node";
-import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
-import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 import { TextCell } from "@dcos/ui-kit";
+
+import Node from "#SRC/js/structs/Node";
+import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 
 export function regionRenderer(
   masterRegion: string,
@@ -43,8 +43,4 @@ export function regionSorter(
 ): Node[] {
   const reverse = sortDirection !== "ASC";
   return sort(data, comparators, { reverse });
-}
-
-export function regionSizer(_args: WidthArgs): number {
-  return 200;
 }

--- a/plugins/nodes/src/js/columns/NodesTableSpacingColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableSpacingColumn.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
-import Node from "#SRC/js/structs/Node";
+import { WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 
-import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
+import Node from "#SRC/js/structs/Node";
 
 export function spacingRenderer(_data: Node): React.ReactNode {
   return null;

--- a/plugins/nodes/src/js/columns/NodesTableTasksColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableTasksColumn.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 import sort from "array-sort";
-import Node from "#SRC/js/structs/Node";
-import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
-import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 import { NumberCell } from "@dcos/ui-kit";
+
+import Node from "#SRC/js/structs/Node";
+import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 
 export function tasksRenderer(data: Node): React.ReactNode {
   return (
@@ -31,8 +31,4 @@ export function tasksSorter(
 ): Node[] {
   const reverse = sortDirection !== "ASC";
   return sort(data, comparators, { reverse });
-}
-
-export function tasksSizer(_args: WidthArgs): number {
-  return 80;
 }

--- a/plugins/nodes/src/js/columns/NodesTableTypeColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableTypeColumn.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import sort from "array-sort";
 import { Trans } from "@lingui/macro";
-import Node from "#SRC/js/structs/Node";
-import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
-import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 import { TextCell } from "@dcos/ui-kit";
+
+import Node from "#SRC/js/structs/Node";
+import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 
 export function typeRenderer(data: Node): React.ReactNode {
   const type = data.isPublic() ? (
@@ -34,8 +34,4 @@ const comparators = [compareNodesByType, compareNodesByHostname];
 export function typeSorter(data: Node[], sortDirection: SortDirection): Node[] {
   const reverse = sortDirection !== "ASC";
   return sort(data, comparators, { reverse });
-}
-
-export function typeSizer(_args: WidthArgs): number {
-  return 70;
 }

--- a/plugins/nodes/src/js/columns/NodesTableZoneColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableZoneColumn.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 import sort from "array-sort";
-import Node from "#SRC/js/structs/Node";
-import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
-import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 import { TextCell } from "@dcos/ui-kit";
+
+import Node from "#SRC/js/structs/Node";
+import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 
 export function zoneRenderer(data: Node): React.ReactNode {
   return (
@@ -32,8 +32,4 @@ const comparators = [compareNodesByZone, compareNodesByHostname];
 export function zoneSorter(data: Node[], sortDirection: SortDirection): Node[] {
   const reverse = sortDirection !== "ASC";
   return sort(data, comparators, { reverse });
-}
-
-export function zoneSizer(_args: WidthArgs): number {
-  return 200;
 }

--- a/plugins/nodes/src/js/columns/__tests__/__snapshots__/NodesTableHealthColumn-test.js.snap
+++ b/plugins/nodes/src/js/columns/__tests__/__snapshots__/NodesTableHealthColumn-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`NodesTableHealthColumn renderer renders with health status 'Healthy' 1`] = `
 <div
-  className="css-1l7ir3d"
+  className="css-txgdtc"
 >
   <span
     className="text-success"
@@ -14,7 +14,7 @@ exports[`NodesTableHealthColumn renderer renders with health status 'Healthy' 1`
 
 exports[`NodesTableHealthColumn renderer renders with health status 'NA' 1`] = `
 <div
-  className="css-1l7ir3d"
+  className="css-txgdtc"
 >
   <span
     className="text-mute"
@@ -26,7 +26,7 @@ exports[`NodesTableHealthColumn renderer renders with health status 'NA' 1`] = `
 
 exports[`NodesTableHealthColumn renderer renders with health status 'Unhealthy' 1`] = `
 <div
-  className="css-1l7ir3d"
+  className="css-txgdtc"
 >
   <span
     className="text-danger"
@@ -38,7 +38,7 @@ exports[`NodesTableHealthColumn renderer renders with health status 'Unhealthy' 
 
 exports[`NodesTableHealthColumn renderer renders with health status 'Warn' 1`] = `
 <div
-  className="css-1l7ir3d"
+  className="css-txgdtc"
 >
   <span
     className="text-warning"

--- a/plugins/nodes/src/js/components/NodesTable.tsx
+++ b/plugins/nodes/src/js/components/NodesTable.tsx
@@ -4,55 +4,26 @@ import { Trans } from "@lingui/macro";
 
 import NodesList from "#SRC/js/structs/NodesList";
 import Node from "#SRC/js/structs/Node";
+import Loader from "#SRC/js/components/Loader";
 
 import { SortDirection } from "../types/SortDirection";
 
-import { ipSorter, ipRenderer, ipSizer } from "../columns/NodesTableIpColumn";
-import {
-  typeSorter,
-  typeRenderer,
-  typeSizer
-} from "../columns/NodesTableTypeColumn";
+import { ipSorter, ipRenderer } from "../columns/NodesTableIpColumn";
+import { typeSorter, typeRenderer } from "../columns/NodesTableTypeColumn";
 import {
   regionSorter,
-  regionRenderer,
-  regionSizer
+  regionRenderer
 } from "../columns/NodesTableRegionColumn";
-import {
-  zoneSorter,
-  zoneRenderer,
-  zoneSizer
-} from "../columns/NodesTableZoneColumn";
+import { zoneSorter, zoneRenderer } from "../columns/NodesTableZoneColumn";
 import {
   healthSorter,
-  healthRenderer,
-  healthSizer
+  healthRenderer
 } from "../columns/NodesTableHealthColumn";
-import {
-  tasksSorter,
-  tasksRenderer,
-  tasksSizer
-} from "../columns/NodesTableTasksColumn";
-import {
-  cpuSorter,
-  cpuRenderer,
-  cpuSizer
-} from "../columns/NodesTableCPUColumn";
-import {
-  memSorter,
-  memRenderer,
-  memSizer
-} from "../columns/NodesTableMemColumn";
-import {
-  diskSorter,
-  diskRenderer,
-  diskSizer
-} from "../columns/NodesTableDiskColumn";
-import {
-  gpuSorter,
-  gpuRenderer,
-  gpuSizer
-} from "../columns/NodesTableGPUColumn";
+import { tasksSorter, tasksRenderer } from "../columns/NodesTableTasksColumn";
+import { cpuSorter, cpuRenderer } from "../columns/NodesTableCPUColumn";
+import { memSorter, memRenderer } from "../columns/NodesTableMemColumn";
+import { diskSorter, diskRenderer } from "../columns/NodesTableDiskColumn";
+import { gpuSorter, gpuRenderer } from "../columns/NodesTableGPUColumn";
 import {
   spacingSizer,
   spacingRenderer
@@ -182,6 +153,10 @@ export default class NodesTable extends React.Component<
   render() {
     const { data, sortColumn, sortDirection } = this.state;
 
+    if (data.length === 0) {
+      return <Loader />;
+    }
+
     return (
       <div className="table-wrapper">
         <Table data={data.slice()}>
@@ -194,7 +169,6 @@ export default class NodesTable extends React.Component<
               />
             }
             cellRenderer={ipRenderer}
-            width={ipSizer}
           />
 
           <Column
@@ -206,7 +180,6 @@ export default class NodesTable extends React.Component<
               />
             }
             cellRenderer={healthRenderer}
-            width={healthSizer}
           />
 
           <Column
@@ -218,7 +191,6 @@ export default class NodesTable extends React.Component<
               />
             }
             cellRenderer={typeRenderer}
-            width={typeSizer}
           />
 
           <Column
@@ -230,7 +202,6 @@ export default class NodesTable extends React.Component<
               />
             }
             cellRenderer={this.regionRenderer}
-            width={regionSizer}
           />
 
           <Column
@@ -242,7 +213,6 @@ export default class NodesTable extends React.Component<
               />
             }
             cellRenderer={zoneRenderer}
-            width={zoneSizer}
           />
 
           <Column
@@ -255,7 +225,6 @@ export default class NodesTable extends React.Component<
               />
             }
             cellRenderer={tasksRenderer}
-            width={tasksSizer}
           />
 
           <Column
@@ -267,7 +236,6 @@ export default class NodesTable extends React.Component<
               />
             }
             cellRenderer={cpuRenderer}
-            width={cpuSizer}
           />
 
           <Column
@@ -279,7 +247,6 @@ export default class NodesTable extends React.Component<
               />
             }
             cellRenderer={memRenderer}
-            width={memSizer}
           />
 
           <Column
@@ -291,7 +258,6 @@ export default class NodesTable extends React.Component<
               />
             }
             cellRenderer={diskRenderer}
-            width={diskSizer}
           />
 
           <Column
@@ -303,7 +269,6 @@ export default class NodesTable extends React.Component<
               />
             }
             cellRenderer={gpuRenderer}
-            width={gpuSizer}
           />
 
           <Column

--- a/src/js/pages/catalog/__tests__/__snapshots__/PackagesTab-test.js.snap
+++ b/src/js/pages/catalog/__tests__/__snapshots__/PackagesTab-test.js.snap
@@ -143,7 +143,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1s6ggg6"
+                className="css-9w8rex"
               >
                 Certified
               </span>
@@ -188,7 +188,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1s6ggg6"
+                className="css-9w8rex"
               >
                 Certified
               </span>
@@ -233,7 +233,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1s6ggg6"
+                className="css-9w8rex"
               >
                 Certified
               </span>
@@ -278,7 +278,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1s6ggg6"
+                className="css-9w8rex"
               >
                 Certified
               </span>
@@ -323,7 +323,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1s6ggg6"
+                className="css-9w8rex"
               >
                 Certified
               </span>
@@ -368,7 +368,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1s6ggg6"
+                className="css-9w8rex"
               >
                 Certified
               </span>
@@ -413,7 +413,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1s6ggg6"
+                className="css-9w8rex"
               >
                 Certified
               </span>
@@ -458,7 +458,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1s6ggg6"
+                className="css-9w8rex"
               >
                 Certified
               </span>
@@ -503,7 +503,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1s6ggg6"
+                className="css-9w8rex"
               >
                 Certified
               </span>
@@ -570,7 +570,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -615,7 +615,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -660,7 +660,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -705,7 +705,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -750,7 +750,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -795,7 +795,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -840,7 +840,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -885,7 +885,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -930,7 +930,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -975,7 +975,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -1020,7 +1020,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -1065,7 +1065,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -1110,7 +1110,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -1155,7 +1155,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -1200,7 +1200,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -1245,7 +1245,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -1290,7 +1290,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -1335,7 +1335,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -1380,7 +1380,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -1425,7 +1425,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -1470,7 +1470,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -1515,7 +1515,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -1560,7 +1560,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -1605,7 +1605,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -1650,7 +1650,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -1695,7 +1695,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -1740,7 +1740,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -1785,7 +1785,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -1830,7 +1830,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -1875,7 +1875,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -1920,7 +1920,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -1965,7 +1965,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -2010,7 +2010,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -2055,7 +2055,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -2100,7 +2100,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -2145,7 +2145,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -2190,7 +2190,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -2235,7 +2235,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -2280,7 +2280,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -2325,7 +2325,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -2370,7 +2370,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -2415,7 +2415,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -2460,7 +2460,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -2505,7 +2505,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -2550,7 +2550,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -2595,7 +2595,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -2640,7 +2640,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -2685,7 +2685,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -2730,7 +2730,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -2775,7 +2775,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -2820,7 +2820,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -2865,7 +2865,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -2910,7 +2910,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -2955,7 +2955,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -3000,7 +3000,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -3045,7 +3045,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -3090,7 +3090,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -3135,7 +3135,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -3180,7 +3180,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -3225,7 +3225,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -3270,7 +3270,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -3315,7 +3315,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -3360,7 +3360,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -3405,7 +3405,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -3450,7 +3450,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -3495,7 +3495,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -3540,7 +3540,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -3585,7 +3585,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -3630,7 +3630,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -3675,7 +3675,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -3720,7 +3720,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -3765,7 +3765,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -3810,7 +3810,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -3855,7 +3855,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -3900,7 +3900,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -3945,7 +3945,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -3990,7 +3990,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -4035,7 +4035,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -4080,7 +4080,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -4125,7 +4125,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -4170,7 +4170,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -4215,7 +4215,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -4260,7 +4260,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -4305,7 +4305,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -4350,7 +4350,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -4395,7 +4395,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -4440,7 +4440,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>
@@ -4485,7 +4485,7 @@ exports[`PackagesTab with packages on the list displays the catalog with package
               className="panel-footer panel-cell panel-cell-narrow flush-top horizontal-center"
             >
               <span
-                className="css-1rtlwt4"
+                className="css-17jd12v"
               >
                 Community
               </span>


### PR DESCRIPTION
Use the new version of the ui-kit to enable the nodes table
to auto resize columns based on their content width.

Closes https://jira.mesosphere.com/browse/DCOS-47175

~Currently blocked by https://github.com/dcos-labs/ui-kit/pull/276~

## Testing
1. Go to Nodes tab
2. Verify that the table doesn't jump as the data is loaded
3. Verify that the table works and the columns are as wide as the content

## Trade-offs
~I don't think that the new table looks better. I considered adding some minimal width to the columns, but then we would have the old table in almost every case (as the health column for example will never be wider than the old value of 120px). @lsamimi , @mperrotti , what do you think?~

I added a loader if the data array is empty, but some of the values in the table are slower to load, which causes it to move.

Also fixed some unrelated failing snapshots and some other minor things.

## Dependencies
~https://github.com/dcos-labs/ui-kit/pull/276~

## Screenshots

### Before
![screenshot from 2019-01-16 11-01-56](https://user-images.githubusercontent.com/40791275/51237982-6c983980-197e-11e9-836c-bc83e98f7af9.png)

### After (old)
![screenshot from 2019-01-16 11-04-40](https://user-images.githubusercontent.com/40791275/51238045-92bdd980-197e-11e9-8fc9-95f9c8861d72.png)

### After (new)
![screenshot from 2019-01-17 09-51-21](https://user-images.githubusercontent.com/40791275/51303824-31117400-1a3f-11e9-8977-7aae9e959471.png)
