### PR TITLE
DCOS-48976: [1.13] Download cli modal shows wrong version if user has no permission

### DIFF
--- a/src/js/components/modals/CliInstallModal.js
+++ b/src/js/components/modals/CliInstallModal.js
@@ -65,14 +65,9 @@ class CliInstallModal extends React.Component {
     const clusterUrl = `${protocol}://${hostname}${port}`;
     const { selectedOS } = this.state;
 
-    let version = MetadataStore.parsedVersion;
-    // Prepend 'dcos-' to any version other than latest
-    if (version !== "latest") {
-      version = `dcos-${version}`;
-    }
     const downloadUrl = `https://downloads.dcos.io/binaries/cli/${
       osTypes[selectedOS]
-    }/x86-64/${version}/dcos`;
+    }/x86-64/latest/dcos`;
     if (selectedOS === "Windows") {
       return this.getWindowsInstallInstruction(clusterUrl, downloadUrl);
     }


### PR DESCRIPTION
Change the CLI install modal instuctions to always show latest version.

Closes https://jira.mesosphere.com/browse/DCOS-48976

## Testing
1. Open CLI install modal from the dropdown in the top right corner
2. Verify that the code snippet for OS X and Linux contains "latest" and not "dcos-1.13" (at the end of the second line)

## Trade-offs
I couldn't find an easy way to unit test that the installation instructions contain "latest".

## Dependencies
None.

## Screenshots
### Before
![screenshot from 2019-02-22 11-55-38](https://user-images.githubusercontent.com/40791275/53234693-c9cb8d00-3698-11e9-851c-0cc1a994541e.png)

### After
![screenshot from 2019-02-22 11-51-12](https://user-images.githubusercontent.com/40791275/53234700-cd5f1400-3698-11e9-9467-c5c35cf494b2.png)
