### PR TITLE
DCOS-47442: [1.11] Deployment bubble-help shows confusing numbers.

### DIFF
--- a/plugins/services/src/js/components/ServiceStatusIcon.js
+++ b/plugins/services/src/js/components/ServiceStatusIcon.js
@@ -96,7 +96,7 @@ class ServiceStatusIcon extends Component {
   getUnableToLaunchWarning(service) {
     if (this.isUnableToLaunch(service)) {
       return this.getTooltip(
-        `DC/OS has been unable to complete this deployment for ${DateUtil.getDuration(Date.now() - DateUtil.strToMs(service.getQueue().since), null)}.`
+        `There are tasks in this queue that DC/OS has failed to deploy for ${DateUtil.getDuration(Date.now() - DateUtil.strToMs(service.getQueue().since), null)}.`
       );
     }
 


### PR DESCRIPTION
Changed delpoyment bubble text to be more accurate.

Closes https://jira.mesosphere.com/browse/DCOS-47442

## Testing
In `dcos-ui/plugins/services/src/js/components/ServiceStatusIcon.js`
change `getUnableToLaunchWarning` function to:
```
      return this.getTooltip(
        `DC/OS has been unable to complete this deployment for ${DateUtil.getDuration(
          Date.now(),
          null
        )}.`
      );

    return null;
```
and `render` function to:
```
    const { service } = this.props;
    const serviceStatus = service.getServiceStatus();
    let iconState;
    return this.getUnableToLaunchWarning(service);
```

Start a service and hover over the message on the left of the status.

## Trade-offs
None.

## Dependencies
None.


## Screenshots
See https://github.com/dcos/dcos-ui/pull/3540