### PR TITLE
DCOS-44841: add network node resolver

### DIFF
--- a/plugins/nodes/src/js/data/NodesNetworkClient.ts
+++ b/plugins/nodes/src/js/data/NodesNetworkClient.ts
@@ -1,25 +1,43 @@
-import { Observable, merge } from "rxjs";
 import { request, RequestResponse } from "@dcos/http-service";
+import { merge, Observable } from "rxjs";
 import { partition, tap } from "rxjs/operators";
 
 export interface NodeNetwork {
-  updated: string;
+  updated: string | Date;
   public_ips: string[];
   private_ip: string;
   hostname: string;
 }
 
-export type NodesNetwork = NodeNetwork[];
+export interface NodeNetworkResponse extends NodeNetwork {
+  updated: string;
+}
 
-export function fetchNodesNetwork(): Observable<RequestResponse<NodesNetwork>> {
+export type NodesNetwork = NodeNetwork[];
+export type NodesNetworkResponse = NodeNetworkResponse[];
+
+export const NodeNetworkSchema = `
+scalar Date
+
+type NodeNetwork {
+  updated: Date
+  public_ips: [String]
+  private_ip: String
+  hostname: String
+}
+`;
+
+export function fetchNodesNetwork(): Observable<
+  RequestResponse<NodesNetworkResponse>
+> {
   const [success, error] = partition(
-    (response: RequestResponse<NodesNetwork>) => response.code < 300
+    (response: RequestResponse<NodesNetworkResponse>) => response.code < 300
   )(request("/net/v1/nodes"));
 
   return merge(
     success,
     error.pipe(
-      tap((response: RequestResponse<NodesNetwork>) => {
+      tap((response: RequestResponse<NodesNetworkResponse>) => {
         const responseMessage =
           response.response && typeof response.response === "object"
             ? JSON.stringify(response.response)

--- a/plugins/nodes/src/js/data/NodesResolver.ts
+++ b/plugins/nodes/src/js/data/NodesResolver.ts
@@ -1,0 +1,124 @@
+import { RequestResponse } from "@dcos/http-service";
+import { makeExecutableSchema } from "graphql-tools";
+import { Observable, of, throwError, timer } from "rxjs";
+import { map, share, switchMap } from "rxjs/operators";
+
+import Config from "#SRC/js/config/Config";
+
+import {
+  fetchNodesNetwork,
+  NodeNetwork,
+  NodeNetworkSchema,
+  NodesNetwork
+} from "./NodesNetworkClient";
+
+export interface ResolverArgs {
+  fetchNodesNetwork: () => Observable<RequestResponse<NodesNetwork>>;
+  pollingInterval: number;
+}
+
+export interface GeneralArgs {
+  privateIP?: string;
+  privateIPs?: string[];
+}
+
+export interface NodeQueryArgs {
+  privateIP: string;
+}
+
+export interface NodesQueryArgs {
+  privateIPs: string[];
+}
+
+function isNodeQueryArgs(args: GeneralArgs): args is NodeQueryArgs {
+  return typeof (args as NodeQueryArgs).privateIP === "string";
+}
+
+function isNodesQueryArgs(args: GeneralArgs): args is NodesQueryArgs {
+  return Array.isArray((args as NodesQueryArgs).privateIPs);
+}
+
+export const resolvers = ({
+  fetchNodesNetwork,
+  pollingInterval
+}: ResolverArgs) => {
+  const pollingInterval$ = timer(0, pollingInterval);
+  const nodes$ = pollingInterval$.pipe(
+    switchMap(() => fetchNodesNetwork()),
+    share()
+  );
+
+  return {
+    Node: {
+      network(parent: { privateIP: string }) {
+        return nodes$.pipe(
+          map(
+            (reqResp: RequestResponse<NodesNetwork>): NodesNetwork => {
+              return [
+                ...reqResp.response.map(item => ({
+                  ...item,
+                  updated: new Date(item.updated)
+                }))
+              ];
+            }
+          ),
+          map(
+            (networkNodes: NodesNetwork) =>
+              networkNodes.find(
+                ({ private_ip }) => private_ip === parent.privateIP
+              ) || {}
+          )
+        );
+      }
+    },
+    Query: {
+      node(_parent = {}, args: GeneralArgs) {
+        if (!isNodeQueryArgs(args)) {
+          return throwError(
+            "Nodes resolver arguments aren't valid for type nodesQueryArgs"
+          );
+        }
+        return of({ hostname: args.privateIP, privateIP: args.privateIP });
+      },
+      nodes(_parent = {}, args: GeneralArgs) {
+        if (!isNodesQueryArgs(args)) {
+          return throwError(
+            "Nodes resolver arguments aren't valid for type nodesQueryArgs"
+          );
+        }
+
+        return of(
+          args.privateIPs.map((privateIP: string) => ({
+            hostname: privateIP,
+            privateIP
+          }))
+        );
+      }
+    }
+  };
+};
+
+const baseSchema = `
+type Node {
+  hostname: String
+  network: NodeNetwork
+}
+
+type Query {
+  nodes(privateIPs: [String!]!): [Node]
+  node(privateIP: String!): Node
+}`;
+
+export const schemas: string[] = [NodeNetworkSchema, baseSchema];
+
+export interface Query {
+  network: NodeNetwork | null;
+}
+
+export default makeExecutableSchema({
+  typeDefs: schemas,
+  resolvers: resolvers({
+    fetchNodesNetwork,
+    pollingInterval: Config.getRefreshRate()
+  })
+});

--- a/plugins/nodes/src/js/data/__tests__/NodesResolver-test.ts
+++ b/plugins/nodes/src/js/data/__tests__/NodesResolver-test.ts
@@ -1,0 +1,602 @@
+const mockRequest = jest.fn();
+jest.mock("@dcos/http-service", () => ({
+  request: mockRequest
+}));
+import { NodesNetworkResponse } from "../NodesNetworkClient";
+
+import { of } from "rxjs";
+import { take } from "rxjs/operators";
+import { marbles } from "rxjs-marbles/jest";
+import { makeExecutableSchema } from "graphql-tools";
+import { graphqlObservable } from "@dcos/data-service";
+import gql from "graphql-tag";
+
+import { schemas, resolvers } from "../NodesResolver";
+
+function makeFakeNodesNetworkResponse(): NodesNetworkResponse {
+  return [
+    {
+      updated: "2019-02-05T13:12:00.979Z",
+      public_ips: ["3.2.2.96"],
+      private_ip: "13.0.6.125",
+      hostname: "ip-13-0-6-125"
+    },
+    {
+      updated: "2019-02-05T13:10:47.965Z",
+      public_ips: ["3.2.2.134"],
+      private_ip: "13.0.6.96",
+      hostname: "ip-13-0-6-96"
+    },
+    {
+      updated: "2019-02-05T13:12:01.553Z",
+      public_ips: [],
+      private_ip: "13.0.1.42",
+      hostname: "ip-13-0-1-42"
+    }
+  ];
+}
+
+function makeResolverConfig(m: any) {
+  return {
+    fetchNodesNetwork: () =>
+      m.cold("(j|)", {
+        j: {
+          code: 200,
+          message: "ok",
+          response: makeFakeNodesNetworkResponse()
+        }
+      }),
+    pollingInterval: m.time("--|")
+  };
+}
+
+describe("Nodes data-layer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("nodes", () => {
+    describe("network", () => {
+      it(
+        "handles a graphql query",
+        marbles(m => {
+          const nodesSchema = makeExecutableSchema({
+            typeDefs: schemas,
+            resolvers: resolvers(makeResolverConfig(m))
+          });
+
+          const query = gql`
+            query {
+              nodes(privateIPs: $privateIPs) {
+                hostname
+                network {
+                  public_ips
+                }
+              }
+            }
+          `;
+
+          const queryResult$ = graphqlObservable(query, nodesSchema, {
+            privateIPs: ["13.0.6.96", "13.0.6.125"]
+          });
+
+          const result$ = queryResult$.pipe(take(1));
+
+          const expected$ = m.cold("(j|)", {
+            j: {
+              data: {
+                nodes: [
+                  {
+                    hostname: "13.0.6.96",
+                    network: {
+                      public_ips: ["3.2.2.134"]
+                    }
+                  },
+                  {
+                    hostname: "13.0.6.125",
+                    network: {
+                      public_ips: ["3.2.2.96"]
+                    }
+                  }
+                ]
+              }
+            }
+          });
+
+          m.expect(result$).toBeObservable(expected$);
+        })
+      );
+
+      it(
+        "returns a full network object",
+        marbles(m => {
+          const nodesSchema = makeExecutableSchema({
+            typeDefs: schemas,
+            resolvers: resolvers(makeResolverConfig(m))
+          });
+
+          const query = gql`
+            query {
+              nodes(privateIPs: $privateIPs) {
+                hostname
+                network {
+                  public_ips
+                  hostname
+                  private_ip
+                  updated
+                }
+              }
+            }
+          `;
+
+          const queryResult$ = graphqlObservable(query, nodesSchema, {
+            privateIPs: ["13.0.6.96", "13.0.6.125"]
+          });
+
+          const result$ = queryResult$.pipe(take(1));
+
+          const expected$ = m.cold("(j|)", {
+            j: {
+              data: {
+                nodes: [
+                  {
+                    hostname: "13.0.6.96",
+                    network: {
+                      updated: new Date("2019-02-05T13:10:47.965Z"),
+                      public_ips: ["3.2.2.134"],
+                      private_ip: "13.0.6.96",
+                      hostname: "ip-13-0-6-96"
+                    }
+                  },
+                  {
+                    hostname: "13.0.6.125",
+                    network: {
+                      updated: new Date("2019-02-05T13:12:00.979Z"),
+                      public_ips: ["3.2.2.96"],
+                      private_ip: "13.0.6.125",
+                      hostname: "ip-13-0-6-125"
+                    }
+                  }
+                ]
+              }
+            }
+          });
+
+          m.expect(result$).toBeObservable(expected$);
+        })
+      );
+      it(
+        "Does not fail if one network is not yet available",
+        marbles(m => {
+          const nodesSchema = makeExecutableSchema({
+            typeDefs: schemas,
+            resolvers: resolvers(makeResolverConfig(m))
+          });
+
+          const query = gql`
+            query {
+              nodes(privateIPs: $privateIPs) {
+                hostname
+                network {
+                  public_ips
+                  hostname
+                  private_ip
+                  updated
+                }
+              }
+            }
+          `;
+
+          const queryResult$ = graphqlObservable(query, nodesSchema, {
+            privateIPs: ["13.0.6.96", "13.0.6.126"]
+          });
+
+          const result$ = queryResult$.pipe(take(1));
+
+          const expected$ = m.cold("(j|)", {
+            j: {
+              data: {
+                nodes: [
+                  {
+                    hostname: "13.0.6.96",
+                    network: {
+                      updated: new Date("2019-02-05T13:10:47.965Z"),
+                      public_ips: ["3.2.2.134"],
+                      private_ip: "13.0.6.96",
+                      hostname: "ip-13-0-6-96"
+                    }
+                  },
+                  {
+                    hostname: "13.0.6.126",
+                    network: {}
+                  }
+                ]
+              }
+            }
+          });
+
+          m.expect(result$).toBeObservable(expected$);
+        })
+      );
+
+      it(
+        "polls the endpoint for 1 item",
+        marbles(m => {
+          const fetchNodesNetwork = () => {
+            return m.cold("j|", {
+              j: {
+                code: 200,
+                message: "ok",
+                response: [
+                  {
+                    updated: "2019-02-05T13:10:47.965Z",
+                    public_ips: ["3.2.2.134"],
+                    private_ip: "13.0.6.96",
+                    hostname: "ip-13-0-6-96"
+                  }
+                ]
+              }
+            });
+          };
+          const nodesSchema = makeExecutableSchema({
+            typeDefs: schemas,
+            resolvers: resolvers({
+              fetchNodesNetwork,
+              pollingInterval: m.time("--|")
+            })
+          });
+
+          const query = gql`
+            query {
+              nodes(privateIPs: $privateIPs) {
+                hostname
+                network {
+                  public_ips
+                  hostname
+                  private_ip
+                  updated
+                }
+              }
+            }
+          `;
+
+          const queryResult$ = graphqlObservable(query, nodesSchema, {
+            privateIPs: ["13.0.6.96"]
+          });
+
+          const expected$ = m.cold("x-x-(x|)", {
+            x: {
+              data: {
+                nodes: [
+                  {
+                    hostname: "13.0.6.96",
+                    network: {
+                      updated: new Date("2019-02-05T13:10:47.965Z"),
+                      public_ips: ["3.2.2.134"],
+                      private_ip: "13.0.6.96",
+                      hostname: "ip-13-0-6-96"
+                    }
+                  }
+                ]
+              }
+            }
+          });
+
+          m.expect(queryResult$.pipe(take(3))).toBeObservable(expected$);
+        })
+      );
+
+      it(
+        "polls the endpoints for 2 item",
+        marbles(m => {
+          const fetchNodesNetwork = () => {
+            return m.cold("j|", {
+              j: {
+                code: 200,
+                message: "ok",
+                response: [
+                  {
+                    updated: "2019-02-05T13:10:47.965Z",
+                    public_ips: ["3.2.2.134"],
+                    private_ip: "13.0.6.96",
+                    hostname: "ip-13-0-6-96"
+                  },
+                  {
+                    updated: "2019-02-05T13:12:00.979Z",
+                    public_ips: ["3.2.2.96"],
+                    private_ip: "13.0.6.125",
+                    hostname: "ip-13-0-6-125"
+                  }
+                ]
+              }
+            });
+          };
+          const nodesSchema = makeExecutableSchema({
+            typeDefs: schemas,
+            resolvers: resolvers({
+              fetchNodesNetwork,
+              pollingInterval: m.time("----|")
+            })
+          });
+
+          const query = gql`
+            query {
+              nodes(privateIPs: $privateIPs) {
+                hostname
+                network {
+                  public_ips
+                  hostname
+                  private_ip
+                  updated
+                }
+              }
+            }
+          `;
+
+          const queryResult$ = graphqlObservable(query, nodesSchema, {
+            privateIPs: ["13.0.6.96", "13.0.6.125"]
+          });
+
+          const expected$ = m.cold("x---(xx)(xx)(xx|)", {
+            x: {
+              data: {
+                nodes: [
+                  {
+                    hostname: "13.0.6.96",
+                    network: {
+                      updated: new Date("2019-02-05T13:10:47.965Z"),
+                      public_ips: ["3.2.2.134"],
+                      private_ip: "13.0.6.96",
+                      hostname: "ip-13-0-6-96"
+                    }
+                  },
+                  {
+                    hostname: "13.0.6.125",
+                    network: {
+                      updated: new Date("2019-02-05T13:12:00.979Z"),
+                      public_ips: ["3.2.2.96"],
+                      private_ip: "13.0.6.125",
+                      hostname: "ip-13-0-6-125"
+                    }
+                  }
+                ]
+              }
+            }
+          });
+
+          m.expect(queryResult$.pipe(take(7))).toBeObservable(expected$);
+        })
+      );
+      it(
+        "shares the subscription",
+        marbles(async m => {
+          const resolverConfig = makeResolverConfig(m);
+          resolverConfig.fetchNodesNetwork = jest
+            .fn(resolverConfig.fetchNodesNetwork)
+            .mockReturnValue(of({ response: makeFakeNodesNetworkResponse() }));
+
+          const nodesSchema = makeExecutableSchema({
+            typeDefs: schemas,
+            resolvers: resolvers(resolverConfig)
+          });
+
+          const query = gql`
+            query {
+              nodes(privateIPs: $privateIPs) {
+                hostname
+                network {
+                  public_ips
+                }
+              }
+            }
+          `;
+
+          const output$ = graphqlObservable(query, nodesSchema, {
+            privateIPs: ["13.0.6.125", "13.0.6.96", "13.0.1.42"]
+          }).pipe(take(1));
+
+          await output$.toPromise();
+          expect(resolverConfig.fetchNodesNetwork).toHaveBeenCalledTimes(1);
+        })
+      );
+    });
+  });
+
+  describe("node", () => {
+    describe("network", () => {
+      it(
+        "handles a graphql query",
+        marbles(m => {
+          const nodesSchema = makeExecutableSchema({
+            typeDefs: schemas,
+            resolvers: resolvers(makeResolverConfig(m))
+          });
+
+          const query = gql`
+            query {
+              node(privateIP: $privateIP) {
+                hostname
+                network {
+                  public_ips
+                }
+              }
+            }
+          `;
+
+          const queryResult$ = graphqlObservable(query, nodesSchema, {
+            privateIP: "13.0.6.96"
+          });
+
+          const result$ = queryResult$.pipe(take(1));
+
+          const expected$ = m.cold("(j|)", {
+            j: {
+              data: {
+                node: {
+                  hostname: "13.0.6.96",
+                  network: {
+                    public_ips: ["3.2.2.134"]
+                  }
+                }
+              }
+            }
+          });
+
+          m.expect(result$).toBeObservable(expected$);
+        })
+      );
+
+      it(
+        "returns a node if network is not available",
+        marbles(m => {
+          const nodesSchema = makeExecutableSchema({
+            typeDefs: schemas,
+            resolvers: resolvers(makeResolverConfig(m))
+          });
+
+          const query = gql`
+            query {
+              node(privateIP: $privateIP) {
+                hostname
+                network {
+                  public_ips
+                }
+              }
+            }
+          `;
+
+          const queryResult$ = graphqlObservable(query, nodesSchema, {
+            privateIP: "13.0.6.97"
+          });
+
+          const result$ = queryResult$.pipe(take(1));
+
+          const expected$ = m.cold("(j|)", {
+            j: {
+              data: {
+                node: {
+                  hostname: "13.0.6.97",
+                  network: {}
+                }
+              }
+            }
+          });
+
+          m.expect(result$).toBeObservable(expected$);
+        })
+      );
+
+      it(
+        "returns a full network object",
+        marbles(m => {
+          const nodesSchema = makeExecutableSchema({
+            typeDefs: schemas,
+            resolvers: resolvers(makeResolverConfig(m))
+          });
+
+          const query = gql`
+            query {
+              node(privateIP: $privateIP) {
+                hostname
+                network {
+                  public_ips
+                  hostname
+                  private_ip
+                  updated
+                }
+              }
+            }
+          `;
+
+          const queryResult$ = graphqlObservable(query, nodesSchema, {
+            privateIP: "13.0.6.96"
+          });
+
+          const result$ = queryResult$.pipe(take(1));
+
+          const expected$ = m.cold("(j|)", {
+            j: {
+              data: {
+                node: {
+                  hostname: "13.0.6.96",
+                  network: {
+                    updated: new Date("2019-02-05T13:10:47.965Z"),
+                    public_ips: ["3.2.2.134"],
+                    private_ip: "13.0.6.96",
+                    hostname: "ip-13-0-6-96"
+                  }
+                }
+              }
+            }
+          });
+
+          m.expect(result$).toBeObservable(expected$);
+        })
+      );
+
+      it(
+        "polls the endpoints",
+        marbles(m => {
+          const fetchNodesNetwork = () =>
+            m.cold("j|", {
+              j: {
+                code: 200,
+                message: "ok",
+                response: [
+                  {
+                    updated: new Date("2019-02-05T13:10:47.965Z"),
+                    public_ips: ["3.2.2.134"],
+                    private_ip: "13.0.6.96",
+                    hostname: "ip-13-0-6-96"
+                  }
+                ]
+              }
+            });
+          const nodesSchema = makeExecutableSchema({
+            typeDefs: schemas,
+            resolvers: resolvers({
+              fetchNodesNetwork,
+              pollingInterval: m.time("--|")
+            })
+          });
+
+          const query = gql`
+            query {
+              node(privateIP: $privateIP) {
+                hostname
+                network {
+                  public_ips
+                  hostname
+                  private_ip
+                  updated
+                }
+              }
+            }
+          `;
+
+          const queryResult$ = graphqlObservable(query, nodesSchema, {
+            privateIP: "13.0.6.96"
+          });
+
+          const expected$ = m.cold("x-x-(x|)", {
+            x: {
+              data: {
+                node: {
+                  hostname: "13.0.6.96",
+                  network: {
+                    updated: new Date("2019-02-05T13:10:47.965Z"),
+                    public_ips: ["3.2.2.134"],
+                    private_ip: "13.0.6.96",
+                    hostname: "ip-13-0-6-96"
+                  }
+                }
+              }
+            }
+          });
+
+          m.expect(queryResult$.pipe(take(3))).toBeObservable(expected$);
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
This adds the nodes resolver using the nodes network client to generate nodes. This is a workaround
since the nodes resolver does not actually return nodes yet.

CLOSES DCOS-44841

## Testing

Check the tests for plausibility 

## Trade-offs

N/A

## Dependencies

This is depending on #3579 

## Screenshots

N/A
