### PR TITLE
DCOS-47798: [1.10] Typo: "Jobss" on jobs page search

### DIFF
--- a/src/js/pages/jobs/JobsTab.js
+++ b/src/js/pages/jobs/JobsTab.js
@@ -129,7 +129,7 @@ class JobsTab extends mixin(StoreMixin) {
       return (
         <FilterHeadline
           onReset={this.resetFilter}
-          name="Jobs"
+          name="Job"
           currentLength={filteredJobs.length}
           totalLength={jobs.length}
         />


### PR DESCRIPTION
Make the Job string to be pluralized only once

Closes https://jira.mesosphere.com/browse/DCOS-47798

## Testing
In Jobs tab search something when two or more jobs exist and verify that "Job" isn't pluralized twice.

## Trade-offs
When I updated the catalog messages, two lines unrelated to this PR appeared, we probably forgot them before.

## Dependencies
None.

## Screenshots

### Before
![screenshot from 2019-01-29 13-42-56](https://user-images.githubusercontent.com/40791275/51906277-7c773b00-23cc-11e9-9d93-bbb7bb755ccb.png)

### After
![screenshot from 2019-01-29 13-43-34](https://user-images.githubusercontent.com/40791275/51906295-84cf7600-23cc-11e9-94a0-8a21759b4851.png)
