### PR TITLE
[spike] DCOS-48014: [1.12] Adding Package Repository with priority 0, does not push all packages 1 priority down

### DIFF
--- a/plugins/catalog/src/js/repositories/RepositoriesAdd.js
+++ b/plugins/catalog/src/js/repositories/RepositoriesAdd.js
@@ -24,8 +24,10 @@ const getErrorMessage = (response = {}) => {
 
 const addPackageRepositoryMutation = gql`
   mutation {
-    addPackageRepository(name: $name, uri: $uri, priority: $index) {
+    addPackageRepository(name: $name, uri: $uri, index: $index) {
       name
+      uri
+      index
     }
   }
 `;

--- a/plugins/catalog/src/js/repositories/data/repositoriesModel.js
+++ b/plugins/catalog/src/js/repositories/data/repositoriesModel.js
@@ -16,6 +16,7 @@ export const typeDefs = `
     id: ID!
     name: String!
     uri: String!
+    index: Int!
   }
 
   type Query {
@@ -24,7 +25,7 @@ export const typeDefs = `
 
   type Mutation {
     addPackageRepository(name: String!, uri: String!, index: Int! ): [PackageRepository!]!
-    removePackageRepository(name: String!, uri: String!): [PackageRepository!]!
+    removePackageRepository(name: String!, uri: String!, index: Int!): [PackageRepository!]!
   }
 `;
 

--- a/src/js/structs/RepositoryList.js
+++ b/src/js/structs/RepositoryList.js
@@ -6,7 +6,7 @@ class RepositoryList extends List {
     // Specify filter properties if not specified
     if (!options.filterProperties) {
       // Use default getters
-      options.filterProperties = { name: null, uri: null };
+      options.filterProperties = { name: null, uri: null, index: null };
     }
 
     // Pass in overloaded options and the rest of the arguments


### PR DESCRIPTION
Fix repository priority when adding a new repository.

Closes https://jira.mesosphere.com/browse/DCOS-48014

Thanks to @nLight for helping me realize that priority is called index in the API.

## Testing
1. Go to Settings > Package Repositories
2. Add a new Package Repository with priority 0, for example using the name "Universe2" and the uri "https://downloads.mesosphere.com/universe/repo/repo-up-to-1.13.json.gz"
3. Verify that the new package was added at the top

## Trade-offs
None.

## Dependencies
None.

## Screenshots

### Before
![peek 2019-02-15 10-54](https://user-images.githubusercontent.com/40791275/52845829-c2dcd180-3110-11e9-8089-2f0de9a98d14.gif)

### After
![peek 2019-02-15 10-54-2](https://user-images.githubusercontent.com/40791275/52845852-ccfed000-3110-11e9-98ef-9e8f839a897f.gif)

