### PR TITLE
DCOS-47801: [1.11] Typo: "Jobss" on jobs page search

### DIFF
--- a/src/js/pages/catalog/PackageDetailTab.js
+++ b/src/js/pages/catalog/PackageDetailTab.js
@@ -275,7 +275,7 @@ class PackageDetailTab extends mixin(StoreMixin) {
             {"This package can only be installed using the CLI. See the "}
             <a
               href={MetadataStore.buildDocsURI(
-                "/cli/command-reference/dcos-service/"
+                "/cli/command-reference/dcos-package/dcos-package-install/"
               )}
               target="_blank"
             >

--- a/src/js/pages/jobs/JobsTab.js
+++ b/src/js/pages/jobs/JobsTab.js
@@ -130,7 +130,7 @@ class JobsTab extends mixin(StoreMixin) {
       return (
         <FilterHeadline
           onReset={this.resetFilter}
-          name="Jobs"
+          name="Job"
           currentLength={filteredJobs.length}
           totalLength={jobs.length}
         />


### PR DESCRIPTION
Make the Job string to be pluralized only once

Closes https://jira.mesosphere.com/browse/DCOS-47801

## Testing
In Jobs tab search something when two or more jobs exist and verify that "Job" isn't pluralized twice.

## Trade-offs
When I updated the catalog messages, two lines unrelated to this PR appeared, we probably forgot them before.

## Dependencies
None.

## Screenshots
See https://github.com/dcos/dcos-ui/pull/3568
