### PR TITLE
[Backport 1.12] fix(MarathonStore): get package image from nested items

### DIFF
--- a/plugins/services/src/js/stores/MarathonStore.js
+++ b/plugins/services/src/js/stores/MarathonStore.js
@@ -469,7 +469,9 @@ class MarathonStore extends GetSetBaseStore {
 
   injectGroupsWithPackageImages(data) {
     data.items.forEach(item => {
-      if (ServiceValidatorUtil.isFrameworkResponse(item)) {
+      if (item.items && Array.isArray(item.items)) {
+        this.injectGroupsWithPackageImages(item);
+      } else if (ServiceValidatorUtil.isFrameworkResponse(item)) {
         item["images"] = CosmosPackagesStore.getPackageImages()[
           item.labels.DCOS_PACKAGE_NAME
         ];


### PR DESCRIPTION
Get package images for icons from services that are inside folders.

Closes DCOS-47536.

## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
