### PR TITLE
DCOS-47513: [1.12] COPS-4345 affecting dcos-ui: Change "Unavailable" status text for External Volumes

### DIFF
--- a/plugins/services/src/js/constants/VolumeStatus.js
+++ b/plugins/services/src/js/constants/VolumeStatus.js
@@ -1,7 +1,7 @@
 var VolumeStatus = {
   ATTACHED: "Attached",
   DETACHED: "Detached",
-  UNAVAILABLE: "Unavailable"
+  UNAVAILABLE: "N/A"
 };
 
 module.exports = VolumeStatus;

--- a/plugins/services/src/js/utils/__tests__/MarathonUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/MarathonUtil-test.js
@@ -83,7 +83,7 @@ describe("MarathonUtil", function() {
         options: { "volume/driver": "value" },
         provider: "volume-provide",
         size: 2048,
-        status: "Unavailable",
+        status: "N/A",
         type: "External"
       });
     });


### PR DESCRIPTION
For services with external volumes, change the unavailable status
to be N/A to make it more descriptive and less misleading.

Closes https://jira.mesosphere.com/browse/DCOS-47513

## Testing
1. Open postgresql from the catalog
2. In the edit configuration screen, select the Storage tab and enable persistent storage and persistent storage properties using the two checkboxes
![screenshot from 2019-01-21 15-50-58](https://user-images.githubusercontent.com/40791275/51479393-c2158180-1d96-11e9-82bc-9517894f4e05.png)
3. Click Review and Run
4. Open the service, open the Volumes tab and verify that the status is shown as "N/A"

## Trade-offs
None.

## Dependencies
None.

## Screenshots

### Before
![screenshot from 2019-01-21 15-44-47](https://user-images.githubusercontent.com/40791275/51479472-ff7a0f00-1d96-11e9-933b-569375d0c56c.png)

### After
![screenshot from 2019-01-21 15-51-11](https://user-images.githubusercontent.com/40791275/51479477-056ff000-1d97-11e9-96a8-7c6980f77c3d.png)

