### PR TITLE
DCOS-51221: Delete Repositores button not working for Package Repository

### DIFF
--- a/plugins/catalog/src/js/repositories/RepositoriesDelete.js
+++ b/plugins/catalog/src/js/repositories/RepositoriesDelete.js
@@ -42,7 +42,7 @@ const removePackageRepository = gql`
 `;
 
 const removePackageRepositoryGraphql = (name, uri) =>
-  dataLayer.get(removePackageRepository, {
+  dataLayer.query(removePackageRepository, {
     name,
     uri
   });

--- a/tests/pages/system/overview/repositories/RepositoriesTab-cy.js
+++ b/tests/pages/system/overview/repositories/RepositoriesTab-cy.js
@@ -45,14 +45,15 @@ describe("Installed Packages Tab", function() {
     });
   });
 
-  it("displays uninstall modal when uninstall is clicked", function() {
+  it("displays uninstall modal when uninstall is clicked and closes the modal when delete button is clicked", function() {
     cy.get(".button.button-danger-link")
       .eq(0)
       .invoke("show")
       .click({ force: true });
-    cy.get(".modal .modal-footer .button.button-danger").should(
-      "contain",
-      "Delete Repository"
-    );
+    cy.get(".modal .modal-footer .button.button-danger")
+      .should("contain", "Delete Repository")
+      .click();
+    cy.get(".modal").should("not.exist");
+    cy.get("table").should("exist");
   });
 });


### PR DESCRIPTION
Change data layer command so that deleting repositories works.

Closes https://jira.mesosphere.com/browse/DCOS-51221

~This is still work in progress. I still need to figure out how our integration tests work right now and add one for deleting.~

## Testing
1. Go to Settings > Package Repositories
2. Add a new repository, for example:
```
name: universe 2
url: https://downloads.mesosphere.com/universe/repo/repo-up-to-1.13.json.gz
priority: 0
```
3. Try to delete it
4. Verify that it gets successfully deleted

## Trade-offs
None.

## Dependencies
None.

## Screenshots
### Before
![Peek 2019-04-04 15-10](https://user-images.githubusercontent.com/40791275/55554687-110f5980-56ec-11e9-9615-7a232ad7599d.gif)

### After
![Peek 2019-04-04 15-12](https://user-images.githubusercontent.com/40791275/55554692-14a2e080-56ec-11e9-9d99-15105ffa61b2.gif)
