### PR TITLE
DCOS-5080: notify users if connection drops

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1113,6 +1113,7 @@
   "You have several protocol options. <0>More Information</0>.": "",
   "You must specify a command, an argument or a container with an image.": "",
   "You need at least one package repository with some packages to be able to install packages. For more <0>information on repositories</0>.": "",
+  "Your computer seems to be offline. We will keep trying to reconnect.": "",
   "Zone": "",
   "Zones": "",
   "and": "",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -1113,6 +1113,7 @@
   "You have several protocol options. <0>More Information</0>.": "您有几个协议选项。<0>更多信息</0>.",
   "You must specify a command, an argument or a container with an image.": "",
   "You need at least one package repository with some packages to be able to install packages. For more <0>information on repositories</0>.": "您至少需要一个含有一些包的包存储库，才能安装包。获取更多 <0>有关存储库的信息</0>.",
+  "Your computer seems to be offline. We will keep trying to reconnect.": "",
   "Zone": "区",
   "Zones": "区",
   "and": "和",

--- a/src/js/components/OfflineBanner.tsx
+++ b/src/js/components/OfflineBanner.tsx
@@ -1,0 +1,43 @@
+import React, { useState, useEffect } from "react";
+import { InfoBoxBanner } from "@dcos/ui-kit";
+import { Trans } from "@lingui/macro";
+
+function useNetworkOffline() {
+  const [isOffline, setIsOffline] = useState(!window.navigator.onLine);
+
+  const handleOffline = () => {
+    setIsOffline(true);
+  };
+
+  const handleOnline = () => {
+    setIsOffline(false);
+  };
+
+  useEffect(() => {
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  });
+
+  return isOffline;
+}
+
+const OfflineBanner = () => {
+  const isOffline = useNetworkOffline();
+
+  return isOffline ? (
+    <InfoBoxBanner
+      appearance="warning"
+      message={
+        <Trans>
+          Your computer seems to be offline. We will keep trying to reconnect.
+        </Trans>
+      }
+    />
+  ) : null;
+};
+
+export default OfflineBanner;

--- a/src/js/components/Page.js
+++ b/src/js/components/Page.js
@@ -9,6 +9,9 @@ import BasePageHeader from "../components/PageHeader";
 import FluidGeminiScrollbar from "./FluidGeminiScrollbar";
 import ScrollbarUtil from "../utils/ScrollbarUtil";
 import TemplateUtil from "../utils/TemplateUtil";
+import OfflineBanner from "./OfflineBanner";
+
+MountService.MountService.registerComponent(OfflineBanner, "Page:TopBanner");
 
 const PageHeader = ({
   actions,


### PR DESCRIPTION
Note to reviewers: the design team changed their mind - they wanted to show a page banner instead of a toast. See comments on the Jira ticket.

## Testing
I recommend testing with Chrome so you can toggle the connection in the browser instead of turning your WiFi on and off

- Open the dev tools and go to the Network tab
- Toggle the "Offline" checkbox in the top of the Network tab

A warning banner should appear when "Offline" is checked, and disappear when it's not checked

## Trade-offs
If you're in a state where we show the `LicenseBanner` and you go offline, both banners will be displayed.
This could have been avoided by using extension-kid to create a Banner service (like the Toast service), but that would be well out of the scope of a 2-point ticket.

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots
![OfflineBanner](https://user-images.githubusercontent.com/2313998/56254434-c946e580-608e-11e9-968f-7abad8faffa5.gif)
