### PR TITLE
Use dcos-1.13 instead of latest in the CLI modal URL

### DIFF
--- a/src/js/components/modals/CliInstallModal.js
+++ b/src/js/components/modals/CliInstallModal.js
@@ -69,7 +69,7 @@ class CliInstallModal extends React.Component {
 
     const downloadUrl = `https://downloads.dcos.io/binaries/cli/${
       osTypes[selectedOS]
-    }/x86-64/latest/dcos`;
+    }/x86-64/dcos-1.13/dcos`;
     if (selectedOS === "Windows") {
       return this.getWindowsInstallInstruction(clusterUrl, downloadUrl);
     }


### PR DESCRIPTION
Follow-up from https://github.com/dcos/dcos-ui/pull/3615

While "latest" (which contains the latest stable release of the CLI)
will be usable on stable DC/OS versions starting from 1.13 and beyond,
this URL doesn't cover the alpha, beta and RC timecycle of DC/OS 1.13.
Specifically, when DC/OS 1.13 becomes alpha or beta, we want users
to download a preview of our yet to be released CLI, not the current
stable CLI which is released for DC/OS 1.12.

As such, we're using the DC/OS 1.13 specific URL. It currently contains
the dev version of our CLI and we'll push a stable release to it while
DC/OS 1.13 is in beta or RC.

We'll reconsider using "latest" for DC/OS 1.14.

cc @ArmandGrillet @rgo3 