### PR TITLE
CI: enable flakiness reporting

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,7 +101,7 @@ pipeline {
             always {
               archiveArtifacts "cypress/**/*"
               // We currently want flaky test runs be marked as success
-              // junit "cypress/results.xml"
+              junit "cypress/results.xml"
             }
           }
         }


### PR DESCRIPTION
## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

- Our integration tests are now red if there was a flake, not only if there is an error. If the reporting in data dog shows the right data we have almost no flake anymore, so this should not make anything worse.

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
