### PR TITLE
[spike] DCOS-46215: Error requesting UI Configuration message email is shown as {0}

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -888,7 +888,7 @@
   "You are about to stop the selected job runs.": "",
   "You are about to {0} {instanceCountContent}. Are you sure you want to continue?": "",
   "You are about to {0} {taskCountContent}. Are you sure you want to continue?": "",
-  "You can also join us on our <0>Slack channel</0> or send us an email at <1>{0}</1>.": "",
+  "You can also join us on our <0>Slack channel</0> or send us an email at": "",
   "You can go to the <0>Repositories Settings</0> page to change installed repositories.": "",
   "You can run Docker containers with both container runtimes. The Universal Container Runtime (UCR) is better supported in DC/OS. <0>More information</0>.": "",
   "You do not have access to this service. Please contact your {0} administrator or see <0>security documentation</0> for more information.": "",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -888,7 +888,7 @@
   "You are about to stop the selected job runs.": "",
   "You are about to {0} {instanceCountContent}. Are you sure you want to continue?": "",
   "You are about to {0} {taskCountContent}. Are you sure you want to continue?": "",
-  "You can also join us on our <0>Slack channel</0> or send us an email at": "",
+  "You can also join us on our <0>Slack channel</0> or send us an email at <1></1>.": "",
   "You can go to the <0>Repositories Settings</0> page to change installed repositories.": "",
   "You can run Docker containers with both container runtimes. The Universal Container Runtime (UCR) is better supported in DC/OS. <0>More information</0>.": "",
   "You do not have access to this service. Please contact your {0} administrator or see <0>security documentation</0> for more information.": "",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -888,7 +888,7 @@
   "You are about to stop the selected job runs.": "您即将停止所选作业运行。",
   "You are about to {0} {instanceCountContent}. Are you sure you want to continue?": "您即将 {0} {instanceCountContent}。确定要继续吗？",
   "You are about to {0} {taskCountContent}. Are you sure you want to continue?": "您即将 {0} {taskCountContent}。确定要继续吗？",
-  "You can also join us on our <0>Slack channel</0> or send us an email at": "您也可以通过 <0>Slack channel</0> 加入我们或发送电子邮件至",
+  "You can also join us on our <0>Slack channel</0> or send us an email at <1></1>.": "您也可以通过 <0>Slack channel</0> 加入我们或发送电子邮件至 <1></1>",
   "You can go to the <0>Repositories Settings</0> page to change installed repositories.": "您可以转到 <0>存储库设置</0> 页面，来更改已安装的存储库。",
   "You can run Docker containers with both container runtimes. The Universal Container Runtime (UCR) is better supported in DC/OS. <0>More information</0>.": "您可以使用两个容器运行时运行 Docker 容器。DC/OS 支持通用容器运行时 (UCR)。<0>更多信息</0>.",
   "You do not have access to this service. Please contact your {0} administrator or see <0>security documentation</0> for more information.": "您无权访问此服务。请联系您的 {0} 管理员或查看 <0>安全文档，</0> 以获取更多信息。",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -888,7 +888,7 @@
   "You are about to stop the selected job runs.": "您即将停止所选作业运行。",
   "You are about to {0} {instanceCountContent}. Are you sure you want to continue?": "您即将 {0} {instanceCountContent}。确定要继续吗？",
   "You are about to {0} {taskCountContent}. Are you sure you want to continue?": "您即将 {0} {taskCountContent}。确定要继续吗？",
-  "You can also join us on our <0>Slack channel</0> or send us an email at <1>{0}</1>.": "您也可以通过 <0>Slack channel</0> 加入我们或发送电子邮件至 <1>{0}</1>.",
+  "You can also join us on our <0>Slack channel</0> or send us an email at": "您也可以通过 <0>Slack channel</0> 加入我们或发送电子邮件至",
   "You can go to the <0>Repositories Settings</0> page to change installed repositories.": "您可以转到 <0>存储库设置</0> 页面，来更改已安装的存储库。",
   "You can run Docker containers with both container runtimes. The Universal Container Runtime (UCR) is better supported in DC/OS. <0>More information</0>.": "您可以使用两个容器运行时运行 Docker 容器。DC/OS 支持通用容器运行时 (UCR)。<0>更多信息</0>.",
   "You do not have access to this service. Please contact your {0} administrator or see <0>security documentation</0> for more information.": "您无权访问此服务。请联系您的 {0} 管理员或查看 <0>安全文档，</0> 以获取更多信息。",

--- a/src/js/components/RequestErrorMsg.js
+++ b/src/js/components/RequestErrorMsg.js
@@ -9,14 +9,16 @@ import Config from "../config/Config";
 
 function getDefaultMessage() {
   return (
-    <Trans render="p" className="text-align-center flush-bottom">
-      You can also join us on our{" "}
-      <a href={Config.slackChannel} target="_blank">
-        Slack channel
-      </a>{" "}
-      or send us an email at{" "}
+    <p className="text-align-center flush-bottom">
+      <Trans>
+        You can also join us on our{" "}
+        <a href={Config.slackChannel} target="_blank">
+          Slack channel
+        </a>{" "}
+        or send us an email at
+      </Trans>{" "}
       <a href={`mailto:${Config.supportEmail}`}>{Config.supportEmail}</a>.
-    </Trans>
+    </p>
   );
 }
 

--- a/src/js/components/RequestErrorMsg.js
+++ b/src/js/components/RequestErrorMsg.js
@@ -10,14 +10,13 @@ import Config from "../config/Config";
 function getDefaultMessage() {
   return (
     <p className="text-align-center flush-bottom">
-      <Trans>
-        You can also join us on our{" "}
-        <a href={Config.slackChannel} target="_blank">
-          Slack channel
-        </a>{" "}
-        or send us an email at
-      </Trans>{" "}
-      <a href={`mailto:${Config.supportEmail}`}>{Config.supportEmail}</a>.
+      <Trans
+        id="You can also join us on our <0>Slack channel</0> or send us an email at <1></1>."
+        components={[
+          <a href={Config.slackChannel} target="_blank" />,
+          <a href={`mailto:${Config.supportEmail}`}>{Config.supportEmail}</a>
+        ]}
+      />
     </p>
   );
 }


### PR DESCRIPTION
Change the error message function in order to show the email.

Closes https://jira.mesosphere.com/browse/DCOS-46215

## Testing
1. In `proxy.dev.js` use an outdated cluster url and run `npm start`.
2. Verify that the email is shown on the error page

## Trade-offs
The message appears in English, even when the language is changed to Chinese, I am not sure why.

## Dependencies
https://github.com/mesosphere/dcos-ui-plugins-private/pull/926

## Screenshots

### Before
![screenshot from 2018-12-13 13-28-19](https://user-images.githubusercontent.com/40791275/52131710-1d245f80-2646-11e9-9bcb-f90f555129ba.png)

### After
![screenshot from 2019-02-01 16-48-26](https://user-images.githubusercontent.com/40791275/52131719-2281aa00-2646-11e9-94d1-6f52943f6873.png)
