### PR TITLE
[spike] DCOS-46215: Error requesting UI Configuration message email is shown as {0}

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1097,7 +1097,7 @@
   "You are about to stop the selected job runs.": "",
   "You are about to {0} {instanceCountContent}. Are you sure you want to continue?": "",
   "You are about to {0} {taskCountContent}. Are you sure you want to continue?": "",
-  "You can also join us on our <0>Slack channel</0> or send us an email at": "",
+  "You can also join us on our <0>Slack channel</0> or send us an email at <1></1>.": "",
   "You can configure the placement of agent nodes in regions and zones for high availability or to expand capacity to new regions when necessary": "",
   "You can go to the <0>Repositories Settings</0> page to change installed repositories.": "",
   "You can link a cluster via the DC/OS CLI. See {documentation} for complete instructions.": "",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1097,7 +1097,7 @@
   "You are about to stop the selected job runs.": "",
   "You are about to {0} {instanceCountContent}. Are you sure you want to continue?": "",
   "You are about to {0} {taskCountContent}. Are you sure you want to continue?": "",
-  "You can also join us on our <0>Slack channel</0> or send us an email at <1>{0}</1>.": "",
+  "You can also join us on our <0>Slack channel</0> or send us an email at": "",
   "You can configure the placement of agent nodes in regions and zones for high availability or to expand capacity to new regions when necessary": "",
   "You can go to the <0>Repositories Settings</0> page to change installed repositories.": "",
   "You can link a cluster via the DC/OS CLI. See {documentation} for complete instructions.": "",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -1097,7 +1097,7 @@
   "You are about to stop the selected job runs.": "您即将停止所选作业运行。",
   "You are about to {0} {instanceCountContent}. Are you sure you want to continue?": "您即将 {0} {instanceCountContent}。确定要继续吗？",
   "You are about to {0} {taskCountContent}. Are you sure you want to continue?": "您即将 {0} {taskCountContent}。确定要继续吗？",
-  "You can also join us on our <0>Slack channel</0> or send us an email at <1>{0}</1>.": "您也可以通过 <0>Slack channel</0> 加入我们或发送电子邮件至 <1>{0}</1>.",
+  "You can also join us on our <0>Slack channel</0> or send us an email at": "您也可以通过 <0>Slack channel</0> 加入我们或发送电子邮件至",
   "You can configure the placement of agent nodes in regions and zones for high availability or to expand capacity to new regions when necessary": "您可以配置区域和区中代理节点的放置以实现高可用性，或在必要时将容量扩展到新区域",
   "You can go to the <0>Repositories Settings</0> page to change installed repositories.": "您可以转到 <0>存储库设置</0> 页面，来更改已安装的存储库。",
   "You can link a cluster via the DC/OS CLI. See {documentation} for complete instructions.": "您可以通过 DC/OS CLI 链接集群。参见 {documentation}，以获取完整说明。",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -1097,7 +1097,7 @@
   "You are about to stop the selected job runs.": "您即将停止所选作业运行。",
   "You are about to {0} {instanceCountContent}. Are you sure you want to continue?": "您即将 {0} {instanceCountContent}。确定要继续吗？",
   "You are about to {0} {taskCountContent}. Are you sure you want to continue?": "您即将 {0} {taskCountContent}。确定要继续吗？",
-  "You can also join us on our <0>Slack channel</0> or send us an email at": "您也可以通过 <0>Slack channel</0> 加入我们或发送电子邮件至",
+  "You can also join us on our <0>Slack channel</0> or send us an email at <1></1>.": "",
   "You can configure the placement of agent nodes in regions and zones for high availability or to expand capacity to new regions when necessary": "您可以配置区域和区中代理节点的放置以实现高可用性，或在必要时将容量扩展到新区域",
   "You can go to the <0>Repositories Settings</0> page to change installed repositories.": "您可以转到 <0>存储库设置</0> 页面，来更改已安装的存储库。",
   "You can link a cluster via the DC/OS CLI. See {documentation} for complete instructions.": "您可以通过 DC/OS CLI 链接集群。参见 {documentation}，以获取完整说明。",

--- a/src/js/components/RequestErrorMsg.js
+++ b/src/js/components/RequestErrorMsg.js
@@ -9,14 +9,16 @@ import Config from "../config/Config";
 
 function getDefaultMessage() {
   return (
-    <Trans render="p" className="text-align-center flush-bottom">
-      You can also join us on our{" "}
-      <a href={Config.slackChannel} target="_blank">
-        Slack channel
-      </a>{" "}
-      or send us an email at{" "}
+    <p className="text-align-center flush-bottom">
+      <Trans>
+        You can also join us on our{" "}
+        <a href={Config.slackChannel} target="_blank">
+          Slack channel
+        </a>{" "}
+        or send us an email at
+      </Trans>{" "}
       <a href={`mailto:${Config.supportEmail}`}>{Config.supportEmail}</a>.
-    </Trans>
+    </p>
   );
 }
 

--- a/src/js/components/RequestErrorMsg.js
+++ b/src/js/components/RequestErrorMsg.js
@@ -10,14 +10,13 @@ import Config from "../config/Config";
 function getDefaultMessage() {
   return (
     <p className="text-align-center flush-bottom">
-      <Trans>
-        You can also join us on our{" "}
-        <a href={Config.slackChannel} target="_blank">
-          Slack channel
-        </a>{" "}
-        or send us an email at
-      </Trans>{" "}
-      <a href={`mailto:${Config.supportEmail}`}>{Config.supportEmail}</a>.
+      <Trans
+        id="You can also join us on our <0>Slack channel</0> or send us an email at <1></1>."
+        components={[
+          <a href={Config.slackChannel} target="_blank" />,
+          <a href={`mailto:${Config.supportEmail}`}>{Config.supportEmail}</a>
+        ]}
+      />
     </p>
   );
 }


### PR DESCRIPTION
Change the error message function in order to show the email.

Closes https://jira.mesosphere.com/browse/DCOS-46215

## Testing
1. In `proxy.dev.js` use an outdated cluster url and run `npm start`.
2. Verify that the email is shown on the error page

## Trade-offs
The message appears in English, even when the language is changed to Chinese, I am not sure why.

## Dependencies
https://github.com/mesosphere/dcos-ui-plugins-private/pull/926

## Screenshots

### Before
![screenshot from 2018-12-13 13-28-19](https://user-images.githubusercontent.com/40791275/52131710-1d245f80-2646-11e9-9bcb-f90f555129ba.png)

### After
![screenshot from 2019-02-01 16-48-26](https://user-images.githubusercontent.com/40791275/52131719-2281aa00-2646-11e9-94d1-6f52943f6873.png)
