### PR TITLE
CI: speedup CI by creating system test cluster at start

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -139,6 +139,7 @@ pipeline {
                 export CLUSTER_AUTH_INFO=\$(echo '{ "uid": "albert@bekstil.net", "description": "albert" }' | base64)
                 DCOS_CLUSTER_SETUP_ACS_TOKEN="\$CLUSTER_AUTH_TOKEN" dcos cluster setup "\$CLUSTER_URL" --provider=dcos-oidc-auth0 --insecure
                 npm run test:system
+                ./system-tests/_scripts/delete-cluster.sh
               '''
             }
           }
@@ -210,19 +211,6 @@ pipeline {
 
 
   post {
-    always {
-      withCredentials([
-        [
-          $class: "AmazonWebServicesCredentialsBinding",
-          credentialsId: "f40eebe0-f9aa-4336-b460-b2c4d7876fde",
-          accessKeyVariable: "AWS_ACCESS_KEY_ID",
-          secretKeyVariable: "AWS_SECRET_ACCESS_KEY"
-        ]
-      ]) {
-        sh "./system-tests/_scripts/delete-cluster.sh"
-      }
-    }
-
     failure {
       withCredentials([
         string(credentialsId: "8b793652-f26a-422f-a9ba-0d1e47eb9d89", variable: "SLACK_TOKEN")
@@ -234,6 +222,16 @@ pipeline {
           teamDomain: "mesosphere",
           token: "${env.SLACK_TOKEN}",
         )
+      }
+      withCredentials([
+        [
+          $class: "AmazonWebServicesCredentialsBinding",
+          credentialsId: "f40eebe0-f9aa-4336-b460-b2c4d7876fde",
+          accessKeyVariable: "AWS_ACCESS_KEY_ID",
+          secretKeyVariable: "AWS_SECRET_ACCESS_KEY"
+        ]
+      ]) {
+        sh "./system-tests/_scripts/delete-cluster.sh"
       }
     }
     unstable {

--- a/system-tests/_scripts/launch-cluster.sh
+++ b/system-tests/_scripts/launch-cluster.sh
@@ -62,14 +62,7 @@ URL=$(echo $LAUNCH_DESCRIBE | jq -r .masters[0].public_ip)
 echo $URL
 URL="http://$URL"
 
-BACKOFF=1
-until $(curl --output /dev/null --silent --head --fail ${URL}); do
-  BACKOFF=$((BACKOFF * 2))
-  sleep $BACKOFF
-done
-
 export CLUSTER_URL=${URL}
-
 if [ -f $CLUSTER_URL_FILE ]; then
   echo "Removing $CLUSTER_URL_FILE"
   rm $CLUSTER_URL_FILE

--- a/system-tests/_scripts/wait-for-cluster.sh
+++ b/system-tests/_scripts/wait-for-cluster.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+BACKOFF=1
+until $(curl --output /dev/null --silent --head --fail ${CLUSTER_URL}); do
+  BACKOFF=$((BACKOFF * 2))
+  sleep $BACKOFF
+done


### PR DESCRIPTION
## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

- [ ] See that it deletes the cluster if system test fail
- [ ] See that it deletes the cluster if system test run successfully
- [ ] See that it deletes the cluster if there is an early failure

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

- We always spawn and destroy a cluster, even if we have an early error. This additional work and cost should be compensated by ~10 minutes less runtime

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
