### PR TITLE
[DCOS-51179] Don't merge mesos summary with older summary data

### DIFF
--- a/src/js/structs/CompositeState.js
+++ b/src/js/structs/CompositeState.js
@@ -1,46 +1,19 @@
 import NodesList from "./NodesList";
 import Node from "./Node";
+import Util from "../utils/Util";
 import ServicesList from "../../../plugins/services/src/js/structs/ServicesList";
 
-const BLANK_NODE = {
+const PRESERVE_KEYS = ["master_info"];
+const MISSING_HEALTH_NODE = {
   health: 3
 };
 
-const mergeData = function(newData, data) {
-  Object.keys(newData).forEach(function(key) {
-    if (Array.isArray(newData[key])) {
-      data[key] = mergeMesosArrays(newData, data, key);
-    } else if (typeof newData[key] === "object" && data[key]) {
-      // We need to recurse over any nested objects.
-      data[key] = mergeData(newData[key], data[key]);
-    } else {
-      // Any other type of value can be replaced.
-      data[key] = newData[key];
-    }
-  });
+// replaces node data with previous node data plus health data
+const enrichNodeDataWithHealthData = (nodes, healthData) => {
+  return nodes.map(function(node) {
+    const matchedHealthNode = healthData[node.hostname] || MISSING_HEALTH_NODE;
 
-  return data;
-};
-
-const mergeMesosArrays = function(newData, data, key) {
-  if (key === "frameworks" || key === "slaves") {
-    // We need to merge the objects within the frameworks and slaves arrays.
-    return mergeObjectsById(newData[key], data[key]);
-  } else {
-    // We can replace any other array.
-    return newData[key];
-  }
-};
-
-const mergeObjectsById = function(newData, data = []) {
-  // Merge the incoming data with the old data.
-  return newData.map(function(newDatum) {
-    const oldDatum = data.find(function(datum) {
-      return datum.id === newDatum.id;
-    });
-
-    // These objects don't need to be deeply merged.
-    return { ...oldDatum, ...newDatum };
+    return { ...node, ...matchedHealthNode };
   });
 };
 
@@ -48,6 +21,7 @@ class CompositeState {
   constructor(data = {}) {
     this._refCount = 0;
     this.data = data;
+    this.nodeHealthData = {};
   }
 
   /**
@@ -76,31 +50,28 @@ class CompositeState {
     if (data == null) {
       return;
     }
+    
+    // Memoize node health data as an object with "host_ip" keys
+    this.nodeHealthData = Util.keyBy(data, "host_ip")
 
-    const oldData = this.data.slaves || [];
-    const dataByIP = {};
-
-    data.forEach(function(datum) {
-      dataByIP[datum.host_ip] = datum;
-    });
-
-    const newData = oldData.map(function(oldDatum) {
-      const matchedNode = dataByIP[oldDatum.hostname] || BLANK_NODE;
-
-      return { ...oldDatum, ...matchedNode };
-    });
-
-    this.data = {
-      ...this.data,
-      slaves: newData
-    };
+    this.data.slaves = enrichNodeDataWithHealthData(this.data.slaves || [], this.nodeHealthData)
   }
 
-  addState(data) {
+  addState(newData) {
     if (this._isDisabled()) {
       return;
     }
-    this.data = mergeData(data, this.data);
+    if (newData == null) {
+      return;
+    }
+
+    this.data = {
+      ...Util.pluck(this.data, PRESERVE_KEYS),
+      ...newData
+    };
+
+    // Reuse memoized node health data
+    this.data.slaves = enrichNodeDataWithHealthData(this.data.slaves || [], this.nodeHealthData)
   }
 
   getServiceList() {

--- a/src/js/structs/CompositeState.js
+++ b/src/js/structs/CompositeState.js
@@ -50,11 +50,14 @@ class CompositeState {
     if (data == null) {
       return;
     }
-    
-    // Memoize node health data as an object with "host_ip" keys
-    this.nodeHealthData = Util.keyBy(data, "host_ip")
 
-    this.data.slaves = enrichNodeDataWithHealthData(this.data.slaves || [], this.nodeHealthData)
+    // Memoize node health data as an object with "host_ip" keys
+    this.nodeHealthData = Util.keyBy(data, "host_ip");
+
+    this.data.slaves = enrichNodeDataWithHealthData(
+      this.data.slaves || [],
+      this.nodeHealthData
+    );
   }
 
   addState(newData) {
@@ -71,7 +74,10 @@ class CompositeState {
     };
 
     // Reuse memoized node health data
-    this.data.slaves = enrichNodeDataWithHealthData(this.data.slaves || [], this.nodeHealthData)
+    this.data.slaves = enrichNodeDataWithHealthData(
+      this.data.slaves || [],
+      this.nodeHealthData
+    );
   }
 
   getServiceList() {

--- a/src/js/structs/CompositeState.js
+++ b/src/js/structs/CompositeState.js
@@ -8,12 +8,12 @@ const MISSING_HEALTH_NODE = {
   health: 3
 };
 
-// replaces node data with previous node data plus health data
+// Mutates node data with node health data. This is much faster than mapping and creating new node objects
 const enrichNodeDataWithHealthData = (nodes, healthData) => {
-  return nodes.map(function(node) {
+  nodes.forEach(function(node) {
     const matchedHealthNode = healthData[node.hostname] || MISSING_HEALTH_NODE;
 
-    return { ...node, ...matchedHealthNode };
+    node.health = matchedHealthNode.health;
   });
 };
 
@@ -54,10 +54,8 @@ class CompositeState {
     // Memoize node health data as an object with "host_ip" keys
     this.nodeHealthData = Util.keyBy(data, "host_ip");
 
-    this.data.slaves = enrichNodeDataWithHealthData(
-      this.data.slaves || [],
-      this.nodeHealthData
-    );
+    this.data.slaves = this.data.slaves || [];
+    enrichNodeDataWithHealthData(this.data.slaves, this.nodeHealthData);
   }
 
   addState(newData) {
@@ -74,10 +72,8 @@ class CompositeState {
     };
 
     // Reuse memoized node health data
-    this.data.slaves = enrichNodeDataWithHealthData(
-      this.data.slaves || [],
-      this.nodeHealthData
-    );
+    this.data.slaves = this.data.slaves || [];
+    enrichNodeDataWithHealthData(this.data.slaves, this.nodeHealthData);
   }
 
   getServiceList() {

--- a/src/js/structs/__tests__/CompositeState-test.js
+++ b/src/js/structs/__tests__/CompositeState-test.js
@@ -79,7 +79,6 @@ describe("CompositeState", function() {
         slaves: [
           {
             hostname: "foo",
-            host_ip: "foo",
             health: 1
           }
         ]

--- a/src/js/structs/__tests__/CompositeState-test.js
+++ b/src/js/structs/__tests__/CompositeState-test.js
@@ -53,7 +53,10 @@ describe("CompositeState", function() {
     });
 
     it("preserves the master_info key", function() {
-      CompositeState.addState({ other_key: "foo-id", master_info: { foo: "bar" } });
+      CompositeState.addState({
+        other_key: "foo-id",
+        master_info: { foo: "bar" }
+      });
       CompositeState.addState({ bar: "baz" });
 
       expect(CompositeState.data).toEqual({

--- a/src/js/structs/__tests__/CompositeState-test.js
+++ b/src/js/structs/__tests__/CompositeState-test.js
@@ -16,7 +16,71 @@ describe("CompositeState", function() {
   describe("#addState", function() {
     it("adds an object to state", function() {
       CompositeState.addState({ foo: "bar" });
-      expect(CompositeState.data).toEqual({ foo: "bar" });
+      expect(CompositeState.data).toEqual({ foo: "bar", slaves: [] });
+    });
+
+    it("removes framework IDs that were not received in the new data", function() {
+      CompositeState.addState({
+        frameworks: [
+          {
+            id: "foo-id",
+            name: "foo",
+            bar: "baz"
+          }
+        ]
+      });
+
+      CompositeState.addState({
+        frameworks: [
+          {
+            id: "bar-id",
+            name: "bar",
+            bar: "baz"
+          }
+        ]
+      });
+
+      expect(CompositeState.data).toEqual({
+        slaves: [],
+        frameworks: [
+          {
+            id: "bar-id",
+            name: "bar",
+            bar: "baz"
+          }
+        ]
+      });
+    });
+
+    it("preserves the master_info key", function() {
+      CompositeState.addState({ other_key: "foo-id", master_info: { foo: "bar" } });
+      CompositeState.addState({ bar: "baz" });
+
+      expect(CompositeState.data).toEqual({
+        master_info: { foo: "bar" },
+        bar: "baz",
+        slaves: []
+      });
+    });
+
+    it("preserves node health data", function() {
+      CompositeState.addState({ slaves: [{ hostname: "foo" }] });
+      CompositeState.addNodeHealth([
+        {
+          host_ip: "foo",
+          health: 1
+        }
+      ]);
+
+      expect(CompositeState.data).toEqual({
+        slaves: [
+          {
+            hostname: "foo",
+            host_ip: "foo",
+            health: 1
+          }
+        ]
+      });
     });
   });
 
@@ -65,142 +129,33 @@ describe("CompositeState", function() {
     it("handles null data gracefully", function() {
       expect(() => CompositeState.addNodeHealth()).not.toThrow();
     });
-  });
 
-  describe("#mergeData", function() {
-    it("deeply merges old and new states", function() {
-      CompositeState.addState({ foo: "bar" });
-      CompositeState.addState({
-        baz: {
-          qux: "quux",
-          corge: {
-            grault: "garply",
-            fred: "plugh"
-          }
+    it("node health data provided for missing health nodes", function() {
+      CompositeState.addNodeHealth([
+        {
+          host_ip: "bar",
+          health: 1
         }
-      });
-      CompositeState.addState({
-        baz: {
-          qux: "quux",
-          corge: {
-            fred: "foo"
-          },
-          xyzzy: ["thud", "bar"]
-        }
-      });
-
-      expect(CompositeState.data).toEqual({
-        foo: "bar",
-        baz: {
-          qux: "quux",
-          corge: {
-            grault: "garply",
-            fred: "foo"
-          },
-          xyzzy: ["thud", "bar"]
-        }
-      });
-    });
-
-    it("merges old and new states, overwriting old with new", function() {
-      CompositeState.addState({ foo: "bar" });
-      CompositeState.addState({ baz: "qux" });
-      CompositeState.addState({ foo: "baz" });
-      expect(CompositeState.data).toEqual({ foo: "baz", baz: "qux" });
-    });
-
-    it("merges framework data set with both addState and addState", function() {
-      CompositeState.addState({
-        frameworks: [
-          {
-            id: "foo-id",
-            name: "foo",
-            baz: {
-              qux: "quux",
-              fred: "plugh"
-            }
-          },
-          {
-            id: "baz-id",
-            name: "baz",
-            baz: {
-              qux: "quux",
-              corge: "graply"
-            }
-          }
-        ]
-      });
+      ]);
 
       CompositeState.addState({
-        frameworks: [
-          {
-            id: "foo-id",
-            name: "foo",
-            bar: {
-              qux: "grault"
-            }
-          },
-          {
-            id: "baz-id",
-            name: "baz",
-            baz: {
-              corge: "quux"
-            }
-          }
+        slaves: [
+          { host_ip: "bar", hostname: "bar" },
+          { host_ip: "foo", hostname: "foo" }
         ]
       });
 
       expect(CompositeState.data).toEqual({
-        frameworks: [
+        slaves: [
           {
-            id: "foo-id",
-            name: "foo",
-            baz: {
-              qux: "quux",
-              fred: "plugh"
-            },
-            bar: {
-              qux: "grault"
-            }
+            hostname: "bar",
+            host_ip: "bar",
+            health: 1
           },
           {
-            id: "baz-id",
-            name: "baz",
-            baz: {
-              corge: "quux"
-            }
-          }
-        ]
-      });
-    });
-
-    it("removes framework IDs that were not received in the new data", function() {
-      CompositeState.addState({
-        frameworks: [
-          {
-            id: "foo-id",
-            name: "foo",
-            bar: "baz"
-          }
-        ]
-      });
-
-      CompositeState.addState({
-        frameworks: [
-          {
-            id: "bar-id",
-            name: "bar",
-            bar: "baz"
-          }
-        ]
-      });
-
-      expect(CompositeState.data).toEqual({
-        frameworks: [
-          {
-            id: "bar-id",
-            name: "bar",
-            bar: "baz"
+            hostname: "foo",
+            host_ip: "foo",
+            health: 3
           }
         ]
       });
@@ -267,12 +222,14 @@ describe("CompositeState", function() {
           {
             id: "foo-id",
             hostname: "foo",
-            _itemData: { id: "foo-id", hostname: "foo" }
+            health: 3,
+            _itemData: { id: "foo-id", hostname: "foo", health: 3 }
           },
           {
             id: "qq-id",
             hostname: "qq",
-            _itemData: { id: "qq-id", hostname: "qq" }
+            health: 3,
+            _itemData: { id: "qq-id", hostname: "qq", health: 3 }
           }
         ],
         filterProperties: {}

--- a/src/js/utils/Util.js
+++ b/src/js/utils/Util.js
@@ -26,6 +26,7 @@ const Util = {
   keyBy(array, key) {
     return array.reduce((acc, current) => {
       acc[current[key]] = current;
+
       return acc;
     }, {});
   },
@@ -38,6 +39,7 @@ const Util = {
    */
   pluck(object, allowKeys) {
     const allow = new Set(allowKeys);
+
     return Object.keys(object).reduce(function(newObject, key) {
       if (allow.has(key)) {
         newObject[key] = object[key];
@@ -55,6 +57,7 @@ const Util = {
    */
   omit(object, denyKeys) {
     const deny = new Set(denyKeys);
+
     return Object.keys(object).reduce(function(newObject, key) {
       if (!deny.has(key)) {
         newObject[key] = object[key];

--- a/src/js/utils/Util.js
+++ b/src/js/utils/Util.js
@@ -17,14 +17,46 @@ const Util = {
   },
 
   /**
-   * Copies an object, omitting blacklisted keys.
-   * @param  {Object} object        Object to copy
-   * @param  {Array} blacklistKeys  Keys to not copy over
-   * @return {Object}               Copy of object without blacklisted keys
+   * Returns a composed aggregate object given an array and a key to use as the composed
+   * object id. If the values of key are not unique, the last object is used.
+   * @param {Array} array            The collection of objects to iterate over
+   * @param {string} key             The key used to retreive a value that will become the key of the aggregate object
+   * @return {Object}                The aggregate object
    */
-  omit(object, blacklistKeys) {
+  keyBy(array, key) {
+    return array.reduce((acc, current) => {
+      acc[current[key]] = current;
+      return acc;
+    }, {});
+  },
+
+  /**
+   * Copies specific keys of an object
+   * @param  {Object} object        Object to copy
+   * @param  {Array} allowKeys      Keys to copy
+   * @return {Object}               Copy of object with allowed keys
+   */
+  pluck(object, allowKeys) {
+    const allow = new Set(allowKeys);
     return Object.keys(object).reduce(function(newObject, key) {
-      if (blacklistKeys.indexOf(key) === -1) {
+      if (allow.has(key)) {
+        newObject[key] = object[key];
+      }
+
+      return newObject;
+    }, {});
+  },
+
+  /**
+   * Copies an object, omitting specific keys.
+   * @param  {Object} object        Object to copy
+   * @param  {Array} denyKeys       Keys to not copy over
+   * @return {Object}               Copy of object without disallowed keys
+   */
+  omit(object, denyKeys) {
+    const deny = new Set(denyKeys);
+    return Object.keys(object).reduce(function(newObject, key) {
+      if (!deny.has(key)) {
         newObject[key] = object[key];
       }
 

--- a/src/js/utils/__tests__/Util-test.js
+++ b/src/js/utils/__tests__/Util-test.js
@@ -70,6 +70,31 @@ describe("Util", function() {
     });
   });
 
+  describe("#pluck", function() {
+    it("returns a copy of the object", function() {
+      var obj = { foo: "bar" };
+      var newObject = Util.pluck(obj, []);
+
+      newObject.foo = "modified";
+
+      expect(obj.foo).toEqual("bar");
+    });
+
+    it("allows multiple keys", function() {
+      var obj = {
+        foo: "bar",
+        qq: "zzz",
+        three: "pie"
+      };
+      var newObject = Util.pluck(obj, ["foo", "three"]);
+
+      expect(Object.keys(newObject).length).toEqual(2);
+      expect(newObject.foo).toEqual("bar");
+      expect(newObject.qq).toEqual(undefined);
+      expect(newObject.three).toEqual("pie");
+    });
+  });
+
   describe("#last", function() {
     describe("with incorrect input", function() {
       it("returns null for objects", function() {

--- a/tests/_fixtures/marathon-1-task/summary.json
+++ b/tests/_fixtures/marathon-1-task/summary.json
@@ -110,6 +110,14 @@
         "disk": 0,
         "mem": 0
       },
+      "domain": {
+        "fault_domain": {
+          "region": {
+            "name": "eu-central-1"
+          },
+          "zone": { "name": "eu-central-1c" }
+        }
+      },
       "pid": "slave(1)@172.17.8.101:5051",
       "registered_time": 1443995289.19971,
       "reregistered_time": 1443995289.19981,

--- a/tests/_fixtures/v0/summary.js
+++ b/tests/_fixtures/v0/summary.js
@@ -79,7 +79,9 @@ module.exports = {
     domain: {
       fault_domain: {
         region: {
-          name: ["aws/eu-central-1", "aws/eu-central-2", "aws/eu-central-3"][Math.floor(Math.random() * 3)]
+          name: ["aws/eu-central-1", "aws/eu-central-2", "aws/eu-central-3"][
+            Math.floor(Math.random() * 3)
+          ]
         },
         zone: {
           name: "aws/eu-central-1c"

--- a/tests/_fixtures/v0/summary.js
+++ b/tests/_fixtures/v0/summary.js
@@ -76,6 +76,16 @@ module.exports = {
       disk: 0,
       mem: 0
     },
+    domain: {
+      fault_domain: {
+        region: {
+          name: ["aws/eu-central-1", "aws/eu-central-2", "aws/eu-central-3"][Math.floor(Math.random() * 3)]
+        },
+        zone: {
+          name: "aws/eu-central-1c"
+        }
+      }
+    },
     pid: `slave(${i})@10.0.1.110:5051`,
     registered_time: 1443995289.19971,
     reregistered_time: 1443995289.19981,

--- a/tests/pages/services/TasksTable-cy.js
+++ b/tests/pages/services/TasksTable-cy.js
@@ -308,14 +308,14 @@ describe("Tasks Table", function() {
 
       cy.get("th.task-table-column-region-address").click();
 
-      cy.get(":nth-child(2) > .task-table-column-region-address").contains(
-        "ap-northeast-1"
+      cy.get(
+        ':nth-child(2) > .task-table-column-region-address:contains("ap-northeast-1")'
       );
-      cy.get(":nth-child(3) > .task-table-column-region-address").contains(
-        "eu-central-1"
+      cy.get(
+        ':nth-child(3) > .task-table-column-region-address:contains("eu-central-1")'
       );
-      cy.get(":nth-child(4) > .task-table-column-region-address").contains(
-        "eu-central-1"
+      cy.get(
+        ':nth-child(4) > .task-table-column-region-address:contains("eu-central-1")'
       );
     });
 
@@ -325,14 +325,14 @@ describe("Tasks Table", function() {
       cy.get("th.task-table-column-region-address").click();
       cy.get("th.task-table-column-region-address").click();
 
-      cy.get(":nth-child(2) > .task-table-column-region-address").contains(
-        "eu-central-1"
+      cy.get(
+        ':nth-child(2) > .task-table-column-region-address:contains("eu-central-1")'
       );
-      cy.get(":nth-child(3) > .task-table-column-region-address").contains(
-        "eu-central-1"
+      cy.get(
+        ':nth-child(3) > .task-table-column-region-address:contains("eu-central-1")'
       );
-      cy.get(":nth-child(4) > .task-table-column-region-address").contains(
-        "ap-northeast-1"
+      cy.get(
+        ':nth-child(4) > .task-table-column-region-address:contains("ap-northeast-1")'
       );
     });
 
@@ -341,14 +341,14 @@ describe("Tasks Table", function() {
 
       cy.get("th.task-table-column-zone-address").click();
 
-      cy.get(":nth-child(2) > .task-table-column-zone-address").contains(
-        "ap-northeast-1a"
+      cy.get(
+        ':nth-child(2) > .task-table-column-zone-address:contains("ap-northeast-1a")'
       );
-      cy.get(":nth-child(3) > .task-table-column-zone-address").contains(
-        "eu-central-1b"
+      cy.get(
+        ':nth-child(3) > .task-table-column-zone-address:contains("eu-central-1b")'
       );
-      cy.get(":nth-child(4) > .task-table-column-zone-address").contains(
-        "eu-central-1c"
+      cy.get(
+        ':nth-child(4) > .task-table-column-zone-address:contains("eu-central-1c")'
       );
     });
 
@@ -357,14 +357,15 @@ describe("Tasks Table", function() {
 
       cy.get("th.task-table-column-zone-address").click();
       cy.get("th.task-table-column-zone-address").click();
-      cy.get(":nth-child(2) > .task-table-column-zone-address").contains(
-        "eu-central-1c"
+
+      cy.get(
+        ':nth-child(2) > .task-table-column-zone-address:contains("eu-central-1c")'
       );
-      cy.get(":nth-child(3) > .task-table-column-zone-address").contains(
-        "eu-central-1b"
+      cy.get(
+        ':nth-child(3) > .task-table-column-zone-address:contains("eu-central-1b")'
       );
-      cy.get(":nth-child(4) > .task-table-column-zone-address").contains(
-        "ap-northeast-1a"
+      cy.get(
+        ':nth-child(4) > .task-table-column-zone-address:contains("ap-northeast-1a")'
       );
     });
   });


### PR DESCRIPTION
## Overview

There is no need to merge mesos summary data now that we are no longer merging stream with summary. CompositeState#addState now (mostly) replaces internal data with the exception of master_info and node health data, which is now memoized and used to update new incoming summaries.

Without a deep merge operation, addState becomes much faster. Using fixtures, the speedup is around ~10x~ 100x for incoming summary data.

## Testing

Nodes and node details should continue to operate as before with no obvious change. The only exception is that region information is now visible when using fixtures.

## Dependencies

~Currently based on https://github.com/dcos/dcos-ui/pull/3771~
