### PR TITLE
DCOS-19295: make "select version" in package detail more obvious

### DIFF
--- a/src/js/pages/catalog/PackageDetailTab.js
+++ b/src/js/pages/catalog/PackageDetailTab.js
@@ -356,7 +356,7 @@ class PackageDetailTab extends mixin(StoreMixin) {
 
     return (
       <Dropdown
-        buttonClassName="button button-link dropdown-toggle"
+        buttonClassName="button button-primary-link dropdown-toggle flush-left flush-right"
         dropdownMenuClassName="dropdown-menu"
         dropdownMenuListClassName="dropdown-menu-list"
         onItemSelection={this.handlePackageVersionChange}
@@ -517,8 +517,11 @@ class PackageDetailTab extends mixin(StoreMixin) {
               </div>
               {!state.isLoadingSelectedVersion && (
                 <div className="media-object-item media-object-item-grow ">
-                  <div className="flex flex-direction-left-to-right">
-                    <h1 className="short flush-top">{name}</h1>
+                  <h1 className="short flush-top flush-bottom">{name}</h1>
+                  <div className="flex flex-align-items-center">
+                    <span className="package-version-label">
+                      <Trans>Version</Trans>:
+                    </span>
                     {this.getPackageVersionsDropdown()}
                   </div>
                   <div className="row">

--- a/src/styles/views/packages/styles.less
+++ b/src/styles/views/packages/styles.less
@@ -35,6 +35,10 @@
       margin-right: @base-spacing-unit * 1/4;
     }
   }
+
+  .package-version-label {
+    padding-right: @base-spacing-unit * 1/4;
+  }
 }
 
 & when (@packages-view-enabled) and (@layout-screen-small-enabled) {


### PR DESCRIPTION
## Testing
- Open a package from the Catalog
- Check that the layout is updated

## Trade-offs
None

## Dependencies
None

## Screenshots
Before:
<img width="920" alt="screen shot 2019-02-15 at 11 13 38 am" src="https://user-images.githubusercontent.com/2313998/52869452-aaba8180-3113-11e9-993e-c2f6abd20c5f.png">

After:
<img width="920" alt="screen shot 2019-02-15 at 11 13 51 am" src="https://user-images.githubusercontent.com/2313998/52869459-aee69f00-3113-11e9-8c5e-d4056430ecc1.png">
