### PR TITLE
DCOS-19315: remove force updates

### DIFF
--- a/plugins/nodes/src/js/pages/NodesAgents.js
+++ b/plugins/nodes/src/js/pages/NodesAgents.js
@@ -83,7 +83,10 @@ var NodesAgents = createReactClass({
   },
 
   getInitialState() {
-    return Object.assign({ selectedResource: "cpus" }, DEFAULT_FILTER_OPTIONS);
+    return Object.assign(
+      { selectedResource: "cpus", nodesHealth: null },
+      DEFAULT_FILTER_OPTIONS
+    );
   },
 
   componentWillMount() {
@@ -96,9 +99,27 @@ var NodesAgents = createReactClass({
     this.store_listeners = [
       {
         name: "nodeHealth",
-        events: ["success", "error"]
+        events: ["success", "error"],
+        suppressUpdate: true
       }
     ];
+  },
+
+  updateNodeHealth() {
+    const nodesHealth = CompositeState.getNodesList()
+      .getItems()
+      .map(function(node) {
+        return node.getHealth();
+      });
+
+    this.setState({ nodesHealth });
+  },
+  onNodeHealthStoreSuccess() {
+    this.updateNodeHealth();
+  },
+
+  onNodeHealthStoreError() {
+    this.updateNodeHealth();
   },
 
   componentDidMount() {
@@ -243,11 +264,8 @@ var NodesAgents = createReactClass({
     const { filterExpression, byServiceFilter, selectedResource } = this.state;
     var data = this.internalStorage_get();
     const nodesList = data.nodes || [];
-    const nodesHealth = CompositeState.getNodesList()
-      .getItems()
-      .map(function(node) {
-        return node.getHealth();
-      });
+
+    const nodesHealth = this.state.nodesHealth;
     const isFiltering = filterExpression && filterExpression.defined;
 
     const isNodesTableContainer =

--- a/plugins/nodes/src/js/pages/NodesAgents.js
+++ b/plugins/nodes/src/js/pages/NodesAgents.js
@@ -139,7 +139,6 @@ var NodesAgents = createReactClass({
 
   onMesosStateChange() {
     this.internalStorage_update(getMesosHosts(this.state));
-    this.forceUpdate();
   },
 
   resetFilter() {

--- a/plugins/nodes/src/js/pages/nodes/NodeDetailPage.js
+++ b/plugins/nodes/src/js/pages/nodes/NodeDetailPage.js
@@ -23,7 +23,7 @@ class NodeDetailPage extends mixin(TabsMixin, StoreMixin) {
 
     this.store_listeners = [
       { name: "summary", events: ["success"], suppressUpdate: true },
-      { name: "state", events: ["success"], suppressUpdate: false },
+      { name: "state", events: ["success"], suppressUpdate: true },
       {
         name: "nodeHealth",
         events: ["nodeSuccess", "nodeError", "unitsSuccess", "unitsError"],
@@ -96,6 +96,13 @@ class NodeDetailPage extends mixin(TabsMixin, StoreMixin) {
     }
   }
 
+  onSummaryStoreSuccess() {
+    this.setState({
+      summaryStatesProcessed: MesosSummaryStore.get("statesProcessed"),
+      summaryStates: MesosSummaryStore.get("states")
+    });
+  }
+
   updateCurrentTab(nextProps) {
     const { routes } = nextProps || this.props;
     const currentTab = RouterUtil.reconstructPathFromRoutes(routes);
@@ -136,10 +143,7 @@ class NodeDetailPage extends mixin(TabsMixin, StoreMixin) {
   }
 
   render() {
-    if (
-      !MesosSummaryStore.get("statesProcessed") ||
-      !this.state.mesosStateLoaded
-    ) {
+    if (!this.state.summaryStatesProcessed || !this.state.mesosStateLoaded) {
       return this.getLoadingScreen();
     }
 

--- a/plugins/nodes/src/js/pages/nodes/NodeDetailPage.js
+++ b/plugins/nodes/src/js/pages/nodes/NodeDetailPage.js
@@ -22,12 +22,12 @@ class NodeDetailPage extends mixin(TabsMixin, StoreMixin) {
     super(...arguments);
 
     this.store_listeners = [
-      { name: "summary", events: ["success"], suppressUpdate: false },
+      { name: "summary", events: ["success"], suppressUpdate: true },
       { name: "state", events: ["success"], suppressUpdate: false },
       {
         name: "nodeHealth",
         events: ["nodeSuccess", "nodeError", "unitsSuccess", "unitsError"],
-        suppressUpdate: false
+        suppressUpdate: true
       }
     ];
 

--- a/plugins/nodes/src/js/pages/nodes/NodeDetailTab.js
+++ b/plugins/nodes/src/js/pages/nodes/NodeDetailTab.js
@@ -84,10 +84,12 @@ class NodeDetailTab extends PureComponent {
                 <Trans render="span">Registered</Trans>
               </ConfigurationMapLabel>
               <ConfigurationMapValue>
-                <DateFormat
-                  value={new Date(node.registered_time.toFixed(3) * 1000)}
-                  format={DateUtil.getFormatOptions("longMonthDateTime")}
-                />
+                {node.registered_time ? (
+                  <DateFormat
+                    value={new Date(node.registered_time.toFixed(3) * 1000)}
+                    format={DateUtil.getFormatOptions("longMonthDateTime")}
+                  />
+                ) : null}
               </ConfigurationMapValue>
             </ConfigurationMapRow>
             <ConfigurationMapRow>

--- a/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
+++ b/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
@@ -30,7 +30,7 @@ class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
         name: "nodeHealth",
         suppressUpdate: true
       },
-      { name: "state", events: ["success"], suppressUpdate: false }
+      { name: "state", events: ["success"], suppressUpdate: true }
     ];
   }
 

--- a/plugins/services/src/js/components/DeploymentsModal.js
+++ b/plugins/services/src/js/components/DeploymentsModal.js
@@ -68,7 +68,7 @@ class DeploymentsModal extends mixin(StoreMixin) {
 
     this.state = {};
     this.store_listeners = [
-      { name: "dcos", events: ["change"], suppressUpdate: false },
+      { name: "dcos", events: ["change"], suppressUpdate: true },
       {
         name: "marathon",
         events: ["deploymentRollbackSuccess", "deploymentRollbackError"],

--- a/plugins/services/src/js/components/DeploymentsModal.js
+++ b/plugins/services/src/js/components/DeploymentsModal.js
@@ -66,7 +66,10 @@ class DeploymentsModal extends mixin(StoreMixin) {
   constructor() {
     super(...arguments);
 
-    this.state = {};
+    this.state = {
+      dcosServiceDataReceived: false,
+      dcosDeploymentsList: []
+    };
     this.store_listeners = [
       { name: "dcos", events: ["change"], suppressUpdate: true },
       {
@@ -79,6 +82,13 @@ class DeploymentsModal extends mixin(StoreMixin) {
     METHODS_TO_BIND.forEach(method => {
       this[method] = this[method].bind(this);
     }, this);
+  }
+
+  onDcosStoreChange() {
+    this.setState({
+      dcosDeploymentsList: DCOSStore.deploymentsList.getItems(),
+      dcosServiceDataReceived: DCOSStore.serviceDataReceived
+    });
   }
 
   onMarathonStoreDeploymentRollbackSuccess(data) {
@@ -521,9 +531,9 @@ class DeploymentsModal extends mixin(StoreMixin) {
 
   render() {
     let content = null;
-    const deployments = DCOSStore.deploymentsList.getItems();
+    const deployments = this.state.dcosDeploymentsList;
     const { isOpen, onClose } = this.props;
-    const loading = !DCOSStore.serviceDataReceived;
+    const loading = !this.state.dcosServiceDataReceived;
 
     if (loading) {
       content = this.renderLoading();
@@ -545,12 +555,12 @@ class DeploymentsModal extends mixin(StoreMixin) {
     const deploymentsCount = deployments.length;
     const deploymentsText =
       deploymentsCount === 1 ? i18nMark("Deployment") : i18nMark("Deployments");
-    const heading = (
+    const heading = !loading ? (
       <ModalHeading>
         {deploymentsCount} <Trans render="span">Active</Trans>{" "}
         <Trans render="span" id={deploymentsText} />
       </ModalHeading>
-    );
+    ) : null;
 
     return (
       <Modal

--- a/plugins/services/src/js/containers/service-detail/ServiceDetail.js
+++ b/plugins/services/src/js/containers/service-detail/ServiceDetail.js
@@ -163,7 +163,6 @@ class ServiceDetail extends mixin(TabsMixin) {
       this.hasVolumes()
     ) {
       this.tabs_tabs["/services/overview/:id/volumes"] = "Volumes";
-      this.forceUpdate();
     }
   }
 

--- a/plugins/services/src/js/pages/ServicesPage.js
+++ b/plugins/services/src/js/pages/ServicesPage.js
@@ -37,7 +37,7 @@ var ServicesPage = createReactClass({
 
   componentWillMount() {
     this.store_listeners = [
-      { name: "notification", events: ["change"], suppressUpdate: false }
+      { name: "notification", events: ["change"], suppressUpdate: true }
     ];
     this.tabs_tabs = {
       "/services/overview": i18nMark("Services")

--- a/src/js/components/Page.js
+++ b/src/js/components/Page.js
@@ -81,7 +81,8 @@ const Page = createReactClass({
     this.store_listeners = [
       {
         name: "sidebar",
-        events: ["widthChange"]
+        events: ["widthChange"],
+        suppressUpdate: true
       }
     ];
   },

--- a/src/js/components/Page.js
+++ b/src/js/components/Page.js
@@ -7,7 +7,6 @@ import { StoreMixin } from "mesosphere-shared-reactjs";
 import { MountService } from "foundation-ui";
 import BasePageHeader from "../components/PageHeader";
 import FluidGeminiScrollbar from "./FluidGeminiScrollbar";
-import InternalStorageMixin from "../mixins/InternalStorageMixin";
 import ScrollbarUtil from "../utils/ScrollbarUtil";
 import TemplateUtil from "../utils/TemplateUtil";
 
@@ -58,7 +57,13 @@ PageHeader.propTypes = {
 const Page = createReactClass({
   displayName: "Page",
 
-  mixins: [InternalStorageMixin, StoreMixin],
+  mixins: [StoreMixin],
+
+  getInitialState() {
+    return {
+      rendered: false
+    };
+  },
 
   propTypes: {
     className: PropTypes.oneOfType([
@@ -82,10 +87,10 @@ const Page = createReactClass({
   },
 
   componentDidMount() {
-    this.internalStorage_set({
+    // eslint-disable-next-line
+    this.setState({
       rendered: true
     });
-    this.forceUpdate();
   },
 
   onSidebarStoreWidthChange() {
@@ -93,8 +98,7 @@ const Page = createReactClass({
   },
 
   getChildren() {
-    var data = this.internalStorage_get();
-    if (data.rendered === true) {
+    if (this.state.rendered === true) {
       // Avoid rendering template children twice
       return TemplateUtil.filterTemplateChildren(
         this.constructor,

--- a/src/js/components/charts/Chart.js
+++ b/src/js/components/charts/Chart.js
@@ -28,7 +28,7 @@ var Chart = createReactClass({
       {
         name: "sidebar",
         events: ["widthChange"],
-        suppressUpdate: false
+        suppressUpdate: true
       }
     ];
 

--- a/src/js/pages/DashboardPage.js
+++ b/src/js/pages/DashboardPage.js
@@ -100,7 +100,7 @@ var DashboardPage = createReactClass({
   componentWillMount() {
     this.store_listeners = [
       { name: "dcos", events: ["change"], suppressUpdate: true },
-      { name: "summary", events: ["success", "error"], suppressUpdate: false },
+      { name: "summary", events: ["success", "error"], suppressUpdate: true },
       {
         name: "unitHealth",
         events: ["success", "error"],

--- a/src/js/pages/DashboardPage.js
+++ b/src/js/pages/DashboardPage.js
@@ -25,6 +25,7 @@ import StringUtil from "../utils/StringUtil";
 import SidebarActions from "../events/SidebarActions";
 import UnitHealthStore from "../stores/UnitHealthStore";
 import DashboardHeadings from "../constants/DashboardHeadings";
+import HealthUnitsList from "../structs/HealthUnitsList";
 
 function getMesosState() {
   const states = MesosSummaryStore.get("states");
@@ -97,6 +98,13 @@ var DashboardPage = createReactClass({
     };
   },
 
+  getInitialState() {
+    return {
+      dcosServices: [],
+      unitHealthUnits: new HealthUnitsList({ items: [] })
+    };
+  },
+
   componentWillMount() {
     this.store_listeners = [
       { name: "dcos", events: ["change"], suppressUpdate: true },
@@ -104,7 +112,7 @@ var DashboardPage = createReactClass({
       {
         name: "unitHealth",
         events: ["success", "error"],
-        suppressUpdate: false
+        suppressUpdate: true
       }
     ];
 
@@ -123,8 +131,26 @@ var DashboardPage = createReactClass({
     this.internalStorage_update(getMesosState());
   },
 
+  onDcosStoreChange() {
+    this.setState({
+      dcosServices: DCOSStore.serviceTree.getServices().getItems()
+    });
+  },
+
+  onUnitHealthStoreSuccess() {
+    this.setState({
+      unitHealthUnits: UnitHealthStore.getUnits()
+    });
+  },
+
+  onUnitHealthStoreError() {
+    this.setState({
+      unitHealthUnits: UnitHealthStore.getUnits()
+    });
+  },
+
   getServicesList() {
-    const services = DCOSStore.serviceTree.getServices().getItems();
+    const services = this.state.dcosServices;
 
     const sortedServices = services.sort(function(service, other) {
       const health = service.getHealth();
@@ -137,7 +163,7 @@ var DashboardPage = createReactClass({
   },
 
   getUnits() {
-    return UnitHealthStore.getUnits();
+    return this.state.unitHealthUnits;
   },
 
   getViewAllComponentsButton() {
@@ -161,7 +187,7 @@ var DashboardPage = createReactClass({
   },
 
   getViewAllServicesBtn() {
-    let servicesCount = DCOSStore.serviceTree.getServices().getItems().length;
+    let servicesCount = this.state.dcosServices.length;
     if (!servicesCount) {
       return null;
     }

--- a/tests/pages/services/DeploymentsModal-cy.js
+++ b/tests/pages/services/DeploymentsModal-cy.js
@@ -49,8 +49,8 @@ describe("Deployments Modal", function() {
     });
 
     it("renders the deployments count", function() {
-      cy.get(".modal-header").then(function($header) {
-        expect($header.get(0).textContent).to.equal("1 Active Deployment");
+      cy.get(".modal-header-title").then(function($header) {
+        expect($header.get(0).textContent).to.contain("1 Active Deployment");
       });
     });
 


### PR DESCRIPTION
## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

- Please click through all pages that might be affected (I don't want to give detailed pages, because if I miss one you miss them too) and see if they still operate like normal. 

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

- Decided to only change this on a level in the component tree that effects a lot of element on rerenders, this should maximize the impact of this PR
- I could not trace back every removed `forceUpdate`, but I still think we should ship them. If they hide an obscure bug, then we need to create better integration tests to catch that in the future. I see no other way, except keeping them and limiting the performance for all users in the future.
- I choose to use the component state in a very trivial way, as this is IMHO also about removing magic

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

|  Page | Before  | After  |
|---|---|---|
| Dashboard  |  <img width="268" alt="Bildschirmfoto 2019-03-19 um 16 39 45" src="https://user-images.githubusercontent.com/1337046/54619896-a01e3f80-4a65-11e9-9af3-7220fbedde6c.png"> |  <img width="265" alt="Bildschirmfoto 2019-03-19 um 16 38 39" src="https://user-images.githubusercontent.com/1337046/54619813-8250da80-4a65-11e9-8004-ebb438cccabd.png"> |
| Deployments | <img width="283" alt="Bildschirmfoto 2019-03-19 um 16 41 03" src="https://user-images.githubusercontent.com/1337046/54620022-d5c32880-4a65-11e9-876e-425e95c7546e.png">  | <img width="273" alt="Bildschirmfoto 2019-03-19 um 16 42 18" src="https://user-images.githubusercontent.com/1337046/54620109-fbe8c880-4a65-11e9-9e0e-cfa1c1ee92b8.png">  |
| Nodes Agents  | <img width="270" alt="Bildschirmfoto 2019-03-19 um 16 43 38" src="https://user-images.githubusercontent.com/1337046/54620248-2dfa2a80-4a66-11e9-98c9-b725abe2d687.png">  |  <img width="270" alt="Bildschirmfoto 2019-03-19 um 16 44 38" src="https://user-images.githubusercontent.com/1337046/54620337-508c4380-4a66-11e9-83b6-0846d5a99a98.png"> |
| Nodes Detail| <img width="275" alt="Bildschirmfoto 2019-03-19 um 16 45 45" src="https://user-images.githubusercontent.com/1337046/54620463-7ca7c480-4a66-11e9-809f-6baab51e3f44.png"> | <img width="275" alt="Bildschirmfoto 2019-03-19 um 16 46 43" src="https://user-images.githubusercontent.com/1337046/54620526-99dc9300-4a66-11e9-96e3-7e6eb835a468.png"> |
| Service Detail | <img width="274" alt="Bildschirmfoto 2019-03-19 um 16 48 13" src="https://user-images.githubusercontent.com/1337046/54620670-d01a1280-4a66-11e9-8d9c-42ea5927c751.png"> | <img width="272" alt="Bildschirmfoto 2019-03-19 um 16 51 40" src="https://user-images.githubusercontent.com/1337046/54620977-4d458780-4a67-11e9-8c1b-a21ff8c84249.png"> |








