### PR TITLE
[DCOS-49716] feat: util to generate RSA keypairs w cli defaults

### DIFF
--- a/src/js/utils/crypto/__tests__/index-test.js
+++ b/src/js/utils/crypto/__tests__/index-test.js
@@ -1,0 +1,101 @@
+import { generatePrintableRSAKeypair, supportsWebCryptography } from "../index";
+
+function MockCryptoKeyPair() {
+  this.publicKey = jest.fn();
+  this.privateKey = jest.fn();
+}
+
+describe("supportsWebCryptography", function() {
+  it("returns false", function() {
+    expect(supportsWebCryptography()).toEqual(false);
+  });
+
+  describe("when window.subtle exists", function() {
+    beforeEach(function() {
+      window.crypto = {
+        subtle: {}
+      };
+    });
+
+    it("returns true", function() {
+      expect(supportsWebCryptography()).toEqual(true);
+    });
+  });
+});
+
+describe("generatePrintableRSAKeypair", function() {
+  beforeEach(function() {
+    window.crypto = {
+      subtle: {
+        exportKey: (_type, _key) => {
+          const buffer = new ArrayBuffer(256);
+          const dataView = new DataView(buffer);
+
+          // Generate 256 bytes of the alphabet, A-Z, in ASCII, repeated
+          for (let pos = 0; pos < buffer.byteLength; pos += 4) {
+            dataView.setInt32(pos, 65 + ((pos / 4) % 26));
+          }
+
+          return new Promise(resolve => {
+            resolve(buffer);
+          });
+        },
+        generateKey: (_options, _exportable, _usage) => {
+          return new Promise(resolve => {
+            resolve(new MockCryptoKeyPair());
+          });
+        }
+      }
+    };
+  });
+
+  describe("when overriding defaults", function() {
+    beforeEach(function() {
+      window.crypto.subtle.generateKey = jest.fn();
+    });
+
+    it("calls generateKey with options and defaults", function() {
+      generatePrintableRSAKeypair({ modulusLength: 4096 });
+      expect(window.crypto.subtle.generateKey).toHaveBeenCalledWith(
+        {
+          hash: "SHA-256",
+          modulusLength: 4096, // <-- not the default
+          name: "RSA-OAEP",
+          publicExponent: new Uint8Array([0x01, 0x00, 0x01])
+        },
+        true,
+        ["encrypt", "decrypt"]
+      );
+    });
+  });
+
+  it("resolves to two base 64 encoded strings", function(done) {
+    expect(generatePrintableRSAKeypair()).resolves.toHaveLength(2);
+
+    generatePrintableRSAKeypair()
+      .then(([privateKey, publicKey]) => {
+        expect(privateKey).toMatch(/-----BEGIN PRIVATE KEY-----/);
+        expect(publicKey).toMatch(/-----BEGIN PUBLIC KEY-----/);
+        done();
+      })
+      .catch(err => {
+        done.fail(err);
+      });
+  });
+
+  it("generates a printable string, each line no longer than 64 characters", function(done) {
+    generatePrintableRSAKeypair()
+      .then(([privateKey, publicKey]) => {
+        expect(privateKey.split("\n").every(line => line.length <= 64)).toBe(
+          true
+        );
+        expect(publicKey.split("\n").every(line => line.length <= 64)).toBe(
+          true
+        );
+        done();
+      })
+      .catch(err => {
+        done.fail(err);
+      });
+  });
+});

