### PR TITLE
Update the doc URL for CLI-only packages

### DIFF
--- a/src/js/pages/catalog/PackageDetailTab.js
+++ b/src/js/pages/catalog/PackageDetailTab.js
@@ -274,7 +274,7 @@ class PackageDetailTab extends mixin(StoreMixin) {
             {"This package can only be installed using the CLI. See the "}
             <a
               href={MetadataStore.buildDocsURI(
-                "/cli/command-reference/dcos-service/"
+                "/cli/command-reference/dcos-package/dcos-package-install/"
               )}
               target="_blank"
             >


### PR DESCRIPTION
It currently points to `dcos service`, it'd be more useful to show the `dcos package install` command instead.

https://jira.mesosphere.com/browse/DCOS-17565