### PR TITLE
DCOS-45214: enable validate test script to run on external plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
     "prebuild-assets": "./node_modules/.bin/gulp checkDependencies",
     "build-assets": "npm run clean && lingui compile && NODE_ENV=production webpack --colors --config ./webpack/webpack.production.js",
     "postbuild-assets": "find ./dist -name 'index.*.css' -exec node ./scripts/inline-bootstrap-css.js ./dist/index.html {} \\;",
-    "prebuild": "./scripts/validate-tests",
+    "prebuild": "PLUGINS_PATH=\"${npm_config_externalplugins}\" ./scripts/validate-tests",
     "build": "npm run lint && ([ -z \"${npm_config_externalplugins}\" ] || npm run lint-plugins) && npm test && npm run build-assets && npm run validate-build",
     "lint": "npm run stylelint && npm run eslint && npm run tslint",
     "eslint": "bash -c 'opts=$@ ; set -f; if [[ $# -lt 1 ]]; then opts=\"{src/js,plugins,packages}/**/*.js\"; fi ; eslint --quiet ${opts}' 0",

--- a/scripts/validate-tests
+++ b/scripts/validate-tests
@@ -9,19 +9,17 @@ source "${SCRIPT_PATH}/utils/test"
 title "Validating tests..."
 
 debug_directives=$(
- find_debug_directives ./src ./plugins ./packages ./tests ./system-tests
+	find_debug_directives ./src ./plugins ./packages ./tests ./system-tests "$PLUGINS_PATH"
 )
 
+if [ -n "${debug_directives}" ]; then
+	warning "Debug directives found"
 
-if [ -n "${debug_directives}" ]
-then
-  warning "Debug directives found"
+	echo -e "Please remove all found debug directives" \
+		"to ensure that all test run properly. \n"
+	"${debug_directives}"
 
-  echo -e "Please remove all found debug directives" \
-   "to ensure that all test run properly. \n"
-   "${debug_directives}"
-
-  exit 1
+	exit 1
 fi
 
 info "Tests look good."


### PR DESCRIPTION
## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

- Check this branch out
- Configure an external plugin
- Add a `it.only` in a test case
- run `npm build` from this repo and see it fail

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

- Use already existing tools now also for external plugins

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
