### PR TITLE
DCOS-47799: [1.12] Typo: "Jobss" on jobs page search

### DIFF
--- a/plugins/jobs/src/js/components/JobsOverviewList.tsx
+++ b/plugins/jobs/src/js/components/JobsOverviewList.tsx
@@ -56,7 +56,7 @@ export default class JobsOverviewList extends React.Component<
     const headline = filter ? (
       <FilterHeadline
         onReset={this.resetFilter}
-        name="Jobs"
+        name="Job"
         currentLength={data.filteredCount}
         totalLength={data.totalCount}
       />


### PR DESCRIPTION
Make the Job string to be pluralized only once

Closes https://jira.mesosphere.com/browse/DCOS-47799

## Testing
In Jobs tab search something when two or more jobs exist and verify that "Job" isn't pluralized twice.

## Trade-offs
When I updated the catalog messages, two lines unrelated to this PR appeared, we probably forgot them before.

## Dependencies
None.

## Screenshots

### Before
![screenshot from 2019-01-29 13-29-57](https://user-images.githubusercontent.com/40791275/51905713-a2034500-23ca-11e9-8f36-fee691c7331a.png)

### After
![screenshot from 2019-01-29 13-31-47](https://user-images.githubusercontent.com/40791275/51905717-a4fe3580-23ca-11e9-89d9-830fea91bc7d.png)
