### PR TITLE
DCOS-46178: update dcos-cli in system tests

### DIFF
--- a/system-tests/_scripts/setup.sh
+++ b/system-tests/_scripts/setup.sh
@@ -5,9 +5,9 @@ source .env/bin/activate
 
 # Install DC/OS CLI in the sandbox so we can setup and teardown our tests
 if [ `uname -s` == "Darwin" ]; then
-  curl https://downloads.dcos.io/binaries/cli/darwin/x86-64/dcos-1.11/dcos -o .env/bin/dcos
+  curl https://downloads.dcos.io/binaries/cli/darwin/x86-64/dcos-1.13/dcos -o .env/bin/dcos
 else
-  curl https://downloads.dcos.io/binaries/cli/linux/x86-64/dcos-1.11/dcos -o .env/bin/dcos
+  curl https://downloads.dcos.io/binaries/cli/linux/x86-64/dcos-1.13/dcos -o .env/bin/dcos
 fi
 chmod +x .env/bin/dcos
 
@@ -15,15 +15,6 @@ chmod +x .env/bin/dcos
 mv "$TMPDIR/bin/cypress" .env/bin/cypress
 
 # Configure DC/OS CLI
-CONFIG_DIR=~/.dcos
-CONFIG_FILE=${CONFIG_DIR}/dcos.toml
-mkdir -p ${CONFIG_DIR}
-cat << EOF > ${CONFIG_FILE}
-  [core]
-  ssl_verify = false
-  reporting = true
-  timeout = 5
-  dcos_url = "${CLUSTER_URL}"
-  dcos_acs_token = "${CLUSTER_AUTH_TOKEN}"
-EOF
-chmod 600 ${CONFIG_FILE}
+DCOS_CLUSTER_SETUP_ACS_TOKEN=${CLUSTER_AUTH_TOKEN} .env/bin/dcos cluster setup ${UPSTREAM_CLUSTER_URL} --insecure
+.env/bin/dcos config set core.reporting true
+.env/bin/dcos config set core.timeout 5


### PR DESCRIPTION
CLI team dropped `.dcos.toml` config file support a while back and we've been using 1.11 cli for our tests

Closes DCOS-46178

## Testing

System tests should pass