--- a/src/js/utils/crypto/index.ts
+++ b/src/js/utils/crypto/index.ts
@@ -1,0 +1,116 @@
+// There is a faster version of this function that doesn't use
+// btoa (which requires a copy of the data). This buffer is
+// rather small so I don't think it makes sense to include it in
+// the bundle: https://gist.github.com/jonleighton/958841
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  let binary = "";
+  let bytes = new Uint8Array(buffer);
+  for (var i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return window.btoa(binary);
+}
+
+function getCryptoApi(): SubtleCrypto {
+  const cryptoLib = window.crypto || (window as any).msCrypto;
+  return cryptoLib.subtle || (cryptoLib as any).webkitSubtle;
+}
+
+function printableBase64(base64: string): string {
+  // > To represent the encapsulated text of a PEM message, the encoding function's output is
+  // > delimited into text lines (using local conventions), with each line except the last
+  // > containing exactly 64 printable characters and the final line containing 64 or fewer
+  // > printable characters.
+
+  let result = "";
+
+  while (base64.length > 0) {
+    result += base64.substring(0, 64) + "\n";
+    base64 = base64.substring(64);
+  }
+
+  return result;
+}
+
+function privateKeyToPem(privateKey: CryptoKey): Promise<string> {
+  return new Promise((resolve, reject) => {
+    getCryptoApi()
+      .exportKey("pkcs8", privateKey)
+      .then(
+        exportedPrivateKey => {
+          const b64 = arrayBufferToBase64(exportedPrivateKey);
+          resolve(
+            "-----BEGIN PRIVATE KEY-----\n" +
+              printableBase64(b64) +
+              "-----END PRIVATE KEY-----"
+          );
+        },
+        error => {
+          reject(error);
+        }
+      );
+  });
+}
+
+function publicKeyToPem(publicKey: CryptoKey): Promise<string> {
+  return new Promise((resolve, reject) => {
+    getCryptoApi()
+      .exportKey("spki", publicKey)
+      .then(
+        exportedPublicKey => {
+          const b64 = arrayBufferToBase64(exportedPublicKey);
+          resolve(
+            "-----BEGIN PUBLIC KEY-----\n" +
+              printableBase64(b64) +
+              "-----END PUBLIC KEY-----"
+          );
+        },
+        error => {
+          reject(error);
+        }
+      );
+  });
+}
+
+function generatePrintableRSAKeypair(
+  options?: RsaHashedKeyGenParams
+): Promise<[string, string]> {
+  const opts: RsaHashedKeyGenParams = { ...DEFAULTS, ...options };
+
+  return new Promise((resolve, reject) => {
+    getCryptoApi()
+      .generateKey(opts, true, ["encrypt", "decrypt"])
+      .then(
+        (pair: CryptoKeyPair) => {
+          Promise.all<string, string>([
+            privateKeyToPem(pair.privateKey),
+            publicKeyToPem(pair.publicKey)
+          ]).then(resolve);
+        },
+        error => {
+          reject(error);
+        }
+      );
+  });
+}
+
+// Defaults for key generation
+const DEFAULTS = {
+  hash: "SHA-256",
+  modulusLength: 2048,
+  name: "RSA-OAEP",
+  publicExponent: new Uint8Array([0x01, 0x00, 0x01]) // == 65537
+};
+
+function supportsWebCryptography() {
+  try {
+    return !!getCryptoApi();
+  } catch (err) {
+    return false;
+  }
+}
+
+// generate function returns a promise containing a 2-tuple of [privateKey, publicKey]
+// in a printable, base64 encoded format. supportsWebCryptography should be called first
+// to determine browser compatibility. (Firefox, Chrome, IE11, Safari 8+ are known to work)
+export { generatePrintableRSAKeypair, supportsWebCryptography };


### PR DESCRIPTION
## Overview

Generates and extracts printable public/private RSA keypairs, with hardcoded defaults.

`generateRSA*` functions return a promise that resolves to a 2-tuple of strings: [privateKey, publicKey]

These strings are base64 encoded, with line breaks (\n) added for better printability.

## Compatibility Notes

This API is not available in IE <= 10, nor Firefox < 34. Callers should check  supportsWebCryptography(), which simply checks for the existence of a global crypto.subtle object.

IE11 _should_ work with this API usage according to the docs, but it should be tested because supportsWebCryptography() will return true currently.

## Testability Notes

jsdom does not ship with webcrypto API at all, so I had to mock out the most important functions. We must browser test keypair generation in order to fully test the API usage. I smoke tested this code in Chrome.

Closes DCOS-49716

## Testing

@TattdCodeMonkey I'd like to test this with a real file secret. But it's late in the day

There's no good way to test this in the browser. Here is an example caller you can add somewhere:

`generatePrintableRSAKeypairUsingDefaults().then(([privateKey, publicKey]) => console.log({ privateKey, publicKey }))`

## Screenshots

Testing in Chrome:

<img width="828" alt="Screen Shot 2019-04-12 at 7 05 27 PM" src="https://user-images.githubusercontent.com/174332/56072912-76e98a00-5d59-11e9-9ea7-1eb2e9027c10.png">
