### PR TITLE
DCOS_OSS-4955: add api defaults as placeholders

### DIFF
--- a/plugins/jobs/src/js/components/form/RunConfigFormSection.tsx
+++ b/plugins/jobs/src/js/components/form/RunConfigFormSection.tsx
@@ -18,6 +18,7 @@ import FieldError from "#SRC/js/components/form/FieldError";
 import InfoTooltipIcon from "#SRC/js/components/form/InfoTooltipIcon";
 import { FormOutput, FormError, RestartPolicy } from "./helpers/JobFormData";
 import { getFieldError } from "./helpers/ErrorUtil";
+import { JobDataPlaceholders } from "./helpers/DefaultFormData";
 
 interface RunConfigSectionProps {
   formData: FormOutput;
@@ -89,6 +90,7 @@ class RunConfigFormSection extends React.Component<RunConfigSectionProps> {
                 type="number"
                 name="job.run.maxLaunchDelay"
                 value={formData.maxLaunchDelay}
+                placeholder={JobDataPlaceholders.maxLaunchDelay}
               />
               <FieldHelp>
                 <Trans render="span">Enter in seconds</Trans>
@@ -210,6 +212,7 @@ class RunConfigFormSection extends React.Component<RunConfigSectionProps> {
                       name={`uri.${i}.artifacts`}
                       type="text"
                       value={artifact.uri}
+                      placeholder="http://www.artifact.com"
                     />
                   </FieldAutofocus>
                 </FormGroup>

--- a/plugins/jobs/src/js/components/form/ScheduleFormSection.tsx
+++ b/plugins/jobs/src/js/components/form/ScheduleFormSection.tsx
@@ -14,6 +14,7 @@ import FieldError from "#SRC/js/components/form/FieldError";
 import MetadataStore from "#SRC/js/stores/MetadataStore";
 import { FormOutput, FormError, ConcurrentPolicy } from "./helpers/JobFormData";
 import { getFieldError } from "./helpers/ErrorUtil";
+import { JobDataPlaceholders } from "./helpers/DefaultFormData";
 
 interface ScheduleSectionProps {
   formData: FormOutput;
@@ -104,6 +105,7 @@ class ScheduleFormSection extends React.Component<ScheduleSectionProps> {
             <FieldInput
               name="schedule.cron"
               type="text"
+              placeholder="* * * * *"
               value={formData.cronSchedule}
             />
             <FieldHelp>
@@ -135,6 +137,7 @@ class ScheduleFormSection extends React.Component<ScheduleSectionProps> {
               name="schedule.timezone"
               type="text"
               value={formData.timezone}
+              placeholder={JobDataPlaceholders.timezone}
             />
             <FieldError>{timezoneErrors}</FieldError>
           </FormGroup>
@@ -158,6 +161,7 @@ class ScheduleFormSection extends React.Component<ScheduleSectionProps> {
               name="schedule.startingDeadlineSeconds"
               type="number"
               value={formData.startingDeadline}
+              placeholder={JobDataPlaceholders.startingDeadlineSeconds}
             />
             <FieldHelp>
               <Trans render="span">

--- a/plugins/jobs/src/js/components/form/helpers/DefaultFormData.ts
+++ b/plugins/jobs/src/js/components/form/helpers/DefaultFormData.ts
@@ -7,6 +7,12 @@ import {
   UcrImageKind
 } from "./JobFormData";
 
+export const JobDataPlaceholders = {
+  maxLaunchDelay: 3600,
+  timezone: "UTC",
+  startingDeadlineSeconds: 900
+};
+
 export const getDefaultJob = (): JobFormData => ({
   id: "",
   description: "",


### PR DESCRIPTION
Add API defaults for optional fields as placeholders.

Closes DCOS_OSS-4955

## Testing

Go to jobs form, ensure fields specified in [JIRA](https://jira.mesosphere.com/browse/DCOS_OSS-4955) have default as placeholder (see also screenshots).

## Trade-offs

N/A

## Dependencies

N/A

## Screenshots

<img width="932" alt="Screen Shot 2019-04-04 at 2 52 03 PM" src="https://user-images.githubusercontent.com/19582796/55591066-76ae1680-56e9-11e9-8904-00ea9c5e28ee.png">
<img width="1043" alt="Screen Shot 2019-04-04 at 2 52 15 PM" src="https://user-images.githubusercontent.com/19582796/55591073-7b72ca80-56e9-11e9-8635-425e3642e820.png">


