### PR TITLE
fix the ee-build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3109,12 +3109,11 @@
       "dev": true
     },
     "babel-plugin-macros": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.5.0.tgz",
-      "integrity": "sha512-BWw0lD0kVZAXRD3Od1kMrdmfudqzDzYv2qrN3l2ISR1HVp1EgLKfbOrYV9xmY5k3qx3RIu5uPAUZZZHpo0o5Iw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.4.1.tgz",
+      "integrity": "sha512-pUdm8I6LAcKIzh6H2JZ1QUJByg7Im5/llcUHD/T9mTtlaBl/4YkHzvd6oUpT0cjIFgkCadVSHuJNVoNkLqvM1w==",
       "requires": {
-        "cosmiconfig": "^5.0.5",
-        "resolve": "^1.8.1"
+        "cosmiconfig": "^5.0.5"
       }
     },
     "babel-plugin-react-transform": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "babel-cli": "6.26.0",
     "babel-core": "6.26.3",
     "babel-loader": "7.1.5",
-    "babel-plugin-macros": "2.5.0",
+    "babel-plugin-macros": "2.4.1",
     "babel-plugin-transform-runtime": "6.23.0",
     "babel-preset-env": "1.7.0",
     "babel-preset-jest": "22.2.0",


### PR DESCRIPTION
re-enabling renovate led to an update of babel-plugin-macros.

babel-plugin-macros changed the ways it resolves macro-plugins internally (we require something outside the project-root) in
2.4.2, thus we go back to 2.4.1 for now and can try to use the
`customResolve`-options that was introduced in 2.5.0 in the future.