### PR TITLE
[COPS] DCOS_OSS-4632: [1.12] dcos6 network is shown as available for UCR in the UI.

### DIFF
--- a/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
@@ -516,10 +516,15 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
         const name = overlay.getName();
 
         return {
+          enabled: overlay.info.enabled,
+          subnet6: overlay.getSubnet6(),
           text: `Virtual Network: ${name}`,
           value: `${CONTAINER}.${name}`
         };
       })
+      .filterItems(
+        virtualNetwork => virtualNetwork.enabled && !virtualNetwork.subnet6
+      )
       .getItems()
       .map((virtualNetwork, index) => {
         return (

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -526,15 +526,28 @@ class NetworkingFormSection extends mixin(StoreMixin) {
   }
 
   getVirtualNetworks() {
+    const mesosContainer =
+      findNestedPropertyInObject(this.props.data, `container.type`) === "MESOS";
+    // Networks with subnet6 should be disabled when "UCR" container type is selected.
+    const virtualNetworkIsAvailable = (mesosContainer, subnet6) =>
+      !mesosContainer || !subnet6;
+
     return VirtualNetworksStore.getOverlays()
       .mapItems(overlay => {
         const name = overlay.getName();
 
         return {
+          enabled: overlay.info.enabled,
+          subnet6: overlay.getSubnet6(),
           text: `Virtual Network: ${name}`,
           value: `${CONTAINER}.${name}`
         };
       })
+      .filterItems(
+        virtualNetwork =>
+          virtualNetwork.enabled &&
+          virtualNetworkIsAvailable(mesosContainer, virtualNetwork.subnet6)
+      )
       .getItems()
       .map((virtualNetwork, index) => {
         return (

--- a/tests/_fixtures/mesos/overlay-master.json
+++ b/tests/_fixtures/mesos/overlay-master.json
@@ -277,12 +277,26 @@
       {
         "name": "dcos-1",
         "prefix": 24,
-        "subnet": "192.168.0.0\/17"
+        "subnet": "192.168.0.0\/17",
+        "enabled": true
       },
       {
         "name": "dcos-2",
         "prefix": 24,
-        "subnet": "192.168.128.0\/17"
+        "subnet": "192.168.128.0\/17",
+        "enabled": true
+      },
+      {
+        "name": "dcos-3",
+        "prefix6": 80,
+        "subnet6": "fd01:b::/64",
+        "enabled": true
+      },
+      {
+        "name": "dcos-4",
+        "prefix": 24,
+        "subnet": "192.168.128.0\/17",
+        "enabled": false
       }
     ],
     "vtep_mac_oui": "70:B3:D5:00:00:00",

--- a/tests/pages/networking/Networks-cy.js
+++ b/tests/pages/networking/Networks-cy.js
@@ -11,7 +11,7 @@ describe("Networks", function() {
 
     it("displays all of the networks in the table", function() {
       cy.get("tbody tr").should(function($tableRows) {
-        expect(getVisibleTableRows($tableRows).length).to.equal(2);
+        expect(getVisibleTableRows($tableRows).length).to.equal(4);
       });
     });
 
@@ -23,9 +23,13 @@ describe("Networks", function() {
             const tableCells = tableRow.querySelectorAll("td");
 
             expect(tableCells[0].textContent).to.equal(overlayData.name);
-            expect(tableCells[1].textContent).to.equal(overlayData.subnet);
+            expect(tableCells[1].textContent).to.equal(
+              overlayData.subnet || overlayData.subnet6
+            );
             expect(tableCells[2].textContent).to.equal(
-              overlayData.prefix.toString()
+              overlayData.prefix
+                ? overlayData.prefix.toString()
+                : overlayData.prefix6.toString()
             );
           });
         });
@@ -72,9 +76,10 @@ describe("Networks", function() {
     });
 
     it("allows users to filter the table", function() {
-      cy
-        .get(".filter-bar-item .filter-input-text")
-        .type("sleep.7084272b-6b76-11e5-a953-08002719334a", { force: true });
+      cy.get(".filter-bar-item .filter-input-text").type(
+        "sleep.7084272b-6b76-11e5-a953-08002719334a",
+        { force: true }
+      );
       cy.get("tbody tr").should(function($tableRows) {
         expect(getVisibleTableRows($tableRows).length).to.equal(1);
       });

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -934,7 +934,7 @@ describe("Service Form Modal", function() {
       }
 
       context("Network Type", function() {
-        it('has all available types when "Docker Engine" selected', function() {
+        it('has all available enabled types when "Docker Engine" selected', function() {
           setRuntime("Docker Engine");
           clickNetworkingTab();
 
@@ -965,9 +965,20 @@ describe("Service Form Modal", function() {
             .children("option:eq(3)")
             .should("have.value", "CONTAINER.dcos-2")
             .should("not.have.attr", "disabled");
+
+          // dcos-3
+          cy.get("@containerDockerNetwork")
+            .children("option:eq(4)")
+            .should("have.value", "CONTAINER.dcos-3")
+            .should("not.have.attr", "disabled");
+
+          // dcos-4
+          cy.get("@containerDockerNetwork")
+            .children("option:eq(5)")
+            .should("not.have.value", "CONTAINER.dcos-4");
         });
 
-        it('has all available types when "Universal Container Runtime (UCR)" selected', function() {
+        it('has all available enabled types without subnet6 when "Universal Container Runtime (UCR)" selected', function() {
           setRuntime("Universal Container Runtime (UCR)");
           clickNetworkingTab();
 
@@ -998,6 +1009,16 @@ describe("Service Form Modal", function() {
             .children("option:eq(3)")
             .should("have.value", "CONTAINER.dcos-2")
             .should("not.have.attr", "disabled");
+
+          // dcos-3
+          cy.get("@containerDockerNetwork")
+            .children("option:eq(4)")
+            .should("not.have.value", "CONTAINER.dcos-3");
+
+          // dcos-4
+          cy.get("@containerDockerNetwork")
+            .children("option:eq(4)")
+            .should("not.have.value", "CONTAINER.dcos-4");
         });
       });
 


### PR DESCRIPTION
Make the virtual network dcos6 unavailable
when UCR is chosen as a container.

Closes DCOS_OSS-4632

## Testing
1. Go to Services tab
2. Create a new Single Container service
3. On the Service tab, click "More Settings" at the bottom and select "Universal Container Runtime (UCR)" for Container Runtime.
4. Go to Networking type, open the Network Type dropdown and verify that "dcos6" is not shown.

## Trade-offs
None.

## Dependencies
None.

## Screenshots
![peek 2019-01-24 16-29](https://user-images.githubusercontent.com/40791275/51684756-77de0b80-1ff5-11e9-925f-d5df38a8691d.gif)

