### PR TITLE
DCOS-44842: add public ip component

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -495,6 +495,7 @@
   "Load Balanced Port": "",
   "Load balance the service internally (layer 4), and create a service address. For external (layer 7) load balancing, create an external load balancer and attach this service. <0>More Information</0>.": "",
   "Load balance this service internally at {hostName}": "",
+  "Loading": "",
   "Loading selected version": "",
   "Local Persistent Volume": "",
   "Log In": "",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -495,6 +495,7 @@
   "Load Balanced Port": "负载均衡器端口",
   "Load balance the service internally (layer 4), and create a service address. For external (layer 7) load balancing, create an external load balancer and attach this service. <0>More Information</0>.": "内部负载均衡服务（层 4），并创建服务地址。对于外部（层 7）负载均衡，创建外部负载均衡器并连接此服务。<0>更多信息</0>.",
   "Load balance this service internally at {hostName}": "在 {hostName} 内部负载均衡此服务",
+  "Loading": "",
   "Loading selected version": "正在加载所选版本",
   "Local Persistent Volume": "本地持久卷",
   "Log In": "登录",

--- a/plugins/nodes/src/js/columns/NodesTablePublicIPColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTablePublicIPColumn.tsx
@@ -1,61 +1,25 @@
-import * as React from "react";
 import { TextCell } from "@dcos/ui-kit";
-
-import { default as schema } from "../data/NodesResolver";
-import { NodeNetwork } from "../data/NodesNetworkClient";
-import graphqlObservable from "reactive-graphql";
-import gql from "graphql-tag";
-import { map, switchMap, startWith } from "rxjs/operators";
-import { componentFromStream } from "@dcos/data-service";
-import { Observable } from "rxjs";
+import * as React from "react";
+import { Tooltip } from "reactjs-components";
 import { Trans } from "@lingui/react";
 
-const getGraphQl = (privateIP: string) =>
-  graphqlObservable<{ node: { network: NodeNetwork } }>(
-    gql`
-      query {
-        node(privateIP: $privateIP) {
-          network {
-            public_ips
-          }
-        }
-      }
-    `,
-    schema,
-    { privateIP }
-  ).pipe(map(response => response.data));
+import Node from "src/js/structs/Node";
 
