### PR TITLE
[spike] DCOS-46611: [1.12] Cannot read property 'stateTypes' of undefined

### DIFF
--- a/src/js/structs/Node.js
+++ b/src/js/structs/Node.js
@@ -73,7 +73,10 @@ class Node extends Item {
     let sum = 0;
 
     Object.keys(TaskStates).forEach(function(taskType) {
-      if (TaskStates[taskType].stateTypes.indexOf(state) !== -1) {
+      if (
+        TaskStates[taskType] &&
+        TaskStates[taskType].stateTypes.indexOf(state) !== -1
+      ) {
         // Make sure there's a value
         if (this[taskType]) {
           sum += this[taskType];


### PR DESCRIPTION
Add a check to prevent trying to read a property from something that
is not defined.

Closes https://jira.mesosphere.com/browse/DCOS-46611

## Testing
Not sure how to test this.

## Trade-offs
None.

## Dependencies
None.

## Screenshots
None.
