### PR TITLE
chore(CI): add check for .only on CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,8 +45,7 @@ pipeline {
       }
     }
 
-
-    stage("Lint Commits") {
+    stage("Verify Commits") {
       when {
         expression {
           !master_branches.contains(BRANCH_NAME)
@@ -55,6 +54,8 @@ pipeline {
 
       steps {
         sh 'npm run commitlint -- --from "${CHANGE_TARGET}"'
+        sh "source ./scripts/utils/test && [ -n \$(find_debug_directives \$(find . -name '*-test.js')) ] && exit 1"
+        sh "source ./scripts/utils/test && [ -n \$(find_debug_directives \$(find . -name '*-test.ts')) ] && exit 1"
       }
     }
 


### PR DESCRIPTION
Closes DCOS-47525

## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->


- Open a PR based on this one
- Add a ‘it.only‘ in a test case
- The CI should fail


## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
