### PR TITLE
Revert "fix: update CLI URL in the installation instruction".

### DIFF
--- a/src/js/components/modals/CliInstallModal.js
+++ b/src/js/components/modals/CliInstallModal.js
@@ -56,10 +56,6 @@ class CliInstallModal extends React.Component {
   }
 
   getCliInstructions() {
-    // TODO (DCOS-8495): Binary cli links have hardcoded version, these should
-    // be updated to a /latest endpoint, when that becomes available.
-    // Binary cli links are also all pointing to the open version, which is
-    // intentional.
     const hostname = global.location.hostname;
     const protocol = global.location.protocol.replace(/[^\w]/g, "");
     let port = "";

--- a/src/js/components/modals/CliInstallModal.js
+++ b/src/js/components/modals/CliInstallModal.js
@@ -56,6 +56,10 @@ class CliInstallModal extends React.Component {
   }
 
   getCliInstructions() {
+    // TODO (DCOS-8495): Binary cli links have hardcoded version, these should
+    // be updated to a /latest endpoint, when that becomes available.
+    // Binary cli links are also all pointing to the open version, which is
+    // intentional.
     const hostname = global.location.hostname;
     const protocol = global.location.protocol.replace(/[^\w]/g, "");
     let port = "";
@@ -64,16 +68,14 @@ class CliInstallModal extends React.Component {
     }
     const clusterUrl = `${protocol}://${hostname}${port}`;
     const { selectedOS } = this.state;
-
-    const downloadUrl =
-      MetadataStore.version && !MetadataStore.version.includes("-dev")
-        ? `https://downloads.dcos.io/cli/releases/binaries/dcos/${
-            osTypes[selectedOS]
-          }/x86-64/latest/dcos`
-        : `https://downloads.dcos.io/cli/testing/binaries/dcos/${
-            osTypes[selectedOS]
-          }/x86-64/master/dcos`;
-
+    let version = MetadataStore.parsedVersion;
+    // Prepend 'dcos-' to any version other than latest
+    if (version !== "latest") {
+      version = `dcos-${version}`;
+    }
+    const downloadUrl = `https://downloads.dcos.io/binaries/cli/${
+      osTypes[selectedOS]
+    }/x86-64/${version}/dcos`;
     if (selectedOS === "Windows") {
       return this.getWindowsInstallInstruction(clusterUrl, downloadUrl);
     }


### PR DESCRIPTION
This reverts commit 810b475b3cac7d81659d5892d14549c77b981c68. The original commit was made due to the lack of a DC/OS CLI for DC/OS 1.13, this is now fixed.

## Testing

A cluster using DC/OS 1.13.

## Trade-offs

We will have to update the URL once we start developing DC/OS 1.14.

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
