### PR TITLE
DCOS-49578: [1.12] MesosLogContainer / TaskFileViewer never loads logs for failed tasks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,6 +31,8 @@ pipeline {
 
     stage("Build") {
       steps {
+        // jenkins seem to have this variable set for no reason, explicitly remiving it…
+        sh "npm config delete externalplugins"
         sh "npm --unsafe-perm install"
         sh "npm run build"
       }

--- a/plugins/services/src/js/pages/task-details/TaskFileViewer.js
+++ b/plugins/services/src/js/pages/task-details/TaskFileViewer.js
@@ -147,6 +147,9 @@ export default class TaskFileViewer extends React.Component {
     }
 
     const files = this.getLogFiles();
+    if (files.length === 0) {
+      return null;
+    }
 
     return (
       files.find(function(file) {
@@ -198,11 +201,22 @@ export default class TaskFileViewer extends React.Component {
     ];
   }
 
+  getNoLogFiles() {
+    return (
+      <div className="flex-grow vertical-top">
+        <span>No log files found on this agent.</span>
+      </div>
+    );
+  }
+
   render() {
     const { task } = this.props;
 
     // Only try to get path if file exists
     const selectedLogFile = this.getSelectedFile();
+    if (!selectedLogFile) {
+      return this.getNoLogFiles();
+    }
     const selectedName = selectedLogFile && selectedLogFile.getName();
     const filePath = selectedLogFile && selectedLogFile.get("path");
 


### PR DESCRIPTION
Add a check to prevent infinite loading
and a message for missing files.

Closes https://jira.mesosphere.com/browse/DCOS-49578

## Testing
1. Start a service.
2. Open the service and click on an instance.
3. In `plugins/services/src/js/pages/task-details/TaskFileViewer.js`, change line 149 from `const files = this.getLogFiles();` to `const files = []`, to mock missing files.
4. Open the logs tab for that instance.
5. Verify that it doesn't load forever and a message is shown.

## Trade-offs
Something broke while rebasing and it shows that @nLight also commited.

## Dependencies
None.

## Screenshots
### Before
![screenshot from 2019-03-05 15-09-16](https://user-images.githubusercontent.com/40791275/53807629-b7830600-3f58-11e9-89c3-147c8b627caf.png)

### After
![screenshot from 2019-03-05 14-39-36](https://user-images.githubusercontent.com/40791275/53807391-1dbb5900-3f58-11e9-8e07-3132effa93e3.png)
