### PR TITLE
DCOS-44840: feature public ip add network nodes endpoint client

### DIFF
--- a/plugins/nodes/src/js/data/NodesNetworkClient.ts
+++ b/plugins/nodes/src/js/data/NodesNetworkClient.ts
@@ -1,0 +1,35 @@
+import { Observable, merge } from "rxjs";
+import { request, RequestResponse } from "@dcos/http-service";
+import { partition, tap } from "rxjs/operators";
+
+export interface NodeNetwork {
+  updated: string;
+  public_ips: string[];
+  private_ip: string;
+  hostname: string;
+}
+
+export type NodesNetwork = NodeNetwork[];
+
+export function fetchNodesNetwork(): Observable<RequestResponse<NodesNetwork>> {
+  const [success, error] = partition(
+    (response: RequestResponse<NodesNetwork>) => response.code < 300
+  )(request("/net/v1/nodes"));
+
+  return merge(
+    success,
+    error.pipe(
+      tap((response: RequestResponse<NodesNetwork>) => {
+        const responseMessage =
+          response.response && typeof response.response === "object"
+            ? JSON.stringify(response.response)
+            : response.response;
+        throw new Error(
+          `Network Nodes API request failed: ${response.code} ${
+            response.message
+          }:${responseMessage}`
+        );
+      })
+    )
+  );
+}

--- a/plugins/nodes/src/js/data/__tests__/NodesNetworkClient-test.ts
+++ b/plugins/nodes/src/js/data/__tests__/NodesNetworkClient-test.ts
@@ -1,0 +1,73 @@
+const mockRequest = jest.fn();
+jest.mock("@dcos/http-service", () => ({
+  request: mockRequest
+}));
+
+import { from } from "rxjs";
+import { marbles } from "rxjs-marbles/jest";
+import { take } from "rxjs/operators";
+
+import * as NodesNetworkClient from "../NodesNetworkClient";
+
+describe("Network Nodes Client", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("makes a request", () => {
+    mockRequest.mockReturnValueOnce(from([{}]));
+    NodesNetworkClient.fetchNodesNetwork();
+    expect(mockRequest).toHaveBeenCalled();
+  });
+
+  it(
+    "emits an event when the data is received",
+    marbles(m => {
+      const expectedResult = [
+        {
+          updated: "2019-02-04T14:17:12.697Z",
+          public_ips: ["18.185.33.115"],
+          private_ip: "10.0.6.192",
+          hostname: "ip-10-0-6-192"
+        }
+      ];
+      const expected$ = m.cold("--(j|)", {
+        j: {
+          response: expectedResult,
+          code: 200,
+          message: "OK"
+        }
+      });
+
+      mockRequest.mockReturnValueOnce(expected$);
+
+      const result$ = NodesNetworkClient.fetchNodesNetwork().pipe(take(1));
+      m.expect(result$).toBeObservable(expected$);
+    })
+  );
+
+  it(
+    "emits an error if non-2XX API response",
+    marbles(m => {
+      const mockResult$ = m.cold("--j", {
+        j: {
+          code: 500,
+          message: "Internal Server Error",
+          response: ["Backend Error :-("]
+        }
+      });
+
+      mockRequest.mockReturnValueOnce(mockResult$);
+
+      const result$ = NodesNetworkClient.fetchNodesNetwork();
+
+      const expected$ = m.cold("--#", undefined, {
+        message:
+          'Network Nodes API request failed: 500 Internal Server Error:["Backend Error :-("]',
+        name: "Error"
+      });
+
+      m.expect(result$).toBeObservable(expected$);
+    })
+  );
+});


### PR DESCRIPTION
This adds a http client which connects to the `/net/v1/nodes` endpoint and is returning a observable

Closes DCOS-44840

## Testing

You can test it by running the test and sanity check the code. Also you could do the following changes
```diff
diff --git a/plugins/nodes/src/js/components/NodesTable.tsx b/plugins/nodes/src/js/components/NodesTable.tsx
index 867ca1b3d..6b7aedbe9 100644
--- a/plugins/nodes/src/js/components/NodesTable.tsx
+++ b/plugins/nodes/src/js/components/NodesTable.tsx
@@ -29,6 +29,10 @@ import {
   spacingRenderer
 } from "../columns/NodesTableSpacingColumn";
 
+import * as NetworkNodesClient from "../data/NetworkNodesClient";
+
+console.log(NetworkNodesClient);
+
 interface NodesTableProps {
   hosts: NodesList;
   nodeHealthResponse: boolean;
diff --git a/plugins/nodes/src/js/data/NetworkNodesClient.ts b/plugins/nodes/src/js/data/NetworkNodesClient.ts
index c5f8f87e0..848b95f95 100644
--- a/plugins/nodes/src/js/data/NetworkNodesClient.ts
+++ b/plugins/nodes/src/js/data/NetworkNodesClient.ts
@@ -30,3 +30,5 @@ export function fetchNetworkNodes(): Observable<RequestResponse<string[]>> {
     })
   );
 }
+
+window.test = fetchNetworkNodes;

```

Alternatively you can run the following command `curl https://gist.githubusercontent.com/Poltergeist/c11cc88857748e91c317eea536a1903a/raw/ebc585ed08fa4f804c640ff1025d1bca73be7f5f/dcos-44840-test.diff | git apply`

And run `window.test().subscribe(a=>console.log(a))` from the console in your browser this should give you the response from the `/net/v1/nodes` endpoint.

## Trade-offs

N/A

## Dependencies

N/A

## Screenshots

N/A