### PR TITLE
fix(TaskDetail): don't hang on loading

### DIFF
--- a/plugins/services/src/js/pages/task-details/__tests__/TaskDetail-test.js
+++ b/plugins/services/src/js/pages/task-details/__tests__/TaskDetail-test.js
@@ -70,8 +70,8 @@ describe("TaskDetail", function() {
   });
 
   describe("#componentDidMount", function() {
-    it("calls fetchDirectory after onStateStoreSuccess is called", function() {
-      TaskDetail.prototype.onStateStoreSuccess.call(mockThis);
+    it("calls fetchDirectory after onMesosStateChange is called", function() {
+      TaskDetail.prototype.onMesosStateChange.call(mockThis);
       expect(mockThis.handleFetchDirectory).toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
Services task details logs used to hang if reloaded on the logs page. This happened because it tried to fetchDirectory once immediately (using the MesosStateStore success event which only fires once), at which point the necessary information (task) wasn't available in the store. Use MesosStateStore events to retry data fetching until necessary info is available.

## Testing

- On soak, go to services page and choose a service with logs (ie data-services > cassandra)
- Go to a task detail page
- Go to logs
- They should load as expected
- Refresh on that page
- Logs should still load

## Trade-offs

It takes a while to load the logs page from a refresh because there is a significant delay in waiting to get a response from the mesos stream. The fetchDirectories request isn't made until the mesos response is available.

## Dependencies

N/A

## Screenshots

N/A
