### PR TITLE
chore(system-tests): fix dev.sh config

### DIFF
--- a/system-tests/driver-config/dev.sh
+++ b/system-tests/driver-config/dev.sh
@@ -29,10 +29,10 @@ targets:
 
     scripts:
       auth: ../_scripts/auth-open.py
-      proxy: (cd ../..; npm run testing)
+      proxy: (cd ../..; npm start)
       setup: >
         mv ../../webpack/proxy.dev.js ../../webpack/proxy.dev.js.bak;
-        echo "module.exports = {'*': '$CLUSTER_URL'};" > ../../webpack/proxy.dev.js
+        echo "module.exports = { '*': { target: '$CLUSTER_URL', secure: false } };" > ../../webpack/proxy.dev.js
       teardown: >
         mv ../../webpack/proxy.dev.js.bak ../../webpack/proxy.dev.js
 EOF


### PR DESCRIPTION
Few adjustments to enable system-tests on dev env.

1. `$ docker-compose toolchain run bash`
1. create cypress cache dir `mkdir /root/.cache/Cypress`
1. install cypress binary `/dcos-ui/node_modules/cypress/bin/cypress install`
2. remove node from node_modules `rm -rf /dcos-ui/node_modules/node`