-const Column = componentFromStream<{ privateIP: string }>(
-  (props$): Observable<React.ReactNode> => {
-    return (props$ as Observable<{ privateIP: string }>).pipe(
-      switchMap(({ privateIP }) => getGraphQl(privateIP)),
-      map(({ node }: { node: { network: { public_ips: string[] } } }) => {
-        if (
-          node.network == null ||
-          node.network.public_ips == null ||
-          node.network.public_ips.length === 0
-        ) {
-          return (
-            <TextCell>
-              <Trans>N/A</Trans>
-            </TextCell>
-          );
-        }
-        return <TextCell>{node.network.public_ips.join(", ")}</TextCell>;
-      }),
-      startWith(
-        <TextCell>
-          <Trans>Loading</Trans>
-        </TextCell>
-      )
+export default function(item: Node) {
+  const publicIps = item.getPublicIps();
+  if (publicIps.length === 0) {
+    return (
+      <TextCell>
+        <Trans>N/A</Trans>
+      </TextCell>
     );
   }
-);
-
-export function publicIPCellWidth(): number {
-  return 125;
-}
-
-export default function({ hostname }: { hostname: string }) {
-  return <Column privateIP={hostname} />;
+  if (publicIps.length === 1) {
+    return <TextCell>{publicIps[0]}</TextCell>;
+  }
+  return (
+    <TextCell>
+      <Tooltip content={publicIps.join(", ")}>{publicIps[0]}</Tooltip>
+    </TextCell>
+  );
 }

--- a/plugins/nodes/src/js/columns/NodesTablePublicIPColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTablePublicIPColumn.tsx
@@ -1,0 +1,61 @@
+import * as React from "react";
+import { TextCell } from "@dcos/ui-kit";
+
+import { default as schema } from "../data/NodesResolver";
+import { NodeNetwork } from "../data/NodesNetworkClient";
+import graphqlObservable from "reactive-graphql";
+import gql from "graphql-tag";
+import { map, switchMap, startWith } from "rxjs/operators";
+import { componentFromStream } from "@dcos/data-service";
+import { Observable } from "rxjs";
+import { Trans } from "@lingui/react";
+
+const getGraphQl = (privateIP: string) =>
+  graphqlObservable<{ node: { network: NodeNetwork } }>(
+    gql`
+      query {
+        node(privateIP: $privateIP) {
+          network {
+            public_ips
+          }
+        }
+      }
+    `,
+    schema,
+    { privateIP }
+  ).pipe(map(response => response.data));
+
+const Column = componentFromStream<{ privateIP: string }>(
+  (props$): Observable<React.ReactNode> => {
+    return (props$ as Observable<{ privateIP: string }>).pipe(
+      switchMap(({ privateIP }) => getGraphQl(privateIP)),
+      map(({ node }: { node: { network: { public_ips: string[] } } }) => {
+        if (
+          node.network == null ||
+          node.network.public_ips == null ||
+          node.network.public_ips.length === 0
+        ) {
+          return (
+            <TextCell>
+              <Trans>N/A</Trans>
+            </TextCell>
+          );
+        }
+        return <TextCell>{node.network.public_ips.join(", ")}</TextCell>;
+      }),
+      startWith(
+        <TextCell>
+          <Trans>Loading</Trans>
+        </TextCell>
+      )
+    );
+  }
+);
+
+export function publicIPCellWidth(): number {
+  return 125;
+}
+
+export default function({ hostname }: { hostname: string }) {
+  return <Column privateIP={hostname} />;
+}

--- a/plugins/nodes/src/js/components/NodesTable.tsx
+++ b/plugins/nodes/src/js/components/NodesTable.tsx
@@ -1,5 +1,10 @@
 import * as React from "react";
-import { Table, Column, SortableHeaderCell } from "@dcos/ui-kit/dist/packages";
+import {
+  Table,
+  Column,
+  SortableHeaderCell,
+  HeaderCell
+} from "@dcos/ui-kit/dist/packages";
 import { Trans } from "@lingui/macro";
 
 import NodesList from "#SRC/js/structs/NodesList";
@@ -29,6 +34,10 @@ import {
   spacingRenderer
 } from "../columns/NodesTableSpacingColumn";
 
+import {
+  default as PublicIPColumn,
+  publicIPCellWidth
+} from "../columns/NodesTablePublicIPColumn";
 interface NodesTableProps {
   hosts: NodesList;
   nodeHealthResponse: boolean;
@@ -180,6 +189,16 @@ export default class NodesTable extends React.Component<
               />
             }
             cellRenderer={healthRenderer}
+          />
+
+          <Column
+            header={
+              <HeaderCell>
+                <Trans>Public IP</Trans>
+              </HeaderCell>
+            }
+            width={publicIPCellWidth}
+            cellRenderer={PublicIPColumn}
           />
 
           <Column

--- a/plugins/nodes/src/js/components/NodesTable.tsx
+++ b/plugins/nodes/src/js/components/NodesTable.tsx
@@ -34,11 +34,9 @@ import {
   spacingRenderer
 } from "../columns/NodesTableSpacingColumn";
 
-import {
-  default as PublicIPColumn,
-  publicIPCellWidth
-} from "../columns/NodesTablePublicIPColumn";
-interface NodesTableProps {
+import { default as PublicIPColumn } from "../columns/NodesTablePublicIPColumn";
+import NodesTableWrapper from "./NodesTableWrapper";
+export interface NodesTableProps {
   hosts: NodesList;
   nodeHealthResponse: boolean;
   masterRegion: string;
@@ -168,134 +166,135 @@ export default class NodesTable extends React.Component<
 
     return (
       <div className="table-wrapper">
-        <Table data={data.slice()}>
-          <Column
-            header={
-              <SortableHeaderCell
-                columnContent={<Trans render="span">Host</Trans>}
-                sortHandler={this.handleSortClick.bind(null, "host")}
-                sortDirection={sortColumn === "host" ? sortDirection : null}
-              />
-            }
-            cellRenderer={ipRenderer}
-          />
+        <NodesTableWrapper data={data.slice()}>
+          <Table data={data.slice()}>
+            <Column
+              header={
+                <SortableHeaderCell
+                  columnContent={<Trans render="span">Host</Trans>}
+                  sortHandler={this.handleSortClick.bind(null, "host")}
+                  sortDirection={sortColumn === "host" ? sortDirection : null}
+                />
+              }
+              cellRenderer={ipRenderer}
+            />
 
-          <Column
-            header={
-              <SortableHeaderCell
-                columnContent={<Trans render="span">Health</Trans>}
-                sortHandler={this.handleSortClick.bind(null, "health")}
-                sortDirection={sortColumn === "health" ? sortDirection : null}
-              />
-            }
-            cellRenderer={healthRenderer}
-          />
+            <Column
+              header={
+                <SortableHeaderCell
+                  columnContent={<Trans render="span">Health</Trans>}
+                  sortHandler={this.handleSortClick.bind(null, "health")}
+                  sortDirection={sortColumn === "health" ? sortDirection : null}
+                />
+              }
+              cellRenderer={healthRenderer}
+            />
 
-          <Column
-            header={
-              <HeaderCell>
-                <Trans>Public IP</Trans>
-              </HeaderCell>
-            }
-            width={publicIPCellWidth}
-            cellRenderer={PublicIPColumn}
-          />
+            <Column
+              header={
+                <HeaderCell>
+                  <Trans>Public IP</Trans>
+                </HeaderCell>
+              }
+              cellRenderer={PublicIPColumn}
+            />
 
-          <Column
-            header={
-              <SortableHeaderCell
-                columnContent={<Trans render="span">Type</Trans>}
-                sortHandler={this.handleSortClick.bind(null, "type")}
-                sortDirection={sortColumn === "type" ? sortDirection : null}
-              />
-            }
-            cellRenderer={typeRenderer}
-          />
+            <Column
+              header={
+                <SortableHeaderCell
+                  columnContent={<Trans render="span">Type</Trans>}
+                  sortHandler={this.handleSortClick.bind(null, "type")}
+                  sortDirection={sortColumn === "type" ? sortDirection : null}
+                />
+              }
+              cellRenderer={typeRenderer}
+            />
 
-          <Column
-            header={
-              <SortableHeaderCell
-                columnContent={<Trans render="span">Region</Trans>}
-                sortHandler={this.handleSortClick.bind(null, "region")}
-                sortDirection={sortColumn === "region" ? sortDirection : null}
-              />
-            }
-            cellRenderer={this.regionRenderer}
-          />
+            <Column
+              header={
+                <SortableHeaderCell
+                  columnContent={<Trans render="span">Region</Trans>}
+                  sortHandler={this.handleSortClick.bind(null, "region")}
+                  sortDirection={sortColumn === "region" ? sortDirection : null}
+                />
+              }
+              cellRenderer={this.regionRenderer}
+            />
 
-          <Column
-            header={
-              <SortableHeaderCell
-                columnContent={<Trans render="span">Zone</Trans>}
-                sortHandler={this.handleSortClick.bind(null, "zone")}
-                sortDirection={sortColumn === "zone" ? sortDirection : null}
-              />
-            }
-            cellRenderer={zoneRenderer}
-          />
+            <Column
+              header={
+                <SortableHeaderCell
+                  columnContent={<Trans render="span">Zone</Trans>}
+                  sortHandler={this.handleSortClick.bind(null, "zone")}
+                  sortDirection={sortColumn === "zone" ? sortDirection : null}
+                />
+              }
+              cellRenderer={zoneRenderer}
+            />
 
-          <Column
-            header={
-              <SortableHeaderCell
-                columnContent={<Trans render="span">Tasks</Trans>}
-                sortHandler={this.handleSortClick.bind(null, "tasks")}
-                sortDirection={sortColumn === "tasks" ? sortDirection : null}
-                textAlign="right"
-              />
-            }
-            cellRenderer={tasksRenderer}
-          />
+            <Column
+              header={
+                <SortableHeaderCell
+                  columnContent={<Trans render="span">Tasks</Trans>}
+                  sortHandler={this.handleSortClick.bind(null, "tasks")}
+                  sortDirection={sortColumn === "tasks" ? sortDirection : null}
+                  textAlign="right"
+                />
+              }
+              cellRenderer={tasksRenderer}
+            />
 
-          <Column
-            header={
-              <SortableHeaderCell
-                columnContent={<Trans render="span">CPU</Trans>}
-                sortHandler={this.handleSortClick.bind(null, "cpu")}
-                sortDirection={sortColumn === "cpu" ? sortDirection : null}
-              />
-            }
-            cellRenderer={cpuRenderer}
-          />
+            <Column
+              header={
+                <SortableHeaderCell
+                  columnContent={<Trans render="span">CPU</Trans>}
+                  sortHandler={this.handleSortClick.bind(null, "cpu")}
+                  sortDirection={sortColumn === "cpu" ? sortDirection : null}
+                />
+              }
+              cellRenderer={cpuRenderer}
+            />
 
-          <Column
-            header={
-              <SortableHeaderCell
-                columnContent={<Trans render="span">Mem</Trans>}
-                sortHandler={this.handleSortClick.bind(null, "mem")}
-                sortDirection={sortColumn === "mem" ? sortDirection : null}
-              />
-            }
-            cellRenderer={memRenderer}
-          />
+            <Column
+              header={
+                <SortableHeaderCell
+                  columnContent={<Trans render="span">Mem</Trans>}
+                  sortHandler={this.handleSortClick.bind(null, "mem")}
+                  sortDirection={sortColumn === "mem" ? sortDirection : null}
+                />
+              }
+              cellRenderer={memRenderer}
+            />
 
-          <Column
-            header={
-              <SortableHeaderCell
-                columnContent={<Trans render="span">Disk</Trans>}
-                sortHandler={this.handleSortClick.bind(null, "disk")}
-                sortDirection={sortColumn === "disk" ? sortDirection : null}
-              />
-            }
-            cellRenderer={diskRenderer}
-          />
+            <Column
+              header={
+                <SortableHeaderCell
+                  columnContent={<Trans render="span">Disk</Trans>}
+                  sortHandler={this.handleSortClick.bind(null, "disk")}
+                  sortDirection={sortColumn === "disk" ? sortDirection : null}
+                />
+              }
+              cellRenderer={diskRenderer}
+            />
 
-          <Column
-            header={
-              <SortableHeaderCell
-                columnContent={<Trans render="span">GPU</Trans>}
-                sortHandler={this.handleSortClick.bind(null, "gpu")}
-                sortDirection={sortColumn === "gpu" ? sortDirection : null}
-              />
-            }
-            cellRenderer={gpuRenderer}
-          />
+            <Column
+              header={
+                <SortableHeaderCell
+                  columnContent={<Trans render="span">GPU</Trans>}
+                  sortHandler={this.handleSortClick.bind(null, "gpu")}
+                  sortDirection={sortColumn === "gpu" ? sortDirection : null}
+                />
+              }
+              cellRenderer={gpuRenderer}
+            />
 
-          <Column
-            header={<span title="Spacing" />}
-            cellRenderer={spacingRenderer}
-            width={spacingSizer}
-          />
-        </Table>
+            <Column
+              header={<span title="Spacing" />}
+              cellRenderer={spacingRenderer}
+              width={spacingSizer}
+            />
+          </Table>
+        </NodesTableWrapper>
       </div>
     );
   }

--- a/plugins/nodes/src/js/components/NodesTableWrapper.tsx
+++ b/plugins/nodes/src/js/components/NodesTableWrapper.tsx
@@ -1,0 +1,82 @@
+import * as React from "react";
+import graphqlObservable from "reactive-graphql";
+import gql from "graphql-tag";
+import { Observable, combineLatest } from "rxjs";
+import { map, distinctUntilChanged, switchMap } from "rxjs/operators";
+import { componentFromStream } from "@dcos/data-service";
+import { TableProps } from "@dcos/ui-kit/dist/packages/table/components/Table";
+
+import { NodeNetwork } from "../data/NodesNetworkClient";
+import { default as schema } from "../data/NodesResolver";
+import Node from "#SRC/js/structs/Node";
+
+interface TableWrapperProps {
+  data: any[];
+  children: React.ReactElement<TableProps>;
+}
+
+const getGraphQl = (privateIP: string) => {
+  return graphqlObservable<{ node: { network: NodeNetwork } }>(
+    gql`
+      query {
+        node(privateIP: $privateIP) {
+          network {
+            public_ips
+          }
+        }
+      }
+    `,
+    schema,
+    { privateIP }
+  ).pipe(map(response => response.data));
+};
+// Put in the same props as you would in the NodesTable
+const NodesTableWrapper = componentFromStream<TableWrapperProps>(props$ => {
+  const data$ = (props$ as Observable<TableWrapperProps>).pipe(
+    map((props: TableWrapperProps) => props.data),
+    distinctUntilChanged((x, y) => {
+      if (x.length === y.length) {
+        return JSON.stringify(x) === JSON.stringify(y);
+      }
+      return false;
+    })
+  );
+  const dataWithPublicIp$ = data$.pipe(
+    switchMap(data => {
+      const streamArray = data.map(item => {
+        return getGraphQl(item.hostname).pipe(
+          map(
+            publicIp =>
+              new Node({
+                ...item.toJSON(),
+                network: publicIp.node.network
+              })
+          )
+        );
+      });
+
+      return combineLatest(...streamArray).pipe(
+        map(([...items]) => {
+          return items;
+        })
+      );
+    })
+  );
+
+  return combineLatest(
+    props$ as Observable<TableWrapperProps>,
+    dataWithPublicIp$
+  ).pipe(
+    map(([props, data]) => {
+      const { children, ...rest } = props;
+      return React.Children.map(children, child => {
+        return React.cloneElement(child as React.ReactElement<any>, {
+          ...rest,
+          data
+        });
+      });
+    })
+  );
+});
+
+export default NodesTableWrapper;

--- a/plugins/nodes/src/js/data/NodesNetworkClient.ts
+++ b/plugins/nodes/src/js/data/NodesNetworkClient.ts
@@ -1,6 +1,6 @@
 import { request, RequestResponse } from "@dcos/http-service";
 import { merge, Observable } from "rxjs";
-import { partition, tap } from "rxjs/operators";
+import { partition, tap, share } from "rxjs/operators";
 
 export interface NodeNetwork {
   updated: string | Date;
@@ -32,7 +32,7 @@ export function fetchNodesNetwork(): Observable<
 > {
   const [success, error] = partition(
     (response: RequestResponse<NodesNetworkResponse>) => response.code < 300
-  )(request("/net/v1/nodes"));
+  )(request<NodeNetworkResponse[]>("/net/v1/nodes").pipe(share()));
 
   return merge(
     success,

--- a/plugins/nodes/src/js/data/NodesResolver.ts
+++ b/plugins/nodes/src/js/data/NodesResolver.ts
@@ -75,7 +75,7 @@ export const resolvers = ({
       node(_parent = {}, args: GeneralArgs) {
         if (!isNodeQueryArgs(args)) {
           return throwError(
-            "Nodes resolver arguments aren't valid for type nodesQueryArgs"
+            "Node resolver arguments aren't valid for type nodeQueryArgs"
           );
         }
         return of({ hostname: args.privateIP, privateIP: args.privateIP });

--- a/src/js/structs/Node.d.ts
+++ b/src/js/structs/Node.d.ts
@@ -14,5 +14,6 @@ export default class Node extends Item {
   sumTaskTypesByState: (state: any) => any;
   getResources: () => any;
   isPublic: () => boolean;
-  getIp:() => string;
+  getIp: () => string;
+  getPublicIps: () => string[];
 }

--- a/src/js/structs/Node.js
+++ b/src/js/structs/Node.js
@@ -107,6 +107,14 @@ class Node extends Item {
   getIp() {
     return this.get("host_ip") || this.getHostName();
   }
+
+  getPublicIps() {
+    if (!this.get("network")) {
+      return [];
+    }
+
+    return this.get("network").public_ips;
+  }
 }
 
 module.exports = Node;


### PR DESCRIPTION
## Testing

Visit the nodes page this should display the public ip of the public available nodes.

## Trade-offs

The cell is refetching the public ip if a cell added to the viewport since only the new component is bound to the resolver. Alternative could be to move the resolver logic up above the table and merge all the nodes information with the available network information.

## Dependencies

#3586 

## Screenshots

![image](https://user-images.githubusercontent.com/156010/52637735-6ab78c80-2ed0-11e9-80b0-a69471b5e602.png)
