### PR TITLE
DCOS-47960 Publish nightly dcos-ui as "nightly" instead of "2.24.4"

### DIFF
--- a/universe/package.json
+++ b/universe/package.json
@@ -1,7 +1,7 @@
 {
   "packagingVersion": "4.0",
   "name": "dcos-ui",
-  "version": "2.24.4",
+  "version": "nightly",
   "tags": ["dcos-ui", "dcos", "ui"],
   "maintainer": "frontend-dev@mesosphere.io",
   "description": "DC/OS UI",


### PR DESCRIPTION
## Testing

Not really testable as this is done on merge

## Trade-offs

N/A

## Dependencies

[dcos-ui-update-service #24](https://github.com/dcos/dcos-ui-update-service/pull/24) will need to merge and land before these nightly versions can be installed. but that shouldn't prevent this from merging

## Screenshots

N/A
