### PR TITLE
update type-defs to match our react-version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4150,10 +4150,14 @@
       "dev": true
     },
     "@types/react": {
-      "version": "15.0.39",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-15.0.39.tgz",
-      "integrity": "sha512-rbkuOYo9XIDQf1evW8VQXW/PbiaJM6btbaO18u2pQ4A2PL7t4V+jx9CJp3WtWP+N3mLHiXMaHcdMmA8gSiId4A==",
-      "dev": true
+      "version": "16.8.2",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.2.tgz",
+      "integrity": "sha512-6mcKsqlqkN9xADrwiUz2gm9Wg4iGnlVGciwBRYFQSMWG6MQjhOZ/AVnxn+6v8nslFgfYTV8fNdE6XwKu6va5PA==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^2.2.0"
+      }
     },
     "@types/react-router": {
       "version": "2.0.54",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@types/jest": "22.2.3",
     "@types/lingui__react": "2.5.0",
     "@types/prop-types": "15.5.3",
-    "@types/react": "15.0.39",
+    "@types/react": "16.8.2",
     "@types/react-router": "2.0.54",
     "@types/recompose": "0.26.1",
     "autoprefixer": "6.3.6",


### PR DESCRIPTION
## Testing

run `npx tsc --noEmit -p tsconfig.json | grep error` before and after this commit and see the number of type errors decreasing. you can also check whether the version of `react` and `@types/react` are matching... 😄  

kudos to @Poltergeist for this finding!