### PR TITLE
Revert "fix: update CLI URL in the installation instruction"

### DIFF
--- a/src/js/components/modals/CliInstallModal.js
+++ b/src/js/components/modals/CliInstallModal.js
@@ -65,15 +65,14 @@ class CliInstallModal extends React.Component {
     const clusterUrl = `${protocol}://${hostname}${port}`;
     const { selectedOS } = this.state;
 
-    const downloadUrl =
-      MetadataStore.version && !MetadataStore.version.includes("-dev")
-        ? `https://downloads.dcos.io/cli/releases/binaries/dcos/${
-            osTypes[selectedOS]
-          }/x86-64/latest/dcos`
-        : `https://downloads.dcos.io/cli/testing/binaries/dcos/${
-            osTypes[selectedOS]
-          }/x86-64/master/dcos`;
-
+    let version = MetadataStore.parsedVersion;
+    // Prepend 'dcos-' to any version other than latest
+    if (version !== "latest") {
+      version = `dcos-${version}`;
+    }
+    const downloadUrl = `https://downloads.dcos.io/binaries/cli/${
+      osTypes[selectedOS]
+    }/x86-64/${version}/dcos`;
     if (selectedOS === "Windows") {
       return this.getWindowsInstallInstruction(clusterUrl, downloadUrl);
     }


### PR DESCRIPTION
This reverts commit 810b475.

Creating this on the behalf of @ArmandGrillet , because his fork https://github.com/dcos/dcos-ui/pull/3535 can't get merged right now.

## Testing
On 1.13 cluster, open the dropdown in the top right corner, click "Install CLI", click "OSX" or "Linux" if they aren't selected and verify that the link in the second row contains "1.13".

## Trade-offs
None.

## Dependencies
None.

## Screenshots

### Before
![screenshot from 2019-01-18 15-29-59](https://user-images.githubusercontent.com/40791275/51390025-b9bf0b80-1b36-11e9-806b-919181773d77.png)

### After
![screenshot from 2019-01-18 15-30-53](https://user-images.githubusercontent.com/40791275/51390031-bd529280-1b36-11e9-8289-84c45108a3de.png)

