### PR TITLE
fix: assert for what is expected

### DIFF
--- a/tests/pages/system/overview/repositories/AddRepositoryFormModal-cy.js
+++ b/tests/pages/system/overview/repositories/AddRepositoryFormModal-cy.js
@@ -45,7 +45,7 @@ describe("Add Repository Form Modal", function() {
       .contains("Add")
       .click();
 
-    cy.get(".modal").should("exist");
+    cy.get(".modal").should("not.exist");
 
     // Clean up
     cy.clusterCleanup(function() {


### PR DESCRIPTION
I believe the test was just broken and passed because of the transition group quirks.

The test is to ensure that the modal is _closed_ but checks for the modal to _exist_ `cy.get(".modal").should("exist");`
Switching it to `cy.get(".modal").should("not.exist");` makes it green and actually makes sense
This is how we test closed modal in other cases `cy.get(".modal").should("to.have.length", 0);` but the `not.exist` reads better to my taste.