### PR TITLE
DCOS-51670 fix: pre-commit

### DIFF
--- a/plugins/services/src/js/components/ServiceStatusIcon.tsx
+++ b/plugins/services/src/js/components/ServiceStatusIcon.tsx
@@ -19,7 +19,7 @@ import ServiceTree from "../structs/ServiceTree";
 
 const UNABLE_TO_LAUNCH_TIMEOUT = 1000 * 60 * 30; // 30 minutes
 
-const getTooltipContent = (service: Service, content: JSX.Element) => {
+const getTooltipContent = (service: Service | Pod, content: JSX.Element) => {
   const servicePath = encodeURIComponent(service.getId());
 
   return (
@@ -35,7 +35,7 @@ const getTooltipContent = (service: Service, content: JSX.Element) => {
   );
 };
 
-type TreeNode = Service | ServiceTree;
+type TreeNode = Service | ServiceTree | Pod;
 
 class ServiceStatusIcon extends React.Component<{
   showTooltip?: boolean;
@@ -129,7 +129,7 @@ class ServiceStatusIcon extends React.Component<{
     );
   }
 
-  getUnableToLaunchWarning(service: Service) {
+  getUnableToLaunchWarning(service: Service | Pod) {
     const duration = DateUtil.getDuration(
       Date.now() - DateUtil.strToMs((service.getQueue() as any).since as string)
     );

--- a/plugins/services/src/js/structs/Service.d.ts
+++ b/plugins/services/src/js/structs/Service.d.ts
@@ -1,5 +1,5 @@
 import Item from "#SRC/js/structs/Item";
-import { Status } from "#PLUGINS/services/src/js/structs/ServiceStatus";
+import { Status } from "#PLUGINS/services/src/js/constants/ServiceStatus";
 
 export default class Service extends Item {
   getId(): string;

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -56,6 +56,10 @@ then
 
   header "Check types..."
   npx tsc || exit $?
+
+  header "Running tests..."
+  npm run test --silent -- --findRelatedTests \
+      ${staged_typescript_files} || exit $?
   info "Staged TypeScript looks good"
 fi
 
@@ -65,4 +69,5 @@ then
   header "Test staged JavaScript files.."
   npm run test --silent -- --findRelatedTests \
     ${staged_javascript_files} || exit $?
+  info "Javascript Tests passed"
 fi


### PR DESCRIPTION
Jest was always returing `1` when running with pre-commit. This ended up being an issue loading a module from an incorrect path. I had to upgrade jest-cli locally just to see this error. We should work on updating jest too.

Additionally once the module path was fixed this exposed a few TS errors. 

I also updated the pre-commit script to look for tests for both JS & TS* files.

## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->
make a change and try to commit something, ensure you can commit without `--no-verify`

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
