### PR TITLE
DCOS-47686: [1.10] DC/OS Enterprise CLI description is wrong

### DIFF
--- a/src/js/pages/catalog/PackageDetailTab.js
+++ b/src/js/pages/catalog/PackageDetailTab.js
@@ -201,7 +201,7 @@ class PackageDetailTab extends mixin(StoreMixin) {
             {"This package can only be installed using the CLI. See the "}
             <a
               href={MetadataStore.buildDocsURI(
-                "/cli/enterprise-cli/#ent-cli-install"
+                "/cli/command-reference/dcos-package/dcos-package-install/"
               )}
               target="_blank"
             >


### PR DESCRIPTION
It currently points to `dcos service`, it'd be more useful to show the
`dcos package install` command instead.

Closes https://jira.mesosphere.com/browse/DCOS-47686

For testing, screenshots, etc. see https://github.com/dcos/dcos-ui/pull/3550