### PR TITLE
DCOS-49577: [1.13] MesosLogContainer / TaskFileViewer never loads logs for failed tasks

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -597,6 +597,7 @@
   "No groups to add": "",
   "No health checks available": "",
   "No linked clusters": "",
+  "No log files found on this agent.": "",
   "No networks detected": "",
   "No nodes detected": "",
   "No package repositories": "",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -597,6 +597,7 @@
   "No groups to add": "没有要添加的组",
   "No health checks available": "无可用的运行状况检查",
   "No linked clusters": "无链接集群",
+  "No log files found on this agent.": "",
   "No networks detected": "未检测到网络",
   "No nodes detected": "未检测到节点",
   "No package repositories": "无包存储库",

--- a/plugins/services/src/js/pages/task-details/TaskFileViewer.js
+++ b/plugins/services/src/js/pages/task-details/TaskFileViewer.js
@@ -148,6 +148,9 @@ export default class TaskFileViewer extends React.Component {
     }
 
     const files = this.getLogFiles();
+    if (files.length === 0) {
+      return null;
+    }
 
     return (
       files.find(function(file) {
@@ -203,11 +206,22 @@ export default class TaskFileViewer extends React.Component {
     ];
   }
 
+  getNoLogFiles() {
+    return (
+      <div className="flex-grow vertical-top">
+        <Trans>No log files found on this agent.</Trans>
+      </div>
+    );
+  }
+
   render() {
     const { task } = this.props;
 
     // Only try to get path if file exists
     const selectedLogFile = this.getSelectedFile();
+    if (!selectedLogFile) {
+      return this.getNoLogFiles();
+    }
     const selectedName = selectedLogFile && selectedLogFile.getName();
     const filePath = selectedLogFile && selectedLogFile.get("path");
 


### PR DESCRIPTION
Add a check to prevent infinite loading
and a message for missing files.

Closes https://jira.mesosphere.com/browse/DCOS-49577

## Testing
1. Start a service.
2. Open the service and click on an instance.
3. In `plugins/services/src/js/pages/task-details/TaskFileViewer.js`, change line 150 from `const files = this.getLogFiles();` to `const files = []`, to mock missing files.
4. Open the logs tab for that instance.
5. Verify that it doesn't load forever and a message is shown.

## Trade-offs
None.

## Dependencies
None.

## Screenshots
### Before
![screenshot from 2019-03-05 14-15-26](https://user-images.githubusercontent.com/40791275/53804980-9d91f500-3f51-11e9-8beb-593e8918565f.png)

### After
![screenshot from 2019-03-05 14-09-48](https://user-images.githubusercontent.com/40791275/53805002-ad113e00-3f51-11e9-97a7-2d0bae464eab.png)
