### PR TITLE
DCOS-47514: [1.13] COPS-4345 affecting dcos-ui: Change "Unavailable" status text for External Volumes

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -912,7 +912,6 @@
   "Unable to edit {0}": "",
   "Unable to fetch permission schema.": "",
   "Unable to login to your DC/OS cluster. Clusters must be connected to the internet.": "",
-  "Unavailable": "",
   "Unhealthy": "",
   "Unique": "",
   "Universal Container Runtime (UCR)": "",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -912,7 +912,6 @@
   "Unable to edit {0}": "无法编辑 {0}",
   "Unable to fetch permission schema.": "无法获取权限框架。",
   "Unable to login to your DC/OS cluster. Clusters must be connected to the internet.": "无法登录到 DC/OS 集群。集群必须连接到互联网。",
-  "Unavailable": "不可用",
   "Unhealthy": "不健康",
   "Unique": "唯一",
   "Universal Container Runtime (UCR)": "通用容器运行时 (UCR)",

--- a/plugins/services/src/js/constants/VolumeStatus.js
+++ b/plugins/services/src/js/constants/VolumeStatus.js
@@ -3,7 +3,7 @@ import { i18nMark } from "@lingui/react";
 const VolumeStatus = {
   ATTACHED: i18nMark("Attached"),
   DETACHED: i18nMark("Detached"),
-  UNAVAILABLE: i18nMark("Unavailable")
+  UNAVAILABLE: i18nMark("N/A")
 };
 
 module.exports = VolumeStatus;

--- a/plugins/services/src/js/utils/__tests__/MarathonUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/MarathonUtil-test.js
@@ -83,7 +83,7 @@ describe("MarathonUtil", function() {
         options: { "volume/driver": "value" },
         provider: "volume-provide",
         size: 2048,
-        status: "Unavailable",
+        status: "N/A",
         type: "External"
       });
     });


### PR DESCRIPTION
For services with external volumes, change the unavailable status
to be N/A to make it more descriptive and less misleading.

Closes https://jira.mesosphere.com/browse/DCOS-47514

## Testing
1. Open postgresql from the catalog
2. In the edit configuration screen, select the Storage tab and enable persistent storage and persistent storage properties using the two checkboxes
![screenshot from 2019-01-21 16-20-39](https://user-images.githubusercontent.com/40791275/51480469-cd1de100-1d99-11e9-81d4-d68afdf92fd1.png)
3. Click Review and Run
4. Open the service, open the Volumes tab and verify that the status is shown as "N/A"


## Trade-offs
None.

## Dependencies
None.

## Screenshots

### Before
![screenshot from 2019-01-21 16-21-14](https://user-images.githubusercontent.com/40791275/51480509-e757bf00-1d99-11e9-9ed5-6b6c22b38679.png)

### After
![screenshot from 2019-01-21 16-21-36](https://user-images.githubusercontent.com/40791275/51480518-f0489080-1d99-11e9-97fe-3e345e752348.png)
