### PR TITLE
Resizable Nodes and Services table columns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4126,7 +4126,7 @@
     },
     "bl": {
       "version": "1.2.2",
-      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "dev": true,
       "requires": {
@@ -4255,7 +4255,6 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
-      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -9982,8 +9981,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -10004,14 +10002,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10026,20 +10022,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -10156,8 +10149,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -10169,7 +10161,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -10184,7 +10175,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -10192,14 +10182,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -10218,7 +10206,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -10299,8 +10286,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -10312,7 +10298,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -10398,8 +10383,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -10435,7 +10419,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -10455,7 +10438,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -10499,14 +10481,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -10994,7 +10974,7 @@
     },
     "graphql-tools": {
       "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-2.23.1.tgz",
+      "resolved": "http://registry.npmjs.org/graphql-tools/-/graphql-tools-2.23.1.tgz",
       "integrity": "sha512-f85OdRuPcHvMhNqiotvgtzpx7RlY2pZW9UnmBu6AcooKVipWVyy0um9q17f78BBI+1UzwAMsfU9S6R38UGMjTQ==",
       "requires": {
         "apollo-link": "^1.2.1",
@@ -11467,8 +11447,7 @@
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "hoist-non-react-statics": {
       "version": "2.5.5",
@@ -11655,7 +11634,7 @@
     },
     "html-webpack-plugin": {
       "version": "3.2.0",
-      "resolved": "http://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
       "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
       "dev": true,
       "requires": {
@@ -20430,7 +20409,7 @@
         },
         "external-editor": {
           "version": "2.2.0",
-          "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
           "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
           "dev": true,
           "requires": {
@@ -20468,7 +20447,7 @@
         },
         "node-fetch": {
           "version": "1.6.3",
-          "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
           "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
           "dev": true,
           "requires": {
@@ -26166,7 +26145,7 @@
     },
     "speed-measure-webpack-plugin": {
       "version": "1.2.2",
-      "resolved": "http://registry.npmjs.org/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.2.2.tgz",
       "integrity": "sha512-OPssnUTAdOwl/ijqToLrYUi8xHxdC9SOVV9e2AxkOC02Hua7+Jkfh3tdFCZxiMbtlghHK5Eyz87kG/XNpeM77w==",
       "dev": true,
       "requires": {
@@ -28675,7 +28654,7 @@
       "dependencies": {
         "qs": {
           "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+          "resolved": "http://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
           "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ=",
           "dev": true
         }

--- a/plugins/nodes/src/js/columns/NodesTableCPUColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableCPUColumn.tsx
@@ -1,11 +1,14 @@
 import * as React from "react";
 import sort from "array-sort";
 import { Cell } from "@dcos/ui-kit";
+import { WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 
 import Node from "#SRC/js/structs/Node";
 import * as ResourcesUtil from "#SRC/js/utils/ResourcesUtil";
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 import ProgressBar from "#SRC/js/components/ProgressBar";
+import TableColumnResizeStore from "#SRC/js/stores/TableColumnResizeStore";
+import { columnWidthsStorageKey } from "../components/NodesTable";
 
 function getCpuUsage(data: Node): number {
   return data.getUsageStats("cpus").percentage;
@@ -43,4 +46,8 @@ const comparators = [compareNodesByCpuUsage, compareNodesByHostname];
 export function cpuSorter(data: Node[], sortDirection: SortDirection): Node[] {
   const reverse = sortDirection !== "ASC";
   return sort(data, comparators, { reverse });
+}
+
+export function cpuWidth(_: WidthArgs) {
+  return TableColumnResizeStore.get(columnWidthsStorageKey).cpu;
 }

--- a/plugins/nodes/src/js/columns/NodesTableDiskColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableDiskColumn.tsx
@@ -1,11 +1,14 @@
 import * as React from "react";
 import sort from "array-sort";
 import { Cell } from "@dcos/ui-kit";
+import { WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 
 import Node from "#SRC/js/structs/Node";
 import * as ResourcesUtil from "#SRC/js/utils/ResourcesUtil";
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 import ProgressBar from "#SRC/js/components/ProgressBar";
+import TableColumnResizeStore from "#SRC/js/stores/TableColumnResizeStore";
+import { columnWidthsStorageKey } from "../components/NodesTable";
 
 function getDiskUsage(data: Node) {
   return data.getUsageStats("disk").percentage;
@@ -45,4 +48,8 @@ const comparators = [compareNodesByDiskUsage, compareNodesByHostname];
 export function diskSorter(data: Node[], sortDirection: SortDirection): Node[] {
   const reverse = sortDirection !== "ASC";
   return sort(data, comparators, { reverse });
+}
+
+export function diskWidth(_: WidthArgs) {
+  return TableColumnResizeStore.get(columnWidthsStorageKey).disk;
 }

--- a/plugins/nodes/src/js/columns/NodesTableGPUColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableGPUColumn.tsx
@@ -1,11 +1,14 @@
 import * as React from "react";
 import sort from "array-sort";
 import { Cell } from "@dcos/ui-kit";
+import { WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 
 import Node from "#SRC/js/structs/Node";
 import * as ResourcesUtil from "#SRC/js/utils/ResourcesUtil";
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 import ProgressBar from "#SRC/js/components/ProgressBar";
+import TableColumnResizeStore from "#SRC/js/stores/TableColumnResizeStore";
+import { columnWidthsStorageKey } from "../components/NodesTable";
 
 function getGpuUsage(data: Node): number {
   return data.getUsageStats("gpus").percentage;
@@ -43,4 +46,8 @@ const comparators = [compareNodesByGpuUsage, compareNodesByHostname];
 export function gpuSorter(data: Node[], sortDirection: SortDirection): Node[] {
   const reverse = sortDirection !== "ASC";
   return sort(data, comparators, { reverse });
+}
+
+export function gpuWidth(_: WidthArgs) {
+  return TableColumnResizeStore.get(columnWidthsStorageKey).gpu;
 }

--- a/plugins/nodes/src/js/columns/NodesTableHealthColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableHealthColumn.tsx
@@ -1,8 +1,11 @@
 import * as React from "react";
 import { TextCell } from "@dcos/ui-kit";
+import { WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 
 import UnitHealthUtil from "#SRC/js/utils/UnitHealthUtil";
 import Node from "#SRC/js/structs/Node";
+import TableColumnResizeStore from "#SRC/js/stores/TableColumnResizeStore";
+import { columnWidthsStorageKey } from "../components/NodesTable";
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 
 const NodeHealth = ({
@@ -29,4 +32,8 @@ export function healthSorter(
 ): Node[] {
   const sortedData = data.sort(UnitHealthUtil.getHealthSortFunction);
   return sortDirection === "ASC" ? sortedData : sortedData.reverse();
+}
+
+export function healthWidth(_: WidthArgs) {
+  return TableColumnResizeStore.get(columnWidthsStorageKey).health;
 }

--- a/plugins/nodes/src/js/columns/NodesTableIpColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableIpColumn.tsx
@@ -10,9 +10,12 @@ import {
   greyDark,
   iconSizeXs
 } from "@dcos/ui-kit/dist/packages/design-tokens/build/js/designTokens";
+import { WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 
 import Node from "#SRC/js/structs/Node";
 import { SortDirection } from "#PLUGINS/nodes/src/js/types/SortDirection";
+import TableColumnResizeStore from "#SRC/js/stores/TableColumnResizeStore";
+import { columnWidthsStorageKey } from "../components/NodesTable";
 
 const NodeIp = React.memo(
   ({
@@ -87,4 +90,8 @@ const comparators = [compareNodesByIp];
 export function ipSorter(data: Node[], sortDirection: SortDirection): Node[] {
   const reverse = sortDirection !== "ASC";
   return sort(data, comparators, { reverse });
+}
+
+export function ipWidth(_: WidthArgs) {
+  return TableColumnResizeStore.get(columnWidthsStorageKey).host;
 }

--- a/plugins/nodes/src/js/columns/NodesTableMemColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableMemColumn.tsx
@@ -1,11 +1,14 @@
 import * as React from "react";
 import sort from "array-sort";
 import { Cell } from "@dcos/ui-kit";
+import { WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 
 import Node from "#SRC/js/structs/Node";
 import * as ResourcesUtil from "#SRC/js/utils/ResourcesUtil";
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 import ProgressBar from "#SRC/js/components/ProgressBar";
+import TableColumnResizeStore from "#SRC/js/stores/TableColumnResizeStore";
+import { columnWidthsStorageKey } from "../components/NodesTable";
 
 function getMemUsage(data: Node): number {
   return data.getUsageStats("mem").percentage;
@@ -43,4 +46,8 @@ const comparators = [compareNodesByMemUsage, compareNodesByHostname];
 export function memSorter(data: Node[], sortDirection: SortDirection): Node[] {
   const reverse = sortDirection !== "ASC";
   return sort(data, comparators, { reverse });
+}
+
+export function memWidth(_: WidthArgs) {
+  return TableColumnResizeStore.get(columnWidthsStorageKey).mem;
 }

--- a/plugins/nodes/src/js/columns/NodesTablePublicIPColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTablePublicIPColumn.tsx
@@ -1,19 +1,21 @@
 import * as React from "react";
 import { Tooltip } from "reactjs-components";
 import { TextCell } from "@dcos/ui-kit/dist/packages/table";
+import { WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 import { Trans } from "@lingui/macro";
 
 import Node from "#SRC/js/structs/Node";
+import TableColumnResizeStore from "#SRC/js/stores/TableColumnResizeStore";
+import { columnWidthsStorageKey } from "../components/NodesTable";
 
-const noPublicIps = (
-  <TextCell>
-    <Trans>N/A</Trans>
-  </TextCell>
-);
 const NodePublicIp = React.memo(
   ({ firstIp, allIps }: { firstIp: string; allIps: string }) => {
     if (!firstIp) {
-      return noPublicIps;
+      return (
+        <TextCell>
+          <Trans>N/A</Trans>
+        </TextCell>
+      );
     }
 
     if (!allIps) {
@@ -34,4 +36,7 @@ const NodesTablePublicIpColumn = (item: Node) => {
   return <NodePublicIp firstIp={publicIps[0]} allIps={publicIps.join(", ")} />;
 };
 
-export { NodesTablePublicIpColumn as default };
+const publicIPWidth = (_: WidthArgs) =>
+  TableColumnResizeStore.get(columnWidthsStorageKey).publicIP;
+
+export { NodesTablePublicIpColumn as default, publicIPWidth };

--- a/plugins/nodes/src/js/columns/NodesTableRegionColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableRegionColumn.tsx
@@ -1,8 +1,11 @@
 import * as React from "react";
 import sort from "array-sort";
 import { TextCell } from "@dcos/ui-kit";
+import { WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 
 import Node from "#SRC/js/structs/Node";
+import TableColumnResizeStore from "#SRC/js/stores/TableColumnResizeStore";
+import { columnWidthsStorageKey } from "../components/NodesTable";
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 
 const NodeRegion = React.memo(({ regionName }: { regionName: string }) => (
@@ -45,4 +48,8 @@ export function regionSorter(
 ): Node[] {
   const reverse = sortDirection !== "ASC";
   return sort(data, comparators, { reverse });
+}
+
+export function regionWidth(_: WidthArgs) {
+  return TableColumnResizeStore.get(columnWidthsStorageKey).region;
 }

--- a/plugins/nodes/src/js/columns/NodesTableTasksColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableTasksColumn.tsx
@@ -1,8 +1,11 @@
 import * as React from "react";
 import sort from "array-sort";
 import { NumberCell } from "@dcos/ui-kit";
+import { WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 
 import Node from "#SRC/js/structs/Node";
+import TableColumnResizeStore from "#SRC/js/stores/TableColumnResizeStore";
+import { columnWidthsStorageKey } from "../components/NodesTable";
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 
 const NodeTasks = React.memo(({ tasks }: { tasks: string }) => (
@@ -33,4 +36,8 @@ export function tasksSorter(
 ): Node[] {
   const reverse = sortDirection !== "ASC";
   return sort(data, comparators, { reverse });
+}
+
+export function tasksWidth(_: WidthArgs) {
+  return TableColumnResizeStore.get(columnWidthsStorageKey).tasks;
 }

--- a/plugins/nodes/src/js/columns/NodesTableTypeColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableTypeColumn.tsx
@@ -2,8 +2,11 @@ import * as React from "react";
 import sort from "array-sort";
 import { Trans } from "@lingui/macro";
 import { TextCell } from "@dcos/ui-kit";
+import { WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 
 import Node from "#SRC/js/structs/Node";
+import TableColumnResizeStore from "#SRC/js/stores/TableColumnResizeStore";
+import { columnWidthsStorageKey } from "../components/NodesTable";
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 
 const NodeType = React.memo(({ isPublic }: { isPublic: boolean }) => {
@@ -38,4 +41,8 @@ const comparators = [compareNodesByType, compareNodesByHostname];
 export function typeSorter(data: Node[], sortDirection: SortDirection): Node[] {
   const reverse = sortDirection !== "ASC";
   return sort(data, comparators, { reverse });
+}
+
+export function typeWidth(_: WidthArgs) {
+  return TableColumnResizeStore.get(columnWidthsStorageKey).type;
 }

--- a/plugins/nodes/src/js/columns/NodesTableZoneColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableZoneColumn.tsx
@@ -1,8 +1,11 @@
 import * as React from "react";
 import sort from "array-sort";
 import { TextCell } from "@dcos/ui-kit";
+import { WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 
 import Node from "#SRC/js/structs/Node";
+import TableColumnResizeStore from "#SRC/js/stores/TableColumnResizeStore";
+import { columnWidthsStorageKey } from "../components/NodesTable";
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 
 const NodeZone = React.memo(({ name }: { name: string }) => (
@@ -33,4 +36,8 @@ const comparators = [compareNodesByZone, compareNodesByHostname];
 export function zoneSorter(data: Node[], sortDirection: SortDirection): Node[] {
   const reverse = sortDirection !== "ASC";
   return sort(data, comparators, { reverse });
+}
+
+export function zoneWidth(_: WidthArgs) {
+  return TableColumnResizeStore.get(columnWidthsStorageKey).zone;
 }

--- a/plugins/nodes/src/js/components/NodesTable.tsx
+++ b/plugins/nodes/src/js/components/NodesTable.tsx
@@ -11,27 +11,61 @@ import isEqual from "lodash/isEqual";
 import NodesList from "#SRC/js/structs/NodesList";
 import Node from "#SRC/js/structs/Node";
 import Loader from "#SRC/js/components/Loader";
+import TableUtil from "#SRC/js/utils/TableUtil";
+import TableColumnResizeStore from "#SRC/js/stores/TableColumnResizeStore";
 
 import { SortDirection } from "../types/SortDirection";
 
-import { ipSorter, ipRenderer } from "../columns/NodesTableIpColumn";
-import { typeSorter, typeRenderer } from "../columns/NodesTableTypeColumn";
+import { ipSorter, ipRenderer, ipWidth } from "../columns/NodesTableIpColumn";
+import {
+  typeSorter,
+  typeRenderer,
+  typeWidth
+} from "../columns/NodesTableTypeColumn";
 import {
   regionSorter,
-  regionRenderer
+  regionRenderer,
+  regionWidth
 } from "../columns/NodesTableRegionColumn";
-import { zoneSorter, zoneRenderer } from "../columns/NodesTableZoneColumn";
+import {
+  zoneSorter,
+  zoneRenderer,
+  zoneWidth
+} from "../columns/NodesTableZoneColumn";
 import {
   healthSorter,
-  healthRenderer
+  healthRenderer,
+  healthWidth
 } from "../columns/NodesTableHealthColumn";
-import { tasksSorter, tasksRenderer } from "../columns/NodesTableTasksColumn";
-import { cpuSorter, cpuRenderer } from "../columns/NodesTableCPUColumn";
-import { memSorter, memRenderer } from "../columns/NodesTableMemColumn";
-import { diskSorter, diskRenderer } from "../columns/NodesTableDiskColumn";
-import { gpuSorter, gpuRenderer } from "../columns/NodesTableGPUColumn";
+import {
+  tasksSorter,
+  tasksRenderer,
+  tasksWidth
+} from "../columns/NodesTableTasksColumn";
+import {
+  cpuSorter,
+  cpuRenderer,
+  cpuWidth
+} from "../columns/NodesTableCPUColumn";
+import {
+  memSorter,
+  memRenderer,
+  memWidth
+} from "../columns/NodesTableMemColumn";
+import {
+  diskSorter,
+  diskRenderer,
+  diskWidth
+} from "../columns/NodesTableDiskColumn";
+import {
+  gpuSorter,
+  gpuRenderer,
+  gpuWidth
+} from "../columns/NodesTableGPUColumn";
 
-import PublicIPColumn from "../columns/NodesTablePublicIPColumn";
+import PublicIPColumn, {
+  publicIPWidth
+} from "../columns/NodesTablePublicIPColumn";
 
 interface NodesTableProps {
   withPublicIP: boolean;
@@ -47,6 +81,8 @@ interface NodesTableState {
 }
 
 type SortFunction<T> = (data: T[], sortDirection: SortDirection) => T[];
+
+export const columnWidthsStorageKey = "nodesTableColWidths";
 
 export default class NodesTable extends React.Component<
   NodesTableProps,
@@ -162,6 +198,14 @@ export default class NodesTable extends React.Component<
     }
   }
 
+  handleResize(columnName: string, resizedColWidth: number) {
+    const savedColWidths = TableColumnResizeStore.get(columnWidthsStorageKey);
+    TableColumnResizeStore.set(columnWidthsStorageKey, {
+      ...savedColWidths,
+      [columnName]: resizedColWidth
+    });
+  }
+
   shouldComponentUpdate(
     nextProps: NodesTableProps,
     nextState: NodesTableState
@@ -198,7 +242,18 @@ export default class NodesTable extends React.Component<
           />
         }
         cellRenderer={ipRenderer}
-        minWidth={120}
+        minWidth={
+          TableUtil.isColWidthCustom(columnWidthsStorageKey, "host")
+            ? undefined
+            : 120
+        }
+        resizable={true}
+        onResize={this.handleResize.bind(null, "host")}
+        width={
+          TableUtil.isColWidthCustom(columnWidthsStorageKey, "host")
+            ? ipWidth
+            : undefined
+        }
       />,
       <Column
         key="health"
@@ -210,8 +265,23 @@ export default class NodesTable extends React.Component<
           />
         }
         cellRenderer={healthRenderer}
-        minWidth={80}
-        maxWidth={100}
+        minWidth={
+          TableUtil.isColWidthCustom(columnWidthsStorageKey, "health")
+            ? undefined
+            : 80
+        }
+        maxWidth={
+          TableUtil.isColWidthCustom(columnWidthsStorageKey, "health")
+            ? undefined
+            : 100
+        }
+        resizable={true}
+        onResize={this.handleResize.bind(null, "health")}
+        width={
+          TableUtil.isColWidthCustom(columnWidthsStorageKey, "health")
+            ? healthWidth
+            : undefined
+        }
       />,
       withPublicIP ? (
         <Column
@@ -222,7 +292,18 @@ export default class NodesTable extends React.Component<
             </HeaderCell>
           }
           cellRenderer={PublicIPColumn}
-          minWidth={125}
+          minWidth={
+            TableUtil.isColWidthCustom(columnWidthsStorageKey, "publicIP")
+              ? undefined
+              : 125
+          }
+          resizable={true}
+          onResize={this.handleResize.bind(null, "publicIP")}
+          width={
+            TableUtil.isColWidthCustom(columnWidthsStorageKey, "publicIP")
+              ? publicIPWidth
+              : undefined
+          }
         />
       ) : null,
       <Column
@@ -235,7 +316,18 @@ export default class NodesTable extends React.Component<
           />
         }
         cellRenderer={typeRenderer}
-        maxWidth={70}
+        maxWidth={
+          TableUtil.isColWidthCustom(columnWidthsStorageKey, "type")
+            ? undefined
+            : 70
+        }
+        resizable={true}
+        onResize={this.handleResize.bind(null, "type")}
+        width={
+          TableUtil.isColWidthCustom(columnWidthsStorageKey, "type")
+            ? typeWidth
+            : undefined
+        }
       />,
       <Column
         key="region"
@@ -247,7 +339,18 @@ export default class NodesTable extends React.Component<
           />
         }
         cellRenderer={this.regionRenderer}
-        minWidth={170}
+        minWidth={
+          TableUtil.isColWidthCustom(columnWidthsStorageKey, "region")
+            ? undefined
+            : 170
+        }
+        resizable={true}
+        onResize={this.handleResize.bind(null, "region")}
+        width={
+          TableUtil.isColWidthCustom(columnWidthsStorageKey, "region")
+            ? regionWidth
+            : undefined
+        }
       />,
       <Column
         key="zone"
@@ -259,7 +362,18 @@ export default class NodesTable extends React.Component<
           />
         }
         cellRenderer={zoneRenderer}
-        minWidth={100}
+        minWidth={
+          TableUtil.isColWidthCustom(columnWidthsStorageKey, "zone")
+            ? undefined
+            : 100
+        }
+        resizable={true}
+        onResize={this.handleResize.bind(null, "zone")}
+        width={
+          TableUtil.isColWidthCustom(columnWidthsStorageKey, "zone")
+            ? zoneWidth
+            : undefined
+        }
       />,
       <Column
         key="tasks"
@@ -272,8 +386,23 @@ export default class NodesTable extends React.Component<
           />
         }
         cellRenderer={tasksRenderer}
-        minWidth={60}
-        maxWidth={80}
+        minWidth={
+          TableUtil.isColWidthCustom(columnWidthsStorageKey, "tasks")
+            ? undefined
+            : 60
+        }
+        maxWidth={
+          TableUtil.isColWidthCustom(columnWidthsStorageKey, "tasks")
+            ? undefined
+            : 80
+        }
+        resizable={true}
+        onResize={this.handleResize.bind(null, "tasks")}
+        width={
+          TableUtil.isColWidthCustom(columnWidthsStorageKey, "tasks")
+            ? tasksWidth
+            : undefined
+        }
       />,
       <Column
         key="cpu"
@@ -285,8 +414,19 @@ export default class NodesTable extends React.Component<
           />
         }
         cellRenderer={cpuRenderer}
-        growToFill={true}
-        minWidth={110}
+        growToFill={!TableUtil.isColWidthCustom(columnWidthsStorageKey, "cpu")}
+        minWidth={
+          TableUtil.isColWidthCustom(columnWidthsStorageKey, "cpu")
+            ? undefined
+            : 110
+        }
+        resizable={true}
+        onResize={this.handleResize.bind(null, "cpu")}
+        width={
+          TableUtil.isColWidthCustom(columnWidthsStorageKey, "cpu")
+            ? cpuWidth
+            : undefined
+        }
       />,
       <Column
         key="mem"
@@ -298,8 +438,19 @@ export default class NodesTable extends React.Component<
           />
         }
         cellRenderer={memRenderer}
-        growToFill={true}
-        minWidth={110}
+        growToFill={!TableUtil.isColWidthCustom(columnWidthsStorageKey, "mem")}
+        minWidth={
+          TableUtil.isColWidthCustom(columnWidthsStorageKey, "mem")
+            ? undefined
+            : 110
+        }
+        resizable={true}
+        onResize={this.handleResize.bind(null, "mem")}
+        width={
+          TableUtil.isColWidthCustom(columnWidthsStorageKey, "mem")
+            ? memWidth
+            : undefined
+        }
       />,
       <Column
         key="disk"
@@ -311,8 +462,19 @@ export default class NodesTable extends React.Component<
           />
         }
         cellRenderer={diskRenderer}
-        growToFill={true}
-        minWidth={110}
+        growToFill={!TableUtil.isColWidthCustom(columnWidthsStorageKey, "disk")}
+        minWidth={
+          TableUtil.isColWidthCustom(columnWidthsStorageKey, "disk")
+            ? undefined
+            : 110
+        }
+        resizable={true}
+        onResize={this.handleResize.bind(null, "disk")}
+        width={
+          TableUtil.isColWidthCustom(columnWidthsStorageKey, "disk")
+            ? diskWidth
+            : undefined
+        }
       />,
       <Column
         key="gpu"
@@ -324,8 +486,19 @@ export default class NodesTable extends React.Component<
           />
         }
         cellRenderer={gpuRenderer}
-        growToFill={true}
-        minWidth={110}
+        growToFill={!TableUtil.isColWidthCustom(columnWidthsStorageKey, "gpu")}
+        minWidth={
+          TableUtil.isColWidthCustom(columnWidthsStorageKey, "gpu")
+            ? undefined
+            : 110
+        }
+        resizable={true}
+        onResize={this.handleResize.bind(null, "gpu")}
+        width={
+          TableUtil.isColWidthCustom(columnWidthsStorageKey, "gpu")
+            ? gpuWidth
+            : undefined
+        }
       />
     ].filter((col): col is React.ReactElement => col !== null);
 

--- a/plugins/services/src/js/columns/ServicesTableCPUColumn.tsx
+++ b/plugins/services/src/js/columns/ServicesTableCPUColumn.tsx
@@ -1,10 +1,13 @@
 import * as React from "react";
 import { NumberCell } from "@dcos/ui-kit";
+import { WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 
+import TableColumnResizeStore from "#SRC/js/stores/TableColumnResizeStore";
 import Pod from "../structs/Pod";
 import Service from "../structs/Service";
 import ServiceTree from "../structs/ServiceTree";
 import Units from "#SRC/js/utils/Units";
+import { columnWidthsStorageKey } from "../containers/services/ServicesTable";
 
 export const ServiceCPU = React.memo(({ resource }: { resource: string }) => (
   <NumberCell>
@@ -16,4 +19,8 @@ export function cpuRenderer(
   service: Service | Pod | ServiceTree
 ): React.ReactNode {
   return <ServiceCPU resource={service.getResources()[`cpus`]} />;
+}
+
+export function cpuWidth(_: WidthArgs) {
+  return TableColumnResizeStore.get(columnWidthsStorageKey).cpu;
 }

--- a/plugins/services/src/js/columns/ServicesTableDiskColumn.tsx
+++ b/plugins/services/src/js/columns/ServicesTableDiskColumn.tsx
@@ -1,10 +1,13 @@
 import * as React from "react";
 import { NumberCell } from "@dcos/ui-kit";
+import { WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 
+import TableColumnResizeStore from "#SRC/js/stores/TableColumnResizeStore";
 import Pod from "../structs/Pod";
 import Service from "../structs/Service";
 import ServiceTree from "../structs/ServiceTree";
 import Units from "#SRC/js/utils/Units";
+import { columnWidthsStorageKey } from "../containers/services/ServicesTable";
 
 export const ServiceDisk = React.memo(({ resource }: { resource: string }) => (
   <NumberCell>
@@ -16,4 +19,8 @@ export function diskRenderer(
   service: Service | Pod | ServiceTree
 ): React.ReactNode {
   return <ServiceDisk resource={service.getResources()[`disk`]} />;
+}
+
+export function diskWidth(_: WidthArgs) {
+  return TableColumnResizeStore.get(columnWidthsStorageKey).disk;
 }

--- a/plugins/services/src/js/columns/ServicesTableGPUColumn.tsx
+++ b/plugins/services/src/js/columns/ServicesTableGPUColumn.tsx
@@ -1,10 +1,13 @@
 import * as React from "react";
 import { NumberCell } from "@dcos/ui-kit";
+import { WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 
+import TableColumnResizeStore from "#SRC/js/stores/TableColumnResizeStore";
 import Pod from "../structs/Pod";
 import Service from "../structs/Service";
 import ServiceTree from "../structs/ServiceTree";
 import Units from "#SRC/js/utils/Units";
+import { columnWidthsStorageKey } from "../containers/services/ServicesTable";
 
 export const ServiceGPU = React.memo(({ resource }: { resource: string }) => (
   <NumberCell>
@@ -16,4 +19,8 @@ export function gpuRenderer(
   service: Service | Pod | ServiceTree
 ): React.ReactNode {
   return <ServiceGPU resource={service.getResources()[`gpus`]} />;
+}
+
+export function gpuWidth(_: WidthArgs) {
+  return TableColumnResizeStore.get(columnWidthsStorageKey).gpu;
 }

--- a/plugins/services/src/js/columns/ServicesTableInstancesColumn.tsx
+++ b/plugins/services/src/js/columns/ServicesTableInstancesColumn.tsx
@@ -2,12 +2,15 @@ import * as React from "react";
 import { Trans } from "@lingui/macro";
 import { NumberCell } from "@dcos/ui-kit";
 import { Tooltip } from "reactjs-components";
+import { WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 
+import TableColumnResizeStore from "#SRC/js/stores/TableColumnResizeStore";
 import Pod from "../structs/Pod";
 import Service from "../structs/Service";
 import ServiceTree from "../structs/ServiceTree";
 import { EmptyStates } from "#SRC/js/constants/EmptyStates";
 import StringUtil from "#SRC/js/utils/StringUtil";
+import { columnWidthsStorageKey } from "../containers/services/ServicesTable";
 
 const ServiceInstances = React.memo(
   ({
@@ -53,4 +56,8 @@ export function instancesRenderer(
       runningInstances={service.getRunningInstancesCount()}
     />
   );
+}
+
+export function instancesWidth(_: WidthArgs) {
+  return TableColumnResizeStore.get(columnWidthsStorageKey).instances;
 }

--- a/plugins/services/src/js/columns/ServicesTableMemColumn.tsx
+++ b/plugins/services/src/js/columns/ServicesTableMemColumn.tsx
@@ -1,10 +1,13 @@
 import * as React from "react";
 import { NumberCell } from "@dcos/ui-kit";
+import { WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 
+import TableColumnResizeStore from "#SRC/js/stores/TableColumnResizeStore";
 import Pod from "../structs/Pod";
 import Service from "../structs/Service";
 import ServiceTree from "../structs/ServiceTree";
 import Units from "#SRC/js/utils/Units";
+import { columnWidthsStorageKey } from "../containers/services/ServicesTable";
 
 export const ServiceMem = React.memo(({ resource }: { resource: string }) => (
   <NumberCell>
@@ -16,4 +19,8 @@ export function memRenderer(
   service: Service | Pod | ServiceTree
 ): React.ReactNode {
   return <ServiceMem resource={service.getResources()[`mem`]} />;
+}
+
+export function memWidth(_: WidthArgs) {
+  return TableColumnResizeStore.get(columnWidthsStorageKey).mem;
 }

--- a/plugins/services/src/js/columns/ServicesTableNameColumn.tsx
+++ b/plugins/services/src/js/columns/ServicesTableNameColumn.tsx
@@ -6,11 +6,14 @@ import {
   greyDark,
   iconSizeXs
 } from "@dcos/ui-kit/dist/packages/design-tokens/build/js/designTokens";
+import { WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 
 import NestedServiceLinks from "#SRC/js/components/NestedServiceLinks";
+import TableColumnResizeStore from "#SRC/js/stores/TableColumnResizeStore";
 import ServiceTree from "../structs/ServiceTree";
 import Service from "../structs/Service";
 import Pod from "../structs/Pod";
+import { columnWidthsStorageKey } from "../containers/services/ServicesTable";
 
 const ServiceName = React.memo(
   ({
@@ -151,4 +154,8 @@ function hasWebUI(service: any): any {
     service.getWebURL() != null &&
     service.getWebURL() !== ""
   );
+}
+
+export function nameWidth(_: WidthArgs) {
+  return TableColumnResizeStore.get(columnWidthsStorageKey).name;
 }

--- a/plugins/services/src/js/columns/ServicesTableRegionColumn.tsx
+++ b/plugins/services/src/js/columns/ServicesTableRegionColumn.tsx
@@ -1,10 +1,13 @@
 import * as React from "react";
 import { TextCell } from "@dcos/ui-kit";
 import { Tooltip } from "reactjs-components";
+import { WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 
+import TableColumnResizeStore from "#SRC/js/stores/TableColumnResizeStore";
 import Pod from "../structs/Pod";
 import Service from "../structs/Service";
 import ServiceTree from "../structs/ServiceTree";
+import { columnWidthsStorageKey } from "../containers/services/ServicesTable";
 
 const ServiceRegion = React.memo(({ regions }: { regions: string }) => (
   <TextCell>
@@ -28,4 +31,8 @@ export function regionRendererFactory(localRegion: string | undefined) {
 
     return <ServiceRegion regions={regions.join(", ")} />;
   };
+}
+
+export function regionWidth(_: WidthArgs) {
+  return TableColumnResizeStore.get(columnWidthsStorageKey).region;
 }

--- a/plugins/services/src/js/columns/ServicesTableStatusColumn.tsx
+++ b/plugins/services/src/js/columns/ServicesTableStatusColumn.tsx
@@ -1,13 +1,16 @@
 import * as React from "react";
 import { Plural, Trans } from "@lingui/macro";
 import { TextCell } from "@dcos/ui-kit";
+import { WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 
 import ServiceStatusProgressBar from "#PLUGINS/services/src/js/components/ServiceStatusProgressBar";
+import TableColumnResizeStore from "#SRC/js/stores/TableColumnResizeStore";
 import * as ServiceStatus from "../constants/ServiceStatus";
 import ServiceStatusIcon from "../components/ServiceStatusIcon";
 import Pod from "../structs/Pod";
 import Service from "../structs/Service";
 import ServiceTree from "../structs/ServiceTree";
+import { columnWidthsStorageKey } from "../containers/services/ServicesTable";
 
 function statusCountsToTooltipContent(counts: {
   total: number;
@@ -104,4 +107,8 @@ export function statusCategorySorter(a: string, b: string): number {
     ServiceStatus.toCategoryPriority(b as ServiceStatus.StatusCategory) -
     ServiceStatus.toCategoryPriority(a as ServiceStatus.StatusCategory)
   );
+}
+
+export function statusWidth(_: WidthArgs) {
+  return TableColumnResizeStore.get(columnWidthsStorageKey).status;
 }

--- a/plugins/services/src/js/columns/ServicesTableVersionColumn.tsx
+++ b/plugins/services/src/js/columns/ServicesTableVersionColumn.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { TextCell } from "@dcos/ui-kit";
 import { Tooltip } from "reactjs-components";
+import { WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 
 // @ts-ignore
 import Framework from "../structs/Framework";
@@ -8,6 +9,8 @@ import Pod from "../structs/Pod";
 import Service from "../structs/Service";
 import ServiceTree from "../structs/ServiceTree";
 import * as Version from "../utils/Version";
+import TableColumnResizeStore from "#SRC/js/stores/TableColumnResizeStore";
+import { columnWidthsStorageKey } from "../containers/services/ServicesTable";
 
 const ServiceVersion = React.memo(
   ({
@@ -39,4 +42,8 @@ export function versionRenderer(
   return (
     <ServiceVersion rawVersion={rawVersion} displayVersion={displayVersion} />
   );
+}
+
+export function versionWidth(_: WidthArgs) {
+  return TableColumnResizeStore.get(columnWidthsStorageKey).version;
 }

--- a/plugins/services/src/js/containers/services/ServiceTreeView.js
+++ b/plugins/services/src/js/containers/services/ServiceTreeView.js
@@ -122,6 +122,9 @@ class ServiceTreeView extends React.Component {
             isFiltered={filterExpression.defined}
             modalHandlers={modalHandlers}
             services={services}
+            hideTable={this.context.router.routes.some(
+              ({ isFullscreenModal }) => isFullscreenModal
+            )}
           />
         </div>
         {children}

--- a/plugins/services/src/js/containers/services/ServicesTable.d.ts
+++ b/plugins/services/src/js/containers/services/ServicesTable.d.ts
@@ -1,0 +1,21 @@
+import { Component } from "react";
+import { SortDirection } from "#PLUGINS/services/src/js/types/SortDirection";
+
+interface ServiceTableProps {
+  isFiltered?: boolean;
+  services?: [];
+}
+
+interface ServiceTableState {
+  actionDisabledService: any;
+  data: [];
+  sortColumn: string;
+  sortDirection: SortDirection;
+}
+
+export const columnWidthsStorageKey: string;
+
+export default class ServicesTable extends Component<
+  ServiceTableProps,
+  ServiceTableState
+> {}

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -18,26 +18,41 @@ import CompositeState from "#SRC/js/structs/CompositeState";
 
 import Loader from "#SRC/js/components/Loader";
 import MetadataStore from "#SRC/js/stores/MetadataStore";
+import TableColumnResizeStore from "#SRC/js/stores/TableColumnResizeStore";
 import {
   MesosMasterRequestType,
   getMasterRegionName
 } from "#SRC/js/core/MesosMasterRequest";
 import container from "#SRC/js/container";
+import TableUtil from "#SRC/js/utils/TableUtil";
 
 import { ServiceActionItem } from "../../constants/ServiceActionItem";
 import ServiceTree from "../../structs/ServiceTree";
 import ServiceActionDisabledModal from "../../components/modals/ServiceActionDisabledModal";
 import * as Version from "../../utils/Version";
 
-import { nameRenderer } from "../../columns/ServicesTableNameColumn";
-import { statusRenderer } from "../../columns/ServicesTableStatusColumn";
-import { versionRenderer } from "../../columns/ServicesTableVersionColumn";
-import { regionRendererFactory } from "../../columns/ServicesTableRegionColumn";
-import { instancesRenderer } from "../../columns/ServicesTableInstancesColumn";
-import { cpuRenderer } from "../../columns/ServicesTableCPUColumn";
-import { memRenderer } from "../../columns/ServicesTableMemColumn";
-import { diskRenderer } from "../../columns/ServicesTableDiskColumn";
-import { gpuRenderer } from "../../columns/ServicesTableGPUColumn";
+import { nameRenderer, nameWidth } from "../../columns/ServicesTableNameColumn";
+import {
+  statusRenderer,
+  statusWidth
+} from "../../columns/ServicesTableStatusColumn";
+import {
+  versionRenderer,
+  versionWidth
+} from "../../columns/ServicesTableVersionColumn";
+import {
+  regionRendererFactory,
+  regionWidth
+} from "../../columns/ServicesTableRegionColumn";
+import {
+  instancesRenderer,
+  instancesWidth
+} from "../../columns/ServicesTableInstancesColumn";
+import { cpuRenderer, cpuWidth } from "../../columns/ServicesTableCPUColumn";
+import { memRenderer, memWidth } from "../../columns/ServicesTableMemColumn";
+import { diskRenderer, diskWidth } from "../../columns/ServicesTableDiskColumn";
+import { gpuRenderer, gpuWidth } from "../../columns/ServicesTableGPUColumn";
+
 import { actionsRendererFactory } from "../../columns/ServicesTableActionsColumn";
 
 const DELETE = ServiceActionItem.DELETE;
@@ -124,6 +139,8 @@ function sortData(
     sortDirection
   };
 }
+
+export const columnWidthsStorageKey = "servicesTableColWidths";
 
 class ServicesTable extends React.Component {
   constructor(props) {
@@ -233,6 +250,14 @@ class ServicesTable extends React.Component {
     return [...groups, ...services];
   }
 
+  handleResize(columnName, resizedColWidth) {
+    const savedColWidths = TableColumnResizeStore.get(columnWidthsStorageKey);
+    TableColumnResizeStore.set(columnWidthsStorageKey, {
+      ...savedColWidths,
+      [columnName]: resizedColWidth
+    });
+  }
+
   render() {
     const {
       actionDisabledService,
@@ -270,8 +295,21 @@ class ServicesTable extends React.Component {
               this.props.isFiltered,
               ...arguments
             )}
-            growToFill={true}
-            minWidth={200}
+            growToFill={
+              !TableUtil.isColWidthCustom(columnWidthsStorageKey, "name")
+            }
+            minWidth={
+              TableUtil.isColWidthCustom(columnWidthsStorageKey, "name")
+                ? undefined
+                : 200
+            }
+            resizable={true}
+            onResize={this.handleResize.bind(null, "name")}
+            width={
+              TableUtil.isColWidthCustom(columnWidthsStorageKey, "name")
+                ? nameWidth
+                : undefined
+            }
           />
 
           <Column
@@ -315,8 +353,21 @@ class ServicesTable extends React.Component {
               />
             }
             cellRenderer={statusRenderer}
-            growToFill={true}
-            minWidth={210}
+            growToFill={
+              !TableUtil.isColWidthCustom(columnWidthsStorageKey, "status")
+            }
+            minWidth={
+              TableUtil.isColWidthCustom(columnWidthsStorageKey, "status")
+                ? undefined
+                : 210
+            }
+            resizable={true}
+            onResize={this.handleResize.bind(null, "status")}
+            width={
+              TableUtil.isColWidthCustom(columnWidthsStorageKey, "status")
+                ? statusWidth
+                : undefined
+            }
           />
 
           <Column
@@ -328,8 +379,21 @@ class ServicesTable extends React.Component {
               />
             }
             cellRenderer={versionRenderer}
-            growToFill={true}
-            maxWidth={120}
+            growToFill={
+              !TableUtil.isColWidthCustom(columnWidthsStorageKey, "version")
+            }
+            maxWidth={
+              TableUtil.isColWidthCustom(columnWidthsStorageKey, "version")
+                ? undefined
+                : 120
+            }
+            resizable={true}
+            onResize={this.handleResize.bind(null, "version")}
+            width={
+              TableUtil.isColWidthCustom(columnWidthsStorageKey, "version")
+                ? versionWidth
+                : undefined
+            }
           />
 
           <Column
@@ -341,9 +405,26 @@ class ServicesTable extends React.Component {
               />
             }
             cellRenderer={this.regionRenderer}
-            growToFill={true}
-            minWidth={60}
-            maxWidth={150}
+            growToFill={
+              !TableUtil.isColWidthCustom(columnWidthsStorageKey, "region")
+            }
+            minWidth={
+              TableUtil.isColWidthCustom(columnWidthsStorageKey, "region")
+                ? undefined
+                : 60
+            }
+            maxWidth={
+              TableUtil.isColWidthCustom(columnWidthsStorageKey, "region")
+                ? undefined
+                : 150
+            }
+            resizable={true}
+            onResize={this.handleResize.bind(null, "region")}
+            width={
+              TableUtil.isColWidthCustom(columnWidthsStorageKey, "region")
+                ? regionWidth
+                : undefined
+            }
           />
 
           <Column
@@ -358,9 +439,26 @@ class ServicesTable extends React.Component {
               />
             }
             cellRenderer={instancesRenderer}
-            growToFill={true}
-            minWidth={100}
-            maxWidth={120}
+            growToFill={
+              !TableUtil.isColWidthCustom(columnWidthsStorageKey, "instances")
+            }
+            minWidth={
+              TableUtil.isColWidthCustom(columnWidthsStorageKey, "instances")
+                ? undefined
+                : 100
+            }
+            maxWidth={
+              !TableUtil.isColWidthCustom(columnWidthsStorageKey, "instances")
+                ? undefined
+                : 120
+            }
+            resizable={true}
+            onResize={this.handleResize.bind(null, "instances")}
+            width={
+              TableUtil.isColWidthCustom(columnWidthsStorageKey, "instances")
+                ? instancesWidth
+                : undefined
+            }
           />
 
           <Column
@@ -373,9 +471,26 @@ class ServicesTable extends React.Component {
               />
             }
             cellRenderer={cpuRenderer}
-            minWidth={70}
-            maxWidth={100}
-            growToFill={true}
+            minWidth={
+              TableUtil.isColWidthCustom(columnWidthsStorageKey, "cpu")
+                ? undefined
+                : 70
+            }
+            maxWidth={
+              TableUtil.isColWidthCustom(columnWidthsStorageKey, "cpu")
+                ? undefined
+                : 100
+            }
+            growToFill={
+              !TableUtil.isColWidthCustom(columnWidthsStorageKey, "cpu")
+            }
+            resizable={true}
+            onResize={this.handleResize.bind(null, "cpu")}
+            width={
+              TableUtil.isColWidthCustom(columnWidthsStorageKey, "cpu")
+                ? cpuWidth
+                : undefined
+            }
           />
 
           <Column
@@ -388,9 +503,26 @@ class ServicesTable extends React.Component {
               />
             }
             cellRenderer={memRenderer}
-            growToFill={true}
-            minWidth={120}
-            maxWidth={150}
+            growToFill={
+              !TableUtil.isColWidthCustom(columnWidthsStorageKey, "mem")
+            }
+            minWidth={
+              TableUtil.isColWidthCustom(columnWidthsStorageKey, "mem")
+                ? undefined
+                : 120
+            }
+            maxWidth={
+              TableUtil.isColWidthCustom(columnWidthsStorageKey, "mem")
+                ? undefined
+                : 150
+            }
+            resizable={true}
+            onResize={this.handleResize.bind(null, "mem")}
+            width={
+              TableUtil.isColWidthCustom(columnWidthsStorageKey, "mem")
+                ? memWidth
+                : undefined
+            }
           />
 
           <Column
@@ -403,9 +535,26 @@ class ServicesTable extends React.Component {
               />
             }
             cellRenderer={diskRenderer}
-            growToFill={true}
-            minWidth={100}
-            maxWidth={120}
+            growToFill={
+              !TableUtil.isColWidthCustom(columnWidthsStorageKey, "disk")
+            }
+            minWidth={
+              TableUtil.isColWidthCustom(columnWidthsStorageKey, "disk")
+                ? undefined
+                : 100
+            }
+            maxWidth={
+              TableUtil.isColWidthCustom(columnWidthsStorageKey, "disk")
+                ? undefined
+                : 120
+            }
+            resizable={true}
+            onResize={this.handleResize.bind(null, "disk")}
+            width={
+              TableUtil.isColWidthCustom(columnWidthsStorageKey, "disk")
+                ? diskWidth
+                : undefined
+            }
           />
 
           <Column
@@ -418,9 +567,26 @@ class ServicesTable extends React.Component {
               />
             }
             cellRenderer={gpuRenderer}
-            growToFill={true}
-            minWidth={50}
-            maxWidth={70}
+            growToFill={
+              !TableUtil.isColWidthCustom(columnWidthsStorageKey, "gpu")
+            }
+            minWidth={
+              TableUtil.isColWidthCustom(columnWidthsStorageKey, "gpu")
+                ? undefined
+                : 50
+            }
+            maxWidth={
+              TableUtil.isColWidthCustom(columnWidthsStorageKey, "gpu")
+                ? undefined
+                : 70
+            }
+            resizable={true}
+            onResize={this.handleResize.bind(null, "gpu")}
+            width={
+              TableUtil.isColWidthCustom(columnWidthsStorageKey, "gpu")
+                ? gpuWidth
+                : undefined
+            }
           />
 
           <Column

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -276,7 +276,12 @@ class ServicesTable extends React.Component {
     }
     const sortedGroups = this.sortGroupsOnTop(data);
 
-    return (
+    // Hiding the table when the create service modal is open.
+    //
+    // This is a workaround for an issue where Cypress' `type`
+    // command would not work as expected when there is a table
+    // with many resizable columns in the DOM
+    return this.props.hideTable ? null : (
       <div className="table-wrapper service-table">
         <Table
           data={sortedGroups.slice()}

--- a/plugins/services/src/js/routes/services.js
+++ b/plugins/services/src/js/routes/services.js
@@ -48,7 +48,8 @@ const serviceRoutes = [
           {
             type: Route,
             path: "create",
-            component: CreateServiceModal
+            component: CreateServiceModal,
+            isFullscreenModal: true
           },
           {
             type: Route,
@@ -57,7 +58,8 @@ const serviceRoutes = [
               {
                 type: Route,
                 path: "create",
-                component: CreateServiceModal
+                component: CreateServiceModal,
+                isFullscreenModal: true
               }
             ]
           }

--- a/src/js/stores/TableColumnResizeStore.d.ts
+++ b/src/js/stores/TableColumnResizeStore.d.ts
@@ -1,0 +1,8 @@
+import { EventEmitter } from "events";
+
+class TableColumnResizeStore extends EventEmitter {
+  get(tableId: string): { [key: string]: number };
+  set(tableId: string, columnWidths: object): () => void;
+}
+
+export default new TableColumnResizeStore();

--- a/src/js/stores/TableColumnResizeStore.js
+++ b/src/js/stores/TableColumnResizeStore.js
@@ -1,0 +1,29 @@
+import { EventEmitter } from "events";
+import Util from "../utils/Util";
+import UserSettingsStore from "./UserSettingsStore";
+import { SAVED_STATE_KEY } from "../constants/UserSettings";
+
+const getColumnWidths = tableId => {
+  return (
+    Util.findNestedPropertyInObject(
+      UserSettingsStore.getKey(SAVED_STATE_KEY),
+      tableId
+    ) || {}
+  );
+};
+
+class TableColumnResizeStore extends EventEmitter {
+  get(tableId) {
+    return getColumnWidths(tableId);
+  }
+
+  set(tableId, columnWidths) {
+    const savedStates = UserSettingsStore.getKey(SAVED_STATE_KEY) || {};
+
+    savedStates[tableId] = columnWidths;
+
+    UserSettingsStore.setKey(SAVED_STATE_KEY, savedStates);
+  }
+}
+
+module.exports = new TableColumnResizeStore();

--- a/src/js/utils/TableUtil.d.ts
+++ b/src/js/utils/TableUtil.d.ts
@@ -1,0 +1,36 @@
+export function getRowHeight(): number;
+export function compareValues(
+  a: string,
+  b: string,
+  aTieBreaker: string,
+  bTieBreaker: string
+): number;
+export function getSortFunction(
+  tieBreakerProp: string,
+  getProperty?: () => void
+): (a: string, b: string, aTieBreaker: string, bTieBreaker: string) => number;
+export function getHealthSortingValue(healthValue: string | number): number;
+export function sortHealthValues(
+  a: {
+    name: string;
+    health: string | number;
+  },
+  b: {
+    name: string;
+    health: string | number;
+  }
+): number;
+export function getHealthSortingOrder(): (
+  a: {
+    name: string;
+    health: string | number;
+  },
+  b: {
+    name: string;
+    health: string | number;
+  }
+) => number;
+export function isColWidthCustom(
+  colWidthsStorageKey: string,
+  columnKey: string
+): boolean;

--- a/src/js/utils/TableUtil.js
+++ b/src/js/utils/TableUtil.js
@@ -1,3 +1,4 @@
+import TableColumnResizeStore from "#SRC/js/stores/TableColumnResizeStore";
 import HealthSorting from "../../../plugins/services/src/js/constants/HealthSorting";
 import UnitHealthStatus from "../constants/UnitHealthStatus";
 import Util from "./Util";
@@ -140,6 +141,18 @@ var TableUtil = {
    */
   getHealthSortingOrder() {
     return TableUtil.sortHealthValues;
+  },
+
+  /**
+   * Checks if localstorage has a
+   * value for a column's width
+   *
+   * @param {String} colWidthsStorageKey
+   * @param {String} columnKey
+   * @returns {Boolean} whether column was resized
+   */
+  isColWidthCustom(colWidthsStorageKey, columnKey) {
+    return Boolean(TableColumnResizeStore.get(colWidthsStorageKey)[columnKey]);
   }
 };
 

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -596,7 +596,6 @@ describe("Service Form Modal", function() {
             .focus()
             .type("{selectall}{backspace}")
             .type("{selectall}{backspace}")
-            .type("{selectall}{backspace}")
             .type("/test-back-button-prompt");
         });
       });

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -596,6 +596,7 @@ describe("Service Form Modal", function() {
             .focus()
             .type("{selectall}{backspace}")
             .type("{selectall}{backspace}")
+            .type("{selectall}{backspace}")
             .type("/test-back-button-prompt");
         });
       });


### PR DESCRIPTION
## Testing
(recommended in a private browsing tab)
1. Navigate to the {Nodes|Services} page
2. Resize some columns
3. Refresh the page

Columns should be resizable, and when you refresh the page, the resized columns should be the same width you resized them to

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots
![ServicesResizeDemo](https://user-images.githubusercontent.com/2313998/55919451-11b06000-5bc4-11e9-94bd-1dcb9fecb9ac.gif)

