### PR TITLE
DCOS-42386: downscale mobile viewport

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -9,8 +9,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <meta name="title" content="Mesosphere DC/OS">
   <meta name="HandheldFriendly" content="True">
-  <meta name="MobileOptimized" content="320">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="MobileOptimized" content="640">
+  <meta name="viewport" content="width=640, initial-scale=0.5" />
   <link rel="icon" href="./img/components/icons/favicon.ico">
   <!--[if IE]>
       <link rel="icon shortcut" href="./img/components/icons/favicon.ico">


### PR DESCRIPTION
To mitigate Android closing the keyboard because of Modal being redrawn.

When there's not enough space for a modal on the screen it tries adjusting its dimensions causing a repaint. For some reason repaint closes Android keyboard.

So the solution is to scale down the UI so that the modal fits :)

Closes DCOS-42386

## Testing

1. Install Android Studio :)
2. Open Android emulator
3. Navigate to you local UI
4. Verify that you can focus login and password inputs without the keyboard being closed

## Trade-offs

The proper way to fix it would be fixing https://github.com/mesosphere/reactjs-components/blob/master/src/Modal/ModalContents.js#L112 so that id doesn't repaint the screen on Android devices. But that could have side effects on the Desktop version.

## Screenshots

Working version:

<img width="434" alt="Screenshot 2019-04-04 at 13 23 07" src="https://user-images.githubusercontent.com/186223/55552135-d18d4100-56dc-11e9-969d-b531bdceba80.png">

