### PR TITLE
[spike] DCOS-47443: [1.12] Deployment bubble-help shows confusing numbers.

### DIFF
--- a/plugins/services/src/js/components/ServiceStatusIcon.js
+++ b/plugins/services/src/js/components/ServiceStatusIcon.js
@@ -102,7 +102,7 @@ class ServiceStatusIcon extends Component {
   getUnableToLaunchWarning(service) {
     if (this.isUnableToLaunch(service)) {
       return this.getTooltip(
-        `DC/OS has been unable to complete this deployment for ${DateUtil.getDuration(
+        `There are tasks in this queue that DC/OS has failed to deploy for ${DateUtil.getDuration(
           Date.now() - DateUtil.strToMs(service.getQueue().since),
           null
         )}.`


### PR DESCRIPTION
Changed delpoyment bubble text to be more accurate.

Closes https://jira.mesosphere.com/browse/DCOS-47444

## Testing
In `dcos-ui/plugins/services/src/js/components/ServiceStatusIcon.js`
change `getUnableToLaunchWarning` function to:
```
      return this.getTooltip(
        `There are tasks in this queue that DC/OS has failed to deploy for ${DateUtil.getDuration(
          Date.now(),
          null
        )}.`
      );

```
and `render` function to:
```
    const { service } = this.props;
    return this.getUnableToLaunchWarning(service);
```

Start a service and hover over the message on the left of the status.

It should say "There are tasks in this queue that DC/OS has failed to deploy for".

## Trade-offs
None.

## Dependencies
None.

## Screenshots

### Before
![screenshot from 2019-01-18 17-36-10](https://user-images.githubusercontent.com/40791275/51396358-9ea8c780-1b47-11e9-8e1d-e7fb8d001a0a.png)

### After
![screenshot from 2019-01-18 17-30-11](https://user-images.githubusercontent.com/40791275/51396372-a5cfd580-1b47-11e9-954c-08cbcbe27c4f.png)

