### PR TITLE
DCOS-49072: [1.12] The nodes tab, masters sub tab shows mesos version but does not label it as mesos

### DIFF
--- a/plugins/nodes/src/js/components/LeaderGrid.js
+++ b/plugins/nodes/src/js/components/LeaderGrid.js
@@ -46,7 +46,7 @@ export default function LeaderGrid({ leader }) {
 
           <ConfigurationRow
             keyValue="version"
-            title={<FormattedMessage id="COMMON.VERSION" />}
+            title={<FormattedMessage id="COMMON.MESOSVERSION" />}
             value={leader.version}
           />
 

--- a/plugins/nodes/src/js/components/__tests__/__snapshots__/LeaderGrid-test.js.snap
+++ b/plugins/nodes/src/js/components/__tests__/__snapshots__/LeaderGrid-test.js.snap
@@ -50,7 +50,7 @@ exports[`LeaderGrid renders with running status 1`] = `
           className="configuration-map-label"
         >
           <span>
-            Version
+            Mesos Version
           </span>
         </div>
         <div

--- a/plugins/nodes/src/js/data/__tests__/__snapshots__/MesosMasters-test.js.snap
+++ b/plugins/nodes/src/js/data/__tests__/__snapshots__/MesosMasters-test.js.snap
@@ -51,7 +51,7 @@ exports[`LeaderGrid renders with running status 1`] = `
             className="configuration-map-label"
           >
             <span>
-              Version
+              Mesos Version
             </span>
           </div>
           <div

--- a/src/js/translations/en-US.json
+++ b/src/js/translations/en-US.json
@@ -9,6 +9,7 @@
   "COMMON.CLUSTER": "Cluster",
   "COMMON.LEADER": "Leader",
   "COMMON.VERSION": "Version",
+  "COMMON.MESOSVERSION": "Mesos Version",
   "COMMON.BUILT": "Built",
   "COMMON.STARTED": "Started",
   "COMMON.ELECTED": "Elected",


### PR DESCRIPTION
Label the Mesos version in Nodes Tab as "Mesos Version".

Closes https://jira.mesosphere.com/browse/DCOS-49072

## Testing
1. Go to Nodes tab, open Masters sub-tab and verify that Mesos version is shown as "Mesos Version".

## Trade-offs
None.

## Dependencies
None.

## Screenshots
### Before
![screenshot from 2019-02-26 15-27-58](https://user-images.githubusercontent.com/40791275/53416622-8e082e80-39dc-11e9-9ec6-3b8aa676cae3.png)

### After
![screenshot from 2019-02-26 15-33-11](https://user-images.githubusercontent.com/40791275/53416633-92344c00-39dc-11e9-8ebc-5af69f928862.png)
