### PR TITLE
DCOS-48975: [1.12] Download cli modal shows wrong version if user has no permission

### DIFF
--- a/src/js/components/modals/CliInstallModal.js
+++ b/src/js/components/modals/CliInstallModal.js
@@ -65,14 +65,10 @@ class CliInstallModal extends React.Component {
     }
     const clusterUrl = `${protocol}://${hostname}${port}`;
     const { selectedOS } = this.state;
-    let version = MetadataStore.parsedVersion;
-    // Prepend 'dcos-' to any version other than latest
-    if (version !== "latest") {
-      version = `dcos-${version}`;
-    }
+
     const downloadUrl = `https://downloads.dcos.io/binaries/cli/${
       osTypes[selectedOS]
-    }/x86-64/${version}/dcos`;
+    }/x86-64/dcos-1.12/dcos`;
     if (selectedOS === "Windows") {
       return this.getWindowsInstallInstruction(clusterUrl, downloadUrl);
     }


### PR DESCRIPTION
Change the CLI install modal instuctions to always show 1.12 version.

Closes https://jira.mesosphere.com/browse/DCOS-48975

## Testing
1. From Organization > Users, create a new user account and give it some permissions (using Add Permission > Insert Permission String) in order to be able to access the UI with it.
For example, the permissions from the jira:
```
dcos:adminrouter:ops:mesos full 
dcos:adminrouter:ops:slave full 
dcos:adminrouter:package full 
dcos:adminrouter:service:marathon full 
dcos:adminrouter:service:metronome full 
dcos:service:marathon:services:/ds full 
dcos:service:metronome:metronome:jobs full
```
2. Login with that user
3. Open the CLI instruction modal from the top right corner
4. Verify that the code snippet for OS X and Linux contains "dcos-1.12" and not "latest" (at the end of the second line)
5. Verify that the link works

## Trade-offs
I couldn't find an easy way to unit test that the installation instructions contain "dcos-1.12".

## Dependencies
None.

## Screenshots
### Before
![screenshot from 2019-02-22 12-23-49](https://user-images.githubusercontent.com/40791275/53236337-b9b5ac80-369c-11e9-92b7-60a880d4d8bd.png)

### After
![screenshot from 2019-02-22 12-18-05](https://user-images.githubusercontent.com/40791275/53236353-bd493380-369c-11e9-895c-191c9e50f849.png)
