### PR TITLE
[DCOS-51776] chore: add secretsDefaultStore to app config

### DIFF
--- a/src/js/config/Config.ts
+++ b/src/js/config/Config.ts
@@ -26,6 +26,7 @@ interface IConfiguration {
   productName: string;
   rootUrl: string;
   secretsAPIPrefix: string;
+  secretsDefaultStore: string;
   setInactiveAfter: number;
   slackChannel: string;
   stateRefresh: number;
@@ -48,6 +49,7 @@ let Config: IConfiguration = {
   networkingAPIPrefix: "/networking/api/v1",
   cosmosAPIPrefix: "/package",
   secretsAPIPrefix: "/secrets/v1",
+  secretsDefaultStore: "default",
   delayAfterErrorCount: 5,
   documentationURI: "https://docs.mesosphere.com",
   mesosDocsURI: "https://mesos.apache.org/documentation/latest/",


### PR DESCRIPTION
## Overview

This information was moved to the secrets plugin but will be needed by multiple plugins (Ex: service accounts can create associated secrets).

We already include another secrets config key here but both will remain unused in the app. All secrets seem to be store in the default secret store.

