### PR TITLE
DCOS-48029: [1.13] Metronome JOBs show "Invalid Date"

### DIFF
--- a/plugins/jobs/src/js/components/JobsOverviewTable.js
+++ b/plugins/jobs/src/js/components/JobsOverviewTable.js
@@ -252,7 +252,10 @@ export default class JobsOverviewTable extends React.Component {
     const nodes = [];
     const statusNode = <span className={statusClasses}>{status}</span>;
 
-    if (lastFailureAt == null && lastSuccessAt == null) {
+    if (
+      !DateUtil.isValidDate(lastFailureAt) ||
+      !DateUtil.isValidDate(lastSuccessAt)
+    ) {
       return statusNode;
     }
 

--- a/src/js/utils/DateUtil.ts
+++ b/src/js/utils/DateUtil.ts
@@ -145,6 +145,15 @@ const DateUtil = {
 
   getDuration(time: number): string {
     return distanceInWordsStrict(0, time);
+  },
+
+  isValidDate(dateString: string) {
+    if (dateString === null) {
+      return false;
+    }
+
+    const date: Date = new Date(dateString);
+    return date instanceof Date && !isNaN(date.getTime());
   }
 };
 

--- a/src/js/utils/__tests__/DateUtil-test.js
+++ b/src/js/utils/__tests__/DateUtil-test.js
@@ -109,4 +109,20 @@ describe("DateUtil", function() {
       expect(DateUtil.strToMs(undefined)).toEqual(null);
     });
   });
+
+  describe("#isValidDate", function() {
+    it("return true for a valid date", function() {
+      expect(DateUtil.isValidDate("1990-01-03T00:00:00.000+0000")).toEqual(
+        true
+      );
+    });
+
+    it("return false for an invalid date", function() {
+      expect(DateUtil.isValidDate("foo")).toEqual(false);
+    });
+
+    it("returns false for null", function() {
+      expect(DateUtil.isValidDate(null)).toEqual(false);
+    });
+  });
 });


### PR DESCRIPTION
Check the dates of last successful and last unsuccessful run
and show no console errors if they are not valid.

Closes https://jira.mesosphere.com/browse/DCOS-48029

In 1.13 it doesn't show "Invalid date", because we use format options, but instead it shows console errors.

## Testing
In `dcos-ui/plugins/jobs/src/js/components/JobsOverviewTable.js`, replace the first line in the `renderLastRunStatusColumn` method with:
```
    let { lastFailureAt, lastSuccessAt, status } = row[prop];
    lastSuccessAt = "foo";
```
Go to jobs tab, create a job (that doesn't fail), run it and wait for it to finish.
From the jobs table, open the console.
You should see no date errors.

## Trade-offs
I am not sure how to reproduce an actual invalid date, so I am mocking one.

## Dependencies
None.

## Screenshots

### Before
![screenshot from 2019-02-15 14-01-07](https://user-images.githubusercontent.com/40791275/52856022-e3feeb80-312b-11e9-8ff9-08941f0a9a2a.png)

### After (no console errors)
![screenshot from 2019-02-15 14-03-28](https://user-images.githubusercontent.com/40791275/52856026-e7927280-312b-11e9-9b87-050169882eb3.png)
