### PR TITLE
[DCOS-49688] Remove metronome subscriber from DCOSStore

### DIFF
--- a/src/js/stores/DCOSStore.d.ts
+++ b/src/js/stores/DCOSStore.d.ts
@@ -1,7 +1,0 @@
-import { EventEmitter } from "events";
-import JobTree from "#SRC/js/structs/JobTree";
-
-export default class DCOSStore extends EventEmitter {
-  jobTree: JobTree;
-  jobDataReceived: boolean;
-}


### PR DESCRIPTION
Metronome data was being kept up to date but not used in the DCOSStore. Without this subscriber, MetronomeStore will no longer poll metronome when visiting unrelated pages.

## Testing

When visiting the dashboard or other non-jobs page, you can see a request to the metronome API for jobs data. With this branch, you won't.
