### PR TITLE
DCOS-51008: Bump marathon version

### DIFF
--- a/scripts/pre-install
+++ b/scripts/pre-install
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 SCRIPT_PATH="$(dirname "$0")/$(dirname "$(readlink "$0")")"
-MARATHON_VERSION="1.7.49-f24b03af3"
+MARATHON_VERSION="1.8.143-7c07b88f9"
 
 # Import utils
 source "${SCRIPT_PATH}/utils/git"

--- a/scripts/utils/marathon
+++ b/scripts/utils/marathon
@@ -39,7 +39,7 @@ function install_marathon_raml() {
 
   # Copy only relevant parts in the RAML directory
   header "Installing raml files"
-  cp -r "${TMP_DIR}/marathon-docs-${VERSION}/docs/rest-api/public/api/v2/"{schema,types,*.raml} "${TARGET_DIR}" \
+  cp -r "${TMP_DIR}/marathon-docs-${VERSION}/docs/rest-api/public/api/v2/"{types,*.raml} "${TARGET_DIR}" \
     && echo "$VERSION" > "${TARGET_DIR}/.marathon-version"
 
   # Cleanup


### PR DESCRIPTION
We download raml definitions to compile App definition validators for the Service Create Form

Marathon version 1.8.143-7c07b88f9

## Testing

1. Check out
2. npm i
3. Verify service form still works and validates JSON
