### PR TITLE
[DCOS-51247] fix: gm-scroll-view does not trigger onScroll events

### DIFF
--- a/plugins/nodes/src/js/components/HealthTab.js
+++ b/plugins/nodes/src/js/components/HealthTab.js
@@ -163,7 +163,7 @@ class HealthTab extends React.PureComponent {
             table-borderless-inner-columns table-hover flush-bottom"
           columns={this.getColumns()}
           colGroup={this.getColGroup()}
-          containerSelector=".gm-scroll-view"
+          containerSelector=".gm-scrollbar-container-fluid-view-width"
           data={visibleData}
           itemHeight={TableUtil.getRowHeight()}
           sortBy={{ prop: "health", order: "asc" }}

--- a/plugins/services/src/js/components/TaskDirectoryTable.js
+++ b/plugins/services/src/js/components/TaskDirectoryTable.js
@@ -204,7 +204,7 @@ class TaskDirectoryTable extends React.Component {
         className="table table-flush table-borderless-outer table-borderless-inner-columns table-hover flush-bottom"
         colGroup={this.getColGroup()}
         columns={this.getColumns()}
-        containerSelector=".gm-scroll-view"
+        containerSelector=".gm-scrollbar-container-fluid-view-width"
         data={this.props.files}
         sortBy={{ prop: "path", order: "asc" }}
       />

--- a/src/js/components/CheckboxTable.js
+++ b/src/js/components/CheckboxTable.js
@@ -216,7 +216,7 @@ class CheckboxTable extends React.Component {
         className={tableClassSet}
         columns={columns}
         colGroup={getColGroup()}
-        containerSelector=".gm-scroll-view"
+        containerSelector=".gm-scrollbar-container-fluid-view-width"
         data={data}
         itemHeight={TableUtil.getRowHeight()}
         sortBy={{ prop: sortProp, order: sortOrder }}

--- a/src/js/components/UnitHealthNodesTable.js
+++ b/src/js/components/UnitHealthNodesTable.js
@@ -119,7 +119,7 @@ class UnitHealthNodesTable extends React.Component {
           table-borderless-inner-columns table-hover flush-bottom"
         columns={this.getColumns()}
         colGroup={this.getColGroup()}
-        containerSelector=".gm-scroll-view"
+        containerSelector=".gm-scrollbar-container-fluid-view-width"
         data={this.props.nodes}
         itemHeight={TableUtil.getRowHeight()}
         sortBy={{ prop: "health", order: "asc" }}

--- a/src/js/pages/system/OrganizationTab.js
+++ b/src/js/pages/system/OrganizationTab.js
@@ -509,7 +509,7 @@ class OrganizationTab extends mixin(StoreMixin, InternalStorageMixin) {
                 table-borderless-inner-columns table-hover flush-bottom"
               columns={this.getColumns()}
               colGroup={this.getColGroup()}
-              containerSelector=".gm-scroll-view"
+              containerSelector=".gm-scrollbar-container-fluid-view-width"
               data={visibleItems}
               itemHeight={TableUtil.getRowHeight()}
               sortBy={{ prop: sortProp, order: "asc" }}

--- a/src/js/pages/system/UnitsHealthTab.js
+++ b/src/js/pages/system/UnitsHealthTab.js
@@ -247,7 +247,7 @@ class UnitsHealthTab extends mixin(StoreMixin) {
                 table-borderless-inner-columns table-hover flush-bottom"
               columns={this.getColumns()}
               colGroup={this.getColGroup()}
-              containerSelector=".gm-scroll-view"
+              containerSelector=".gm-scrollbar-container-fluid-view-width"
               data={visibleData}
               itemHeight={TableUtil.getRowHeight()}
               sortBy={{ prop: "health", order: "asc" }}


### PR DESCRIPTION
## Overview

reactjs-components Table was expecting `.gm-scroll-view` to raise scroll events in order to update it's virtual list of items. These events were not being raised because this is not the scrollable element in gemini. The new selector is the one added to &lt;GeminiScrollbar&gt; component in our FluidGeminiScrollbar wrapper.

There is another separate issue of the entire &lt;tbody&gt; getting replaced on the DOM when the event is raised, but this fixes the "giant blank screen" issue after scrolling ends and reveals a "janky scroll because the browser is too busy manipulating the DOM" issue.

## Testing

Go to the jobs history page on SOAK to see a long list and start scrolling.


