### PR TITLE
DCOS-51596: Services Table: avoid rerenders

### DIFF
--- a/plugins/services/src/js/components/ServiceBreadcrumbs.js
+++ b/plugins/services/src/js/components/ServiceBreadcrumbs.js
@@ -142,6 +142,7 @@ class ServiceBreadcrumbs extends React.Component {
     let iconDisplay = null;
     const instancesCount = service.getInstancesCount();
     const runningInstances = service.getRunningInstancesCount();
+    const serviceStatus = service.getServiceStatus();
 
     const tooltipContent = (
       <Plural
@@ -154,7 +155,12 @@ class ServiceBreadcrumbs extends React.Component {
     if (this.props.taskID == null && this.props.params != null) {
       progressBar = (
         <BreadcrumbSupplementalContent hasProgressBar={true}>
-          <ServiceStatusProgressBar key="status-bar" service={service} />
+          <ServiceStatusProgressBar
+            key="status-bar"
+            instancesCount={instancesCount}
+            runningInstances={runningInstances}
+            serviceStatus={serviceStatus}
+          />
         </BreadcrumbSupplementalContent>
       );
     }

--- a/plugins/services/src/js/components/ServiceList.js
+++ b/plugins/services/src/js/components/ServiceList.js
@@ -7,6 +7,7 @@ import createReactClass from "create-react-class";
 import { Link, routerShape } from "react-router";
 
 import ServiceStatusIcon from "./ServiceStatusIcon";
+import { getStatusIconProps } from "../utils/ServiceStatusIconUtil";
 
 const ServiceList = createReactClass({
   displayName: "ServiceList",
@@ -50,6 +51,7 @@ const ServiceList = createReactClass({
     return services.map(service => {
       const instancesCount = service.getInstancesCount();
       const runningInstances = service.getRunningInstancesCount();
+      const iconProps = getStatusIconProps(service);
 
       const tooltipContent = (
         <Plural
@@ -81,9 +83,9 @@ const ServiceList = createReactClass({
             content: (
               <ServiceStatusIcon
                 key="icon"
-                service={service}
                 showTooltip={true}
                 tooltipContent={tooltipContent}
+                {...iconProps}
               />
             ),
             tag: "div"

--- a/plugins/services/src/js/components/ServiceStatusProgressBar.tsx
+++ b/plugins/services/src/js/components/ServiceStatusProgressBar.tsx
@@ -3,15 +3,14 @@ import * as React from "react";
 import { Tooltip } from "reactjs-components";
 
 import ProgressBar from "#SRC/js/components/ProgressBar";
-import Pod from "../structs/Pod";
-import Service from "../structs/Service";
-import ServiceTree from "../structs/ServiceTree";
 import * as ServiceStatus from "../constants/ServiceStatus";
 
 const { Plural } = require("@lingui/macro");
 
 interface ServiceStatusProgressBarProps {
-  service: Service | ServiceTree | Pod;
+  runningInstances: number;
+  instancesCount: number;
+  serviceStatus: any;
 }
 
 export const ServiceProgressBar = React.memo(
@@ -48,19 +47,15 @@ class ServiceStatusProgressBar extends React.Component<
   ServiceStatusProgressBarProps
 > {
   static propTypes = {
-    service: PropTypes.oneOfType([
-      PropTypes.instanceOf(Service),
-      PropTypes.instanceOf(ServiceTree),
-      PropTypes.instanceOf(Pod)
-    ]).isRequired
+    runningInstances: PropTypes.number.isRequired,
+    instancesCount: PropTypes.number.isRequired,
+    serviceStatus: PropTypes.object.isRequired
   };
 
   render() {
-    const { service } = this.props;
-    const instancesCount = service.getInstancesCount();
-    const runningInstances = service.getRunningInstancesCount();
+    const { instancesCount, serviceStatus, runningInstances } = this.props;
 
-    if (!ServiceStatus.showProgressBar(service.getServiceStatus())) {
+    if (!ServiceStatus.showProgressBar(serviceStatus)) {
       return null;
     }
 

--- a/plugins/services/src/js/components/__tests__/ServiceStatusProgressBar-test.js
+++ b/plugins/services/src/js/components/__tests__/ServiceStatusProgressBar-test.js
@@ -1,26 +1,108 @@
 import React from "react";
-import renderer from "react-test-renderer";
+import { shallow } from "enzyme";
 
-import { ServiceProgressBar } from "../ServiceStatusProgressBar";
+import ServiceStatusProgressBar from "../ServiceStatusProgressBar";
 
-describe("ServiceProgressBar", () => {
-  for (const [runningInstances, instancesCount] of [
-    [0, 1],
-    [0, 10],
-    [3, 4],
-    [10, 10]
-  ]) {
-    it(`displays a (${runningInstances} / ${instancesCount}) ProgressBar`, () => {
-      expect(
-        renderer
-          .create(
-            <ServiceProgressBar
-              instancesCount={instancesCount}
-              runningInstances={runningInstances}
-            />
-          )
-          .toJSON()
-      ).toMatchSnapshot();
+const Tooltip = require("reactjs-components").Tooltip;
+
+const ProgressBar = require("#SRC/js/components/ProgressBar");
+const Application = require("../../structs/Application");
+const Pod = require("../../structs/Pod");
+
+const service = new Application({
+  instances: 1,
+  tasksRunning: 1,
+  tasksHealthy: 0,
+  tasksUnhealthy: 0,
+  tasksUnknown: 0,
+  tasksStaged: 0
+});
+
+let thisInstance;
+
+describe("ServiceStatusProgressBar", function() {
+  beforeEach(function() {
+    thisInstance = shallow(
+      <ServiceStatusProgressBar
+        runningInstances={service.getRunningInstancesCount()}
+        instancesCount={service.getInstancesCount()}
+        statusText={service.getStatus()}
+      />
+    );
+  });
+
+  describe("ProgressBar", function() {
+    it("display ProgressBar", function() {
+      const pod = new Pod({
+        env: {
+          SDK_UNINSTALL: true
+        },
+        spec: {
+          scaling: {
+            instances: 10,
+            kind: "fixed"
+          }
+        },
+        instances: [
+          {
+            status: "stable"
+          },
+          {
+            status: "stable"
+          },
+          {
+            status: "stable"
+          },
+          {
+            status: "stable"
+          }
+        ]
+      });
+      thisInstance = shallow(
+        <ServiceStatusProgressBar
+          runningInstances={pod.getRunningInstancesCount()}
+          instancesCount={pod.getInstancesCount()}
+          serviceStatus={pod.getServiceStatus()}
+        />
+      );
+
+      const progressBar = thisInstance.find(ProgressBar);
+      expect(progressBar).toBeTruthy();
+      expect(progressBar.prop("total")).toBe(10);
+      expect(progressBar.prop("data")[0].value).toBe(4);
+    });
+  });
+
+  describe("Tooltip", function() {
+    it("display Tooltip", function() {
+      const service = new Application({
+        queue: {
+          overdue: true
+        }
+      });
+
+      thisInstance = shallow(
+        <ServiceStatusProgressBar
+          runningInstances={service.getRunningInstancesCount()}
+          instancesCount={service.getInstancesCount()}
+          serviceStatus={service.getStatus()}
+        />
+      );
+
+      expect(expect(thisInstance.find(Tooltip).exists())).toBeTruthy();
+    });
+
+    it("get #getTooltipContent", function() {
+      const childrenContent = shallow(
+        thisInstance.instance().getTooltipContent()
+      )
+        .find("WithI18n")
+        .props().values;
+
+      expect(childrenContent).toMatchObject({
+        instancesCount: 1,
+        runningInstances: 0
+      });
     });
   }
 });

--- a/plugins/services/src/js/containers/pod-detail/PodHeader.js
+++ b/plugins/services/src/js/containers/pod-detail/PodHeader.js
@@ -109,6 +109,8 @@ class PodHeader extends React.Component {
   getSubHeader(pod) {
     const serviceHealth = pod.getHealth();
     const serviceStatus = pod.getServiceStatus();
+    const runningInstances = pod.getRunningInstancesCount();
+    const instancesCount = pod.getInstancesCount();
     const tasksSummary = pod.getTasksSummary();
     const serviceStatusClassSet =
       StatusMapping[serviceStatus.displayName] || "";
@@ -130,7 +132,14 @@ class PodHeader extends React.Component {
         shouldShow: runningTasksCount != null && runningTasksSubHeader != null
       },
       {
-        label: <ServiceStatusProgressBar service={pod} />,
+        label: (
+          <ServiceStatusProgressBar
+            service={pod}
+            instancesCount={instancesCount}
+            runningInstances={runningInstances}
+            serviceStatus={serviceStatus}
+          />
+        ),
         shouldShow: true
       }
     ].map(function(item, index) {

--- a/plugins/services/src/js/containers/services/__tests__/ServicesTableRenderers-test.js
+++ b/plugins/services/src/js/containers/services/__tests__/ServicesTableRenderers-test.js
@@ -1,0 +1,172 @@
+import { regionRenderer } from "../../../columns/ServicesTableRegionColumn";
+import { cpuRenderer } from "../../../columns/ServicesTableCPUColumn";
+import { memRenderer } from "../../../columns/ServicesTableMemColumn";
+import { diskRenderer } from "../../../columns/ServicesTableDiskColumn";
+import { gpuRenderer } from "../../../columns/ServicesTableGPUColumn";
+
+// Explicitly mock for react-intl
+jest.mock("../../../components/modals/ServiceActionDisabledModal");
+
+/* eslint-disable no-unused-vars */
+const React = require("react");
+/* eslint-enable no-unused-vars */
+const renderer = require("react-test-renderer");
+const Application = require("../../../structs/Application");
+
+describe("ServicesTable", function() {
+  const healthyService = new Application({
+    healthChecks: [{ path: "", protocol: "HTTP" }],
+    cpus: 1,
+    gpus: 1,
+    instances: 1,
+    mem: 2048,
+    disk: 0,
+    tasksStaged: 0,
+    tasksRunning: 2,
+    tasksHealthy: 2,
+    tasksUnhealthy: 0
+  });
+
+  describe("#renderStats", function() {
+    it("renders resources/stats cpus property", function() {
+      var cpusCell = renderer.create(cpuRenderer(healthyService)).toJSON();
+
+      expect(cpusCell).toMatchSnapshot();
+    });
+
+    it("renders resources/stats gpus property", function() {
+      var gpusCell = renderer.create(gpuRenderer(healthyService)).toJSON();
+
+      expect(gpusCell).toMatchSnapshot();
+    });
+
+    it("renders resources/stats mem property", function() {
+      var memCell = renderer.create(memRenderer(healthyService)).toJSON();
+
+      expect(memCell).toMatchSnapshot();
+    });
+
+    it("renders resources/stats disk property", function() {
+      var disksCell = renderer.create(diskRenderer(healthyService)).toJSON();
+
+      expect(disksCell).toMatchSnapshot();
+    });
+
+    it("renders sum of resources/stats cpus property", function() {
+      const application = new Application({
+        healthChecks: [{ path: "", protocol: "HTTP" }],
+        cpus: 1,
+        instances: 2,
+        mem: 2048,
+        disk: 0,
+        tasksStaged: 0,
+        tasksRunning: 2,
+        tasksHealthy: 2,
+        tasksUnhealthy: 0,
+        getResources: jest.fn()
+      });
+
+      application.getResources.mockReturnValue({ cpus: application.cpus });
+      var cpusCell = renderer.create(cpuRenderer(application)).toJSON();
+
+      expect(cpusCell).toMatchSnapshot();
+    });
+
+    it("renders sum of resources/stats gpus property", function() {
+      const application = new Application({
+        healthChecks: [{ path: "", protocol: "HTTP" }],
+        cpus: 1,
+        gpus: 1,
+        instances: 2,
+        mem: 2048,
+        disk: 0,
+        tasksStaged: 0,
+        tasksRunning: 2,
+        tasksHealthy: 2,
+        tasksUnhealthy: 0,
+        getResources: jest.fn()
+      });
+
+      application.getResources.mockReturnValue({ gpus: application.gpus });
+      var gpusCell = renderer.create(gpuRenderer(application)).toJSON();
+
+      expect(gpusCell).toMatchSnapshot();
+    });
+
+    it("renders sum of resources/stats mem property", function() {
+      const application = new Application({
+        healthChecks: [{ path: "", protocol: "HTTP" }],
+        cpus: 1,
+        gpus: 1,
+        instances: 2,
+        mem: 2048,
+        disk: 0,
+        tasksStaged: 0,
+        tasksRunning: 2,
+        tasksHealthy: 2,
+        tasksUnhealthy: 0,
+        getResources: jest.fn()
+      });
+
+      application.getResources.mockReturnValue({ mem: application.mem });
+      var memCell = renderer.create(memRenderer(application)).toJSON();
+
+      expect(memCell).toMatchSnapshot();
+    });
+
+    it("renders sum of resources/stats disk property", function() {
+      const application = new Application({
+        healthChecks: [{ path: "", protocol: "HTTP" }],
+        cpus: 1,
+        gpus: 1,
+        instances: 2,
+        mem: 2048,
+        disk: 0,
+        tasksStaged: 0,
+        tasksRunning: 2,
+        tasksHealthy: 2,
+        tasksUnhealthy: 0,
+        getResources: jest.fn()
+      });
+
+      application.getResources.mockReturnValue({ disk: application.disk });
+      var diskCell = renderer.create(diskRenderer(application)).toJSON();
+
+      expect(diskCell).toMatchSnapshot();
+    });
+  });
+
+  describe("#renderRegions", function() {
+    const renderRegions = regionRenderer;
+    let mockService;
+    beforeEach(function() {
+      mockService = {
+        getRegions: jest.fn()
+      };
+    });
+
+    it("renders with no regions", function() {
+      mockService.getRegions.mockReturnValue([]);
+
+      expect(
+        renderer.create(renderRegions(mockService)).toJSON()
+      ).toMatchSnapshot();
+    });
+
+    it("renders with one region", function() {
+      mockService.getRegions.mockReturnValue(["aws/eu-central-1"]);
+
+      expect(
+        renderer.create(renderRegions(mockService)).toJSON()
+      ).toMatchSnapshot();
+    });
+
+    it("renders with multiple regions", function() {
+      mockService.getRegions.mockReturnValue(["aws/eu-central-1", "dc-east"]);
+
+      expect(
+        renderer.create(renderRegions(mockService)).toJSON()
+      ).toMatchSnapshot();
+    });
+  });
+});

--- a/plugins/services/src/js/containers/services/__tests__/__snapshots__/ServicesTableRenderers-test.js.snap
+++ b/plugins/services/src/js/containers/services/__tests__/__snapshots__/ServicesTableRenderers-test.js.snap
@@ -1,0 +1,123 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ServicesTable #renderRegions renders with multiple regions 1`] = `
+<div
+  className="css-1c5c0a1"
+>
+  <span
+    className="tooltip-wrapper text-align-center"
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    aws/eu-central-1, dc-east
+  </span>
+</div>
+`;
+
+exports[`ServicesTable #renderRegions renders with no regions 1`] = `
+<div
+  className="css-1c5c0a1"
+>
+  <span
+    className="tooltip-wrapper text-align-center"
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    N/A
+  </span>
+</div>
+`;
+
+exports[`ServicesTable #renderRegions renders with one region 1`] = `
+<div
+  className="css-1c5c0a1"
+>
+  <span
+    className="tooltip-wrapper text-align-center"
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    aws/eu-central-1
+  </span>
+</div>
+`;
+
+exports[`ServicesTable #renderStats renders resources/stats cpus property 1`] = `
+<div
+  className="css-jupmst"
+>
+  <span>
+    1
+  </span>
+</div>
+`;
+
+exports[`ServicesTable #renderStats renders resources/stats disk property 1`] = `
+<div
+  className="css-jupmst"
+>
+  <span>
+    0 B
+  </span>
+</div>
+`;
+
+exports[`ServicesTable #renderStats renders resources/stats gpus property 1`] = `
+<div
+  className="css-jupmst"
+>
+  <span>
+    1
+  </span>
+</div>
+`;
+
+exports[`ServicesTable #renderStats renders resources/stats mem property 1`] = `
+<div
+  className="css-jupmst"
+>
+  <span>
+    2 GiB
+  </span>
+</div>
+`;
+
+exports[`ServicesTable #renderStats renders sum of resources/stats cpus property 1`] = `
+<div
+  className="css-jupmst"
+>
+  <span>
+    1
+  </span>
+</div>
+`;
+
+exports[`ServicesTable #renderStats renders sum of resources/stats gpus property 1`] = `
+<div
+  className="css-jupmst"
+>
+  <span>
+    1
+  </span>
+</div>
+`;
+
+exports[`ServicesTable #renderStats renders sum of resources/stats mem property 1`] = `
+<div
+  className="css-jupmst"
+>
+  <span>
+    2 GiB
+  </span>
+</div>
+`;
+
+exports[`ServicesTable #renderStats renders sum of resources/stats disk property 1`] = `
+<div
+  className="css-jupmst"
+>
+  <span>
+    0 B
+  </span>
+</div>
+`;

--- a/plugins/services/src/js/utils/DeclinedOffersUtil.d.ts
+++ b/plugins/services/src/js/utils/DeclinedOffersUtil.d.ts
@@ -1,0 +1,20 @@
+interface Queue {
+  app?: unknown;
+  pod?: unknown;
+  processedOffersSummary?: unknown;
+  lastUnusedOffers?: unknown;
+  since?: unknown;
+}
+
+interface ItemWithQueue {
+  getQueue(): Queue | null;
+}
+
+export default class DeclinedOffersUtil {
+  static getTimeWaiting(queue: Queue): string | null;
+  static displayDeclinedOffersWarning<T extends ItemWithQueue>(
+    item: T
+  ): boolean;
+  getSummaryFromQueue(queue: Queue): unknown;
+  getOffersFromQueue(queue: Queue): unknown;
+}

--- a/plugins/services/src/js/utils/ServiceStatusIconUtil.ts
+++ b/plugins/services/src/js/utils/ServiceStatusIconUtil.ts
@@ -1,0 +1,59 @@
+import DateUtil from "#SRC/js/utils/DateUtil";
+
+import Pod from "../structs/Pod";
+import Service from "../structs/Service";
+import ServiceTree from "../structs/ServiceTree";
+import DeclinedOffersUtil from "../utils/DeclinedOffersUtil";
+
+interface ServiceQueue {
+  since: string | null;
+}
+
+const isUnableToLaunch = (service: Service | Pod | ServiceTree) => {
+  const queue = service.getQueue() as ServiceQueue | null;
+  const UNABLE_TO_LAUNCH_TIMEOUT = 1000 * 60 * 30;
+
+  if (queue == null) {
+    return false;
+  }
+
+  return (
+    Date.now() - (DateUtil.strToMs(queue.since) || 0) >=
+    UNABLE_TO_LAUNCH_TIMEOUT
+  );
+};
+
+export function getStatusIconProps(service: Service | ServiceTree | Pod) {
+  const queue = service.getQueue() as ServiceQueue | null;
+  const isServiceTree = service instanceof ServiceTree;
+  const unableToLaunch = isUnableToLaunch(service);
+  const appsWithWarnings = isServiceTree
+    ? (service as ServiceTree)
+        .filterItems((item: any) => {
+          if (!(item instanceof ServiceTree)) {
+            return (
+              DeclinedOffersUtil.displayDeclinedOffersWarning(item) ||
+              isUnableToLaunch(item)
+            );
+          }
+
+          return false;
+        })
+        .flattenItems()
+        .getItems().length
+    : null;
+
+  return {
+    id: service.getId(),
+    timeWaiting: queue ? DeclinedOffersUtil.getTimeWaiting(queue) : null,
+    timeQueued: queue ? DateUtil.strToMs(queue.since) : null,
+    serviceStatus: service.getServiceStatus(),
+    isServiceTree,
+    isService: service instanceof Service,
+    displayDeclinedOffers: DeclinedOffersUtil.displayDeclinedOffersWarning(
+      service
+    ),
+    appsWithWarnings,
+    unableToLaunch
+  };
+}


### PR DESCRIPTION
## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

- Open a services page with react dev tools and [flash on rerender](https://blog.logrocket.com/make-react-fast-again-part-3-highlighting-component-updates-6119e45e6833) enabled and see that there are less then before this change
- Check that loading icons and deploying status bars still display as before

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

| Before                                                                                                                                        | After first commit                                                                                                                            | After - no render if no data change                                                                                                           |
|-----------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
| ![Bildschirmfoto 2019-04-08 um 16 07 45](https://user-images.githubusercontent.com/1337046/55735188-27d1eb00-5a21-11e9-9b02-5e00e866e675.png) | ![Bildschirmfoto 2019-04-08 um 16 48 55](https://user-images.githubusercontent.com/1337046/55735193-2a344500-5a21-11e9-955a-399de145727c.png) | ![Screen Shot 2019-04-09 at 2 16 10 PM](https://user-images.githubusercontent.com/2313998/55825284-b43ce600-5ad3-11e9-8082-87f9cc3fc872.png)  |