### PR TITLE
DCOS-47925: remove manual trigger for rerun script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -477,12 +477,9 @@ Alternatively you can run cypress from the command line.
 We have tooling to check if a test case (or the implementation) is flaky.
 
 1.  Open up a PR with your changes
-2.  Add a `.only` on the test case you want to check
-3.  Click on the `continuous-integration/jenkins/pr-head` and navigate to the old view (square symbol with arrow on the top right corner)
-4.  Navigate to the PR in Jenkins by clicking the PR name on the breadcrumbs
-5.  Click "Build with Parameters" on the left sidebar to and run the job with "shouldRun" checked
-6.  Wait for the `100` runs to finish
-7.  Check the result on the PR notification. If there is still a flake `continuous-integration/jenkins/pr-head` should be red.
+2.  Add a `.only` on the test case you want to check and push the commit
+3.  Wait for the `100` runs to finish
+4.  Check the result on the PR status. If there is still a flake `continuous-integration/jenkins/pr-head` should be red.
 
 If you want to test more runs you can change the number in `Jenkinsfile.reruns`.
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,6 +40,7 @@ pipeline {
         sh "git fetch"
         sh "git checkout \"\$([ -z \"\$CHANGE_BRANCH\" ] && echo \$BRANCH_NAME || echo \$CHANGE_BRANCH )\""
 
+        sh "npm run validate-tests"
         sh "npm --unsafe-perm ci"
         sh "npm run build"
       }

--- a/Jenkinsfile.reruns
+++ b/Jenkinsfile.reruns
@@ -11,10 +11,6 @@ pipeline {
     }
   }
 
-  parameters {
-    booleanParam(defaultValue: false, description: 'Should this job be executed?', name: 'shouldRun')
-  }
-
   environment {
     JENKINS_VERSION = "yes"
     NODE_PATH = "node_modules"
@@ -34,12 +30,6 @@ pipeline {
     }
 
     stage("Build") {
-      when {
-        expression {
-          return params.shouldRun
-        }
-      }
-
       steps {
         sh "npm --unsafe-perm ci"
         sh "npm run build-assets"
@@ -47,20 +37,14 @@ pipeline {
     }
 
     stage("Tests") {
-      when {
-        expression {
-          return params.shouldRun
-        }
-      }
-
       steps {
         sh "REPORT=false RERUN=100 npm run rerun:integration-tests"
       }
 
       post {
         always {
-          archiveArtifacts "cypress/**/*"
-          junit "cypress/results.xml"
+          archiveArtifacts artifacts: "cypress/**/*", allowEmptyArchive: true
+          junit testResults: "cypress/results.xml", allowEmptyResults: true
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "prebuild-assets": "./node_modules/.bin/gulp checkDependencies",
     "build-assets": "npm run clean && lingui compile && NODE_ENV=production webpack --colors --config ./webpack/webpack.production.js",
     "postbuild-assets": "find ./dist -name 'index.*.css' -exec node ./scripts/inline-bootstrap-css.js ./dist/index.html {} \\;",
-    "prebuild": "PLUGINS_PATH=\"${npm_config_externalplugins}\" ./scripts/validate-tests",
+    "validate-tests": "PLUGINS_PATH=\"${npm_config_externalplugins}\" ./scripts/validate-tests",
     "build": "npm run lint && ([ -z \"${npm_config_externalplugins}\" ] || npm run lint-plugins) && npm test && npm run build-assets && npm run validate-build",
     "lint": "npm run stylelint && npm run eslint && npm run tslint",
     "eslint": "bash -c 'opts=$@ ; set -f; if [[ $# -lt 1 ]]; then opts=\"{src/js,plugins,packages}/**/*.js\"; fi ; eslint --quiet ${opts}' 0",

--- a/scripts/ci/rerun-integration-tests.sh
+++ b/scripts/ci/rerun-integration-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-
 set -e
+
 # configurable by environment variable
 RERUNS=${RERUNS:-100}
 
@@ -13,9 +13,13 @@ PROJECT_ROOT="$( cd "$( echo "${SCRIPT_PATH}" | sed s+/scripts/ci++)" && pwd )"
 source "$SCRIPT_PATH/../utils/test"
 source "$SCRIPT_PATH/../utils/integration-tests"
 
+# This aborts if no files are found
+if [ -z $(find_files_with_debug_directives "$PROJECT_ROOT/$TESTS_FOLDER") ]; then
+  echo "No files found to run, aborting"
+  exit 0
+fi
 
 # Get all files with .only in it
-# This aborts if no files are found
 FILES_TO_RUN="$(find_files_with_debug_directives "$PROJECT_ROOT/$TESTS_FOLDER")"
 
 setup


### PR DESCRIPTION
## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

- Check if this branch has a job with `head` that was triggered automatically without a manual check and ran successfully without rerunning the tests
- Check if this branch has a job with `head` that was triggered automatically without a manual check and ran successfully with rerunning a subset of tests
- Check if a `.only` in an integration test can be commited without a warning, renders the `merge` test red, but triggers the `branch` test to run reruns


## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

- Decided that ~10min of work for not running is okay, compared to maintaining an extra check before the tests run. As always, feel free to challenge me on this 😇 

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
