### PR TITLE
DCOS-47685: [1.11] DC/OS Enterprise CLI description is wrong

### DIFF
--- a/src/js/pages/catalog/PackageDetailTab.js
+++ b/src/js/pages/catalog/PackageDetailTab.js
@@ -275,7 +275,7 @@ class PackageDetailTab extends mixin(StoreMixin) {
             {"This package can only be installed using the CLI. See the "}
             <a
               href={MetadataStore.buildDocsURI(
-                "/cli/command-reference/dcos-service/"
+                "/cli/command-reference/dcos-package/dcos-package-install/"
               )}
               target="_blank"
             >


### PR DESCRIPTION
It currently points to `dcos service`, it'd be more useful to show the
`dcos package install` command instead.

Closes https://jira.mesosphere.com/browse/DCOS-47685

For testing, screenshots, etc. see https://github.com/dcos/dcos-ui/pull/3550
