### PR TITLE
fix(jest): add --forceExit to resolve issue with jest hanging

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,7 +223,7 @@
     "test:system": "PLUGINS_PATH=\"${npm_config_externalplugins}\" ./scripts/run-system-tests",
     "test:validate": "PLUGINS_PATH=\"${npm_config_externalplugins}\" ./scripts/validate-tests",
     "test:watch": "npm test -- --watch",
-    "test": "lingui compile && NODE_PATH=node_modules jest --config=jest.config.js --no-cache",
+    "test": "lingui compile && NODE_PATH=node_modules jest --config=jest.config.js --no-cache --forceExit --detectOpenHandles",
     "util:env:validate": "node ./scripts/validate-engine-versions.js",
     "util:lingui:extract-with-plugins": "./scripts/lingui-extract-with-plugins",
     "util:scaffold": "node ./scripts/ensureConfig.js",


### PR DESCRIPTION
Adding `--forceExit` flag when we call `jest` in `npm test` to try and ensure jest exits when all tests are completed. We are seeing some issues in CI where jest will failed to exit. This flag will hopefully resolve this issue.

## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->
```
$ npm run test
```

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
