### PR TITLE
[spike] DCOS-48028: [1.12] Metronome JOBs show "Invalid Date".

### DIFF
--- a/plugins/jobs/src/js/components/JobsOverviewTable.js
+++ b/plugins/jobs/src/js/components/JobsOverviewTable.js
@@ -5,6 +5,7 @@ import PropTypes from "prop-types";
 import React from "react";
 import { Table, Tooltip } from "reactjs-components";
 
+import DateUtil from "#SRC/js/utils/DateUtil";
 import Icon from "#SRC/js/components/Icon";
 import ResourceTableUtil from "#SRC/js/utils/ResourceTableUtil";
 import TableUtil from "#SRC/js/utils/TableUtil";
@@ -238,7 +239,10 @@ export default class JobsOverviewTable extends React.Component {
     const nodes = [];
     const statusNode = <span className={statusClasses}>{status}</span>;
 
-    if (lastFailureAt == null && lastSuccessAt == null) {
+    if (
+      !DateUtil.isValidDate(lastFailureAt) ||
+      !DateUtil.isValidDate(lastSuccessAt)
+    ) {
       return statusNode;
     }
 

--- a/src/js/utils/DateUtil.js
+++ b/src/js/utils/DateUtil.js
@@ -88,6 +88,15 @@ const DateUtil = {
 
   getDuration(time, formatKey = "seconds") {
     return moment.duration(time, formatKey).humanize();
+  },
+
+  isValidDate(dateString) {
+    if (dateString === null) {
+      return false;
+    }
+    const date = new Date(dateString);
+
+    return date instanceof Date && !isNaN(date);
   }
 };
 

--- a/src/js/utils/__tests__/DateUtil-test.js
+++ b/src/js/utils/__tests__/DateUtil-test.js
@@ -123,4 +123,20 @@ describe("DateUtil", function() {
       expect(DateUtil.strToMs(undefined)).toEqual(null);
     });
   });
+
+  describe("#isValidDate", function() {
+    it("returns true for a valid date", function() {
+      expect(DateUtil.isValidDate("1990-01-03T00:00:00.604+0000")).toEqual(
+        true
+      );
+    });
+
+    it("returns false for an invalid date", function() {
+      expect(DateUtil.isValidDate("foo")).toEqual(false);
+    });
+
+    it("returns false for null", function() {
+      expect(DateUtil.isValidDate(null)).toEqual(false);
+    });
+  });
 });


### PR DESCRIPTION
Check the dates of last successful and last unsuccessful run
and show no tooltip if they are not valid.

Closes https://jira.mesosphere.com/browse/DCOS-48028

## Testing
In `dcos-ui/plugins/jobs/src/js/components/JobsOverviewTable.js`, replace the first line in the `renderLastRunStatusColumn` method with:
```
    let { lastFailureAt, lastSuccessAt, status } = row[prop];
    lastSuccessAt = "foo";
```
Go to jobs tab, create a job (that doesn't fail), run it and wait for it to finish.
From the jobs table, hover over the value for the "Last Run" column for this job.
You should see no tooltip.

## Trade-offs
I am not sure how to reproduce an actual invalid date, so I am mocking one.

## Dependencies
None.

## Screenshots

### Before
![screenshot from 2019-02-15 13-32-15](https://user-images.githubusercontent.com/40791275/52855274-9aad9c80-3129-11e9-8887-e1ad8746b157.png)

### After (no tooltip)
![screenshot from 2019-02-15 13-47-18](https://user-images.githubusercontent.com/40791275/52855277-9e412380-3129-11e9-8be7-b56343b59b63.png)
