### PR TITLE
fix log scroll view for Chrome and Firefox

### DIFF
--- a/src/styles/components/log-view/styles.less
+++ b/src/styles/components/log-view/styles.less
@@ -4,5 +4,6 @@
     color: @white;
     overflow: auto;
     position: relative;
+    height: 1px;
   }
 }


### PR DESCRIPTION
In response to https://jira.mesosphere.com/browse/DCOS_OSS-4768

Adds a very small height on the `.log-view` which forces the browsers to scroll. 
##Test System
OS: MacOS Mojave
Browsers: 
- Firefox Quantom 65.0
- Chrome 72.0.3626.81 (Official Build) (64-bit)
- Safari Version 12.0.2 (14606.3.4) (non-issue)

