### PR TITLE
DCOS-49871 Support service tabs from plugins

### DIFF
--- a/plugins/services/src/js/components/modals/CreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/CreateServiceModalForm.js
@@ -3,6 +3,7 @@ import { i18nMark, withI18n } from "@lingui/react";
 import classNames from "classnames";
 import isEqual from "lodash.isequal";
 import { MountService } from "foundation-ui";
+import { Hooks } from "PluginSDK";
 import PropTypes from "prop-types";
 import React, { Component, Suspense, lazy } from "react";
 
@@ -473,7 +474,7 @@ class CreateServiceModalForm extends Component {
         ? "Service"
         : "Services";
 
-    const tabList = [
+    let tabList = [
       {
         id: "services",
         label: serviceLabel,
@@ -501,6 +502,10 @@ class CreateServiceModalForm extends Component {
           label: i18nMark("Environment")
         }
       );
+      tabList = Hooks.applyFilter(
+        "createServiceMultiContainerTabList",
+        tabList
+      );
     } else {
       tabList.push(
         { id: "placement", key: "placement", label: i18nMark("Placement") },
@@ -516,6 +521,10 @@ class CreateServiceModalForm extends Component {
           key: "environment",
           label: i18nMark("Environment")
         }
+      );
+      tabList = Hooks.applyFilter(
+        "createServiceMultiContainerTabList",
+        tabList
       );
     }
 
@@ -551,8 +560,19 @@ class CreateServiceModalForm extends Component {
     const { showAllErrors } = this.props;
     const errors = this.getErrors();
 
+    const pluginTabProps = {
+      data,
+      errors,
+      errorMap,
+      hideTopLevelErrors: !showAllErrors,
+      onAddItem: this.handleAddItem,
+      onRemoveItem: this.handleRemoveItem,
+      onTabChange: this.props.handleTabChange,
+      pathMapping: ServiceErrorPathMapping
+    };
+
     if (this.state.isPod) {
-      return [
+      const tabs = [
         <TabView id="placement" key="placement">
           <ErrorsAlert
             errors={errors}
@@ -630,9 +650,15 @@ class CreateServiceModalForm extends Component {
           />
         </TabView>
       ];
+
+      return Hooks.applyFilter(
+        "createServiceMultiContainerTabViews",
+        tabs,
+        pluginTabProps
+      );
     }
 
-    return [
+    const tabs = [
       <TabView id="placement" key="placement">
         <ErrorsAlert
           errors={errors}
@@ -708,6 +734,8 @@ class CreateServiceModalForm extends Component {
         />
       </TabView>
     ];
+
+    return Hooks.applyFilter("createServiceTabViews", tabs, pluginTabProps);
   }
 
   /**


### PR DESCRIPTION
Added the ability for a plugin to add a tab to the create service
modals, single and multi-container. This was done using
Hooks.applyFilter so that plugins could add additional navigation items
and TabView items to the CreateServiceModalForm component.

## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->
Ensure tabs and navigation doesn't break. The Hook filters created here will be used by plugins and nothing else to be tested here.

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
