### PR TITLE
[Spike] DCOS-51672: camelcase svg attributes

### DIFF
--- a/src/js/components/charts/TimeSeriesArea.js
+++ b/src/js/components/charts/TimeSeriesArea.js
@@ -44,13 +44,13 @@ var TimeSeriesArea = createReactClass({
         <path className={"area " + className} d={this.props.path} />
         <path
           className={"line " + className}
-          stroke-linecap="butt"
+          strokeLinecap="butt"
           d={this.props.line}
         />
         <path
           className={"line line-unavailable " + className}
-          stroke-dasharray="2,1"
-          stroke-linecap="butt"
+          strokeDasharray="2,1"
+          strokeLinecap="butt"
           d={this.props.unavailableLine}
         />
       </g>


### PR DESCRIPTION
Camelcase svg attributes strokeLinecap and strokeDasharray to avoid console warnings when running app locally.

Closes DCOS-51672

## Testing

Hard refresh on dashboard page with console open. You should not see these warnings:
<img width="622" alt="Screen Shot 2019-04-11 at 10 36 38 AM" src="https://user-images.githubusercontent.com/19582796/55978859-ba52d400-5c45-11e9-8259-0ac9d77f83ad.png">


## Trade-offs

N/A

## Dependencies

N/A


