### PR TITLE
DCOS-48983: [1.12] Unable to stop running Metronome job

### DIFF
--- a/src/js/stores/MetronomeStore.js
+++ b/src/js/stores/MetronomeStore.js
@@ -222,9 +222,8 @@ class MetronomeStore extends EventEmitter {
   }
 
   stopJobRun(jobID, jobRunID) {
-    const job = this.getJob(jobID);
-
-    if (job == null || jobRunID == null) {
+    // TODO: DCOS-48982 Check if the job actually exists
+    if (jobID == null || jobRunID == null) {
       return;
     }
 

--- a/system-tests/jobs/test-jobs.js
+++ b/system-tests/jobs/test-jobs.js
@@ -20,10 +20,14 @@ describe("Jobs", function() {
     cy.contains("Create a Job").click();
 
     // Wait for the 'New Job' dialog to appear
-    cy.get(".modal-header").contains("New Job").should("exist");
+    cy.get(".modal-header")
+      .contains("New Job")
+      .should("exist");
 
     // Fill-in the input elements
-    cy.root().getFormGroupInputFor("ID *").type(`{selectall}${fullJobName}`);
+    cy.root()
+      .getFormGroupInputFor("ID *")
+      .type(`{selectall}${fullJobName}`);
     //
     // TODO: Due to a bug in cypress you cannot type values with dots
     // cy
@@ -31,8 +35,12 @@ describe("Jobs", function() {
     //   .getFormGroupInputFor('CPUs')
     //   .type('{selectall}0.1');
     //
-    cy.root().getFormGroupInputFor("Mem (MiB)").type("{selectall}32");
-    cy.root().getFormGroupInputFor("Command").type(cmdline);
+    cy.root()
+      .getFormGroupInputFor("Mem (MiB)")
+      .type("{selectall}32");
+    cy.root()
+      .getFormGroupInputFor("Command")
+      .type(cmdline);
 
     // Click create job
     cy.contains("Create Job").click();
@@ -41,30 +49,31 @@ describe("Jobs", function() {
     cy.visitUrl(`jobs/overview/${Cypress.env("TEST_UUID")}`);
 
     // Wait for the table and the service to appear
-    cy
-      .get(".page-body-content table")
+    cy.get(".page-body-content table")
       .contains(jobName, { timeout: Timeouts.JOB_DEPLOYMENT_TIMEOUT })
       .get("a.table-cell-link-primary")
       .contains(`${jobName}`)
       .click();
 
     // open edit screen
-    cy
-      .get(".page-header-actions .dropdown")
+    cy.get(".page-header-actions .dropdown")
       .click()
       .get(".dropdown-menu-items")
       .contains("Edit")
       .click();
 
     // Check the input elements
-    cy
-      .root()
+    cy.root()
       .getFormGroupInputFor("ID *")
       .should("have.value", `${fullJobName}`);
 
-    cy.root().getFormGroupInputFor("Mem (MiB)").should("have.value", "32");
+    cy.root()
+      .getFormGroupInputFor("Mem (MiB)")
+      .should("have.value", "32");
 
-    cy.root().getFormGroupInputFor("Command").contains(`${cmdline}`);
+    cy.root()
+      .getFormGroupInputFor("Command")
+      .contains(`${cmdline}`);
   });
 
   it("creates a job with docker config", function() {
@@ -80,10 +89,14 @@ describe("Jobs", function() {
     cy.get(".button.button-primary-link.button-narrow").click();
 
     // Wait for the 'New Job' dialog to appear
-    cy.get(".modal-header").contains("New Job").should("exist");
+    cy.get(".modal-header")
+      .contains("New Job")
+      .should("exist");
 
     // Fill-in the input elements
-    cy.root().getFormGroupInputFor("ID *").type(`{selectall}${fullJobName}`);
+    cy.root()
+      .getFormGroupInputFor("ID *")
+      .type(`{selectall}${fullJobName}`);
     //
     // TODO: Due to a bug in cypress you cannot type values with dots
     // cy
@@ -91,18 +104,23 @@ describe("Jobs", function() {
     //   .getFormGroupInputFor('CPUs')
     //   .type('{selectall}0.5');
     //
-    cy.root().getFormGroupInputFor("Mem (MiB)").type("{selectall}32");
-    cy.root().getFormGroupInputFor("Command").type(cmdline);
+    cy.root()
+      .getFormGroupInputFor("Mem (MiB)")
+      .type("{selectall}32");
+    cy.root()
+      .getFormGroupInputFor("Command")
+      .type(cmdline);
 
     // Select `Docker Container`
-    cy
-      .root()
+    cy.root()
       .get(".multiple-form-modal-sidebar-menu-item")
       .contains("Docker Container")
       .click();
 
     // Fill-in image
-    cy.root().getFormGroupInputFor("Image").type("python:3");
+    cy.root()
+      .getFormGroupInputFor("Image")
+      .type("python:3");
 
     // Click crate job
     cy.contains("Create Job").click();
@@ -111,24 +129,21 @@ describe("Jobs", function() {
     cy.visitUrl(`jobs/overview/${Cypress.env("TEST_UUID")}`);
 
     // Wait for the table and the service to appear
-    cy
-      .get(".page-body-content table")
+    cy.get(".page-body-content table")
       .contains(jobName, { timeout: Timeouts.JOB_DEPLOYMENT_TIMEOUT })
       .get("a.table-cell-link-primary")
       .contains(`${jobName}`)
       .click();
 
     // open edit screen
-    cy
-      .get(".page-header-actions .dropdown")
+    cy.get(".page-header-actions .dropdown")
       .click()
       .get(".dropdown-menu-items")
       .contains("Edit")
       .click();
 
     // Fill-in the input elements
-    cy
-      .root()
+    cy.root()
       .getFormGroupInputFor("ID *")
       .should("have.value", `${fullJobName}`);
     //
@@ -138,18 +153,23 @@ describe("Jobs", function() {
     //   .getFormGroupInputFor('CPUs')
     //   .type('{selectall}0.5');
     //
-    cy.root().getFormGroupInputFor("Mem (MiB)").should("have.value", "32");
-    cy.root().getFormGroupInputFor("Command").contains(cmdline);
+    cy.root()
+      .getFormGroupInputFor("Mem (MiB)")
+      .should("have.value", "32");
+    cy.root()
+      .getFormGroupInputFor("Command")
+      .contains(cmdline);
 
     // Select `Docker Container`
-    cy
-      .root()
+    cy.root()
       .get(".multiple-form-modal-sidebar-menu-item")
       .contains("Docker Container")
       .click();
 
     // Fill-in image
-    cy.root().getFormGroupInputFor("Image").should("have.value", "python:3");
+    cy.root()
+      .getFormGroupInputFor("Image")
+      .should("have.value", "python:3");
   });
 
   it("creates a job with labels", function() {
@@ -166,10 +186,14 @@ describe("Jobs", function() {
 
     // Wait for the 'New Job' dialog to appear
     // Note: The current group contains the previous two jobs
-    cy.get(".modal-header").contains("New Job").should("exist");
+    cy.get(".modal-header")
+      .contains("New Job")
+      .should("exist");
 
     // Fill-in the input elements
-    cy.root().getFormGroupInputFor("ID *").type(`{selectall}${fullJobName}`);
+    cy.root()
+      .getFormGroupInputFor("ID *")
+      .type(`{selectall}${fullJobName}`);
     //
     // TODO: Due to a bug in cypress you cannot type values with dots
     // cy
@@ -177,40 +201,73 @@ describe("Jobs", function() {
     //   .getFormGroupInputFor('CPUs')
     //   .type('{selectall}0.5');
     //
-    cy.root().getFormGroupInputFor("Mem (MiB)").type("{selectall}32");
-    cy.root().getFormGroupInputFor("Command").type(cmdline);
+    cy.root()
+      .getFormGroupInputFor("Mem (MiB)")
+      .type("{selectall}32");
+    cy.root()
+      .getFormGroupInputFor("Command")
+      .type(cmdline);
 
     // Select `Labels`
-    cy
-      .root()
+    cy.root()
       .get(".multiple-form-modal-sidebar-menu-item")
       .contains("Labels")
       .click();
 
     // Fill-in the first label
-    cy.root().getFormGroupInputFor("Label Name").eq(0).type("camelCase");
-    cy.root().getFormGroupInputFor("Label Value").eq(0).type("test");
+    cy.root()
+      .getFormGroupInputFor("Label Name")
+      .eq(0)
+      .type("camelCase");
+    cy.root()
+      .getFormGroupInputFor("Label Value")
+      .eq(0)
+      .type("test");
 
     // Add an additional label
-    cy.get(".clickable").contains("Add Label").click({ force: true });
+    cy.get(".clickable")
+      .contains("Add Label")
+      .click({ force: true });
 
     // Fill-in the second label
-    cy.root().getFormGroupInputFor("Label Name").eq(1).type("snake_case");
-    cy.root().getFormGroupInputFor("Label Value").eq(1).type("test");
+    cy.root()
+      .getFormGroupInputFor("Label Name")
+      .eq(1)
+      .type("snake_case");
+    cy.root()
+      .getFormGroupInputFor("Label Value")
+      .eq(1)
+      .type("test");
 
     // Add an additional label
-    cy.get(".clickable").contains("Add Label").click({ force: true });
+    cy.get(".clickable")
+      .contains("Add Label")
+      .click({ force: true });
 
     // Fill-in the third label
-    cy.root().getFormGroupInputFor("Label Name").eq(2).type("lowercase");
-    cy.root().getFormGroupInputFor("Label Value").eq(2).type("test");
+    cy.root()
+      .getFormGroupInputFor("Label Name")
+      .eq(2)
+      .type("lowercase");
+    cy.root()
+      .getFormGroupInputFor("Label Value")
+      .eq(2)
+      .type("test");
 
     // Add an additional label
-    cy.get(".clickable").contains("Add Label").click({ force: true });
+    cy.get(".clickable")
+      .contains("Add Label")
+      .click({ force: true });
 
     // Fill-in the fourth label
-    cy.root().getFormGroupInputFor("Label Name").eq(3).type("UPPERCASE");
-    cy.root().getFormGroupInputFor("Label Value").eq(3).type("test");
+    cy.root()
+      .getFormGroupInputFor("Label Name")
+      .eq(3)
+      .type("UPPERCASE");
+    cy.root()
+      .getFormGroupInputFor("Label Value")
+      .eq(3)
+      .type("test");
 
     // Click crate job
     cy.contains("Create Job").click();
@@ -219,80 +276,72 @@ describe("Jobs", function() {
     cy.visitUrl(`jobs/overview/${Cypress.env("TEST_UUID")}`);
 
     // Wait for the table and the service to appear
-    cy
-      .get(".page-body-content table")
+    cy.get(".page-body-content table")
       .contains(jobName, { timeout: Timeouts.JOB_DEPLOYMENT_TIMEOUT })
       .get("a.table-cell-link-primary")
       .contains(`${jobName}`)
       .click();
 
     // open edit screen
-    cy
-      .get(".page-header-actions .dropdown")
+    cy.get(".page-header-actions .dropdown")
       .click()
       .get(".dropdown-menu-items")
       .contains("Edit")
       .click();
 
     // Fill-in the input elements
-    cy
-      .root()
+    cy.root()
       .getFormGroupInputFor("ID *")
       .should("have.value", `${fullJobName}`);
-    cy.root().getFormGroupInputFor("Mem (MiB)").should("have.value", "32");
-    cy.root().getFormGroupInputFor("Command").contains(cmdline);
+    cy.root()
+      .getFormGroupInputFor("Mem (MiB)")
+      .should("have.value", "32");
+    cy.root()
+      .getFormGroupInputFor("Command")
+      .contains(cmdline);
 
     // Select `Labels`
-    cy
-      .root()
+    cy.root()
       .get(".multiple-form-modal-sidebar-menu-item")
       .contains("Labels")
       .click();
 
     // Fill-in the first label
-    cy
-      .root()
+    cy.root()
       .getFormGroupInputFor("Label Name")
       .eq(0)
       .should("have.value", "camelCase");
-    cy
-      .root()
+    cy.root()
       .getFormGroupInputFor("Label Value")
       .eq(0)
       .should("have.value", "test");
 
     // Fill-in the second label
-    cy
-      .root()
+    cy.root()
       .getFormGroupInputFor("Label Name")
       .eq(1)
       .should("have.value", "snake_case");
-    cy
-      .root()
+    cy.root()
       .getFormGroupInputFor("Label Value")
       .eq(1)
       .should("have.value", "test");
 
     // Fill-in the third label
-    cy
-      .root()
+    cy.root()
       .getFormGroupInputFor("Label Name")
       .eq(2)
       .should("have.value", "lowercase");
-    cy
-      .root()
+    cy.root()
       .getFormGroupInputFor("Label Value")
       .eq(2)
       .should("have.value", "test");
 
     // Fill-in the fourth label
-    cy
-      .root()
+    cy.root()
       .getFormGroupInputFor("Label Name")
       .eq(3)
       .should("have.value", "UPPERCASE");
-    cy
-      .root()
+    cy.root()
       .getFormGroupInputFor("Label Value")
       .eq(3)
       .should("have.value", "test");
@@ -311,10 +360,14 @@ describe("Jobs", function() {
     cy.get(".button.button-primary-link.button-narrow").click();
 
     // Wait for the 'New Job' dialog to appear
-    cy.get(".modal-header").contains("New Job").should("exist");
+    cy.get(".modal-header")
+      .contains("New Job")
+      .should("exist");
 
     // Fill-in the input elements
-    cy.root().getFormGroupInputFor("ID *").type(`{selectall}${fullJobName}`);
+    cy.root()
+      .getFormGroupInputFor("ID *")
+      .type(`{selectall}${fullJobName}`);
     //
     // TODO: Due to a bug in cypress you cannot type values with dots
     // cy
@@ -322,12 +375,15 @@ describe("Jobs", function() {
     //   .getFormGroupInputFor('CPUs')
     //   .type('{selectall}0.1');
     //
-    cy.root().getFormGroupInputFor("Mem (MiB)").type("{selectall}32");
-    cy.root().getFormGroupInputFor("Command").type(cmdline);
+    cy.root()
+      .getFormGroupInputFor("Mem (MiB)")
+      .type("{selectall}32");
+    cy.root()
+      .getFormGroupInputFor("Command")
+      .type(cmdline);
 
     // Select `Schedule`
-    cy
-      .root()
+    cy.root()
       .get(".multiple-form-modal-sidebar-menu-item")
       .contains("Schedule")
       .click();
@@ -336,7 +392,9 @@ describe("Jobs", function() {
     cy.contains("Run on a schedule").click();
 
     // Specify a schedule
-    cy.root().getFormGroupInputFor("Cron Schedule *").type("* * * * *");
+    cy.root()
+      .getFormGroupInputFor("Cron Schedule *")
+      .type("* * * * *");
 
     // Enable schedule
     cy.contains("Enable").click();
@@ -348,24 +406,21 @@ describe("Jobs", function() {
     cy.visitUrl(`jobs/overview/${Cypress.env("TEST_UUID")}`);
 
     // Wait for the table and the service to appear
-    cy
-      .get(".page-body-content table")
+    cy.get(".page-body-content table")
       .contains(jobName, { timeout: Timeouts.JOB_DEPLOYMENT_TIMEOUT })
       .get("a.table-cell-link-primary")
       .contains(`${jobName}`)
       .click();
 
     // open edit screen
-    cy
-      .get(".page-header-actions .dropdown")
+    cy.get(".page-header-actions .dropdown")
       .click()
       .get(".dropdown-menu-items")
       .contains("Edit")
       .click();
 
     // Fill-in the input elements
-    cy
-      .root()
+    cy.root()
       .getFormGroupInputFor("ID *")
       .should("have.value", `${fullJobName}`);
     //
@@ -375,23 +430,25 @@ describe("Jobs", function() {
     //   .getFormGroupInputFor('CPUs')
     //   .type('{selectall}0.1');
     //
-    cy.root().getFormGroupInputFor("Mem (MiB)").should("have.value", "32");
-    cy.root().getFormGroupInputFor("Command").contains(cmdline);
+    cy.root()
+      .getFormGroupInputFor("Mem (MiB)")
+      .should("have.value", "32");
+    cy.root()
+      .getFormGroupInputFor("Command")
+      .contains(cmdline);
 
     // Select `Schedule`
-    cy
-      .root()
+    cy.root()
       .get(".multiple-form-modal-sidebar-menu-item")
       .contains("Schedule")
       .click();
 
-    cy
-      .root()
+    cy.root()
       .getFormGroupInputFor("Cron Schedule *")
       .should("have.value", "* * * * *");
   });
 
-  it("removes job from table when deleted", function() {
+  it("runs, stops and deletes a job", function() {
     // first create a simple job
     const jobName = "job-to-delete";
     const fullJobName = `${Cypress.env("TEST_UUID")}.${jobName}`;
@@ -400,11 +457,17 @@ describe("Jobs", function() {
     // Visit jobs
     cy.visitUrl("jobs/overview");
     cy.get(".button.button-primary-link.button-narrow").click();
-    cy.get(".modal-header").contains("New Job").should("exist");
+    cy.get(".modal-header")
+      .contains("New Job")
+      .should("exist");
 
     // Fill-in the input elements
-    cy.root().getFormGroupInputFor("ID *").type(`{selectall}${fullJobName}`);
-    cy.root().getFormGroupInputFor("Command").type(cmdline);
+    cy.root()
+      .getFormGroupInputFor("ID *")
+      .type(`{selectall}${fullJobName}`);
+    cy.root()
+      .getFormGroupInputFor("Command")
+      .type(cmdline);
 
     // Click create job
     cy.contains("Create Job").click();
@@ -413,28 +476,62 @@ describe("Jobs", function() {
     cy.visitUrl(`jobs/overview/${Cypress.env("TEST_UUID")}`);
 
     // Wait for the table and the service to appear
-    cy
-      .get(".page-body-content table")
+    cy.get(".page-body-content table")
       .contains(jobName, { timeout: Timeouts.JOB_DEPLOYMENT_TIMEOUT })
       .get("a.table-cell-link-primary")
       .contains(`${jobName}`)
       .click();
 
-    // open edit screen
-    cy
-      .get(".page-header-actions .dropdown")
+    // run job
+    cy.get(".page-header-actions .dropdown").click();
+    cy.get(".dropdown-menu-items")
+      .contains("Run Now")
+      .click();
+    cy.wait(10000); // wait 10 seconds
+    cy.get(".table-virtual-list")
+      .contains("Running")
+      .should("exist");
+
+    // stop job
+    cy.get(".table-virtual-list")
+      .children()
+      .get(".form-control-toggle-indicator")
+      .should("exist");
+    cy.get(".table-virtual-list")
+      .children()
+      .get(".form-control-toggle-indicator")
+      .click();
+    cy.get(".button-danger")
+      .contains("Stop")
+      .click();
+    cy.get(".button-danger")
+      .contains("Stop Job Run")
+      .should("exist");
+    cy.get(".button-danger")
+      .contains("Stop Job Run")
+      .click();
+    cy.get(".table-virtual-list")
+      .contains("Failed")
+      .should("exist");
+
+    // open delete screen
+    cy.get(".page-header-actions .dropdown")
       .click()
       .get(".dropdown-menu-items")
       .contains("Delete")
       .click();
 
     // click delete
-    cy.get(".modal .button-danger").contains("Delete Job").click();
+    cy.get(".modal .button-danger")
+      .contains("Delete Job")
+      .click();
 
     // Switch to the group that will contain the service
     cy.visitUrl(`jobs/overview/${Cypress.env("TEST_UUID")}`);
 
     // The job should no longer be in the table
-    cy.get(".page-body-content table").contains(jobName).should("not.exist");
+    cy.get(".page-body-content table")
+      .contains(jobName)
+      .should("not.exist");
   });
 });


### PR DESCRIPTION
Change job existence check because of jobTree structure bug.

Closes https://jira.mesosphere.com/browse/DCOS-48983

## Testing
1. Go to jobs tab and create a new job, for example using the configuration from the jira:
```
{
  "id": "check",
  "labels": {},
  "run": {
    "cpus": 0.01,
    "mem": 128,
    "disk": 0,
    "cmd": "sleep 3600;",
    "env": {},
    "placement": {
      "constraints": []
    },
    "artifacts": [],
    "maxLaunchDelay": 3600,
    "volumes": [],
    "restart": {
      "policy": "NEVER"
    },
    "secrets": {}
  },
  "schedules": []
}
```
2. Click it, run it and wait for it to be running
3. Click the checkbox next to running instance table row, click the stop button and verify that the modal closes, the job stops and the table row shows "Failed"
4. Verify that the new system test makes sense

## Trade-offs
While investigating this, @nLight and I discovered it was caused by a problem with the way jobs are saved. This is a temporary solution, the underlying problem should be resolved by https://jira.mesosphere.com/browse/DCOS-48982 .

## Dependencies
None.

## Screenshots
### Before
![peek 2019-02-22 15-50](https://user-images.githubusercontent.com/40791275/53246816-5c305880-36ba-11e9-90bb-f76e025ccbd3.gif)

### After
![peek 2019-02-22 15-33](https://user-images.githubusercontent.com/40791275/53246829-681c1a80-36ba-11e9-9c87-b752aaf3a97b.gif)
