### PR TITLE
Improve typescript integration with externalplugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,10 +18,9 @@ tmp/
 jest/test-results
 webpack/proxy.dev.js
 src/resources/raml
-.vscode/
 .chrome/
 .envrc
 .env
 locale/_build/
 locale/*/messages.js
-.dcos-ui-plugins-private
+plugins-ee

--- a/.linguirc
+++ b/.linguirc
@@ -7,7 +7,7 @@
   "srcPathDirs": [
       "./src",
       "./plugins",
-      "./.dcos-ui-plugins-private"
+      "./plugins-ee"
   ],
   "srcPathIgnorePatterns": [
       "node_modules/",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "search.exclude": {
+    "**/_build": true,
+    "cypress": true
+  },
+  "search.useIgnoreFiles": false
+}

--- a/package.json
+++ b/package.json
@@ -222,8 +222,10 @@
     "test:validate": "PLUGINS_PATH=\"${npm_config_externalplugins}\" ./scripts/validate-tests",
     "test:watch": "npm test -- --watch",
     "test": "lingui compile && NODE_PATH=node_modules jest --config=jest.config.js --no-cache",
+    "util:env:link-externalplugins": "test -L ./plugins-ee || ln -s \"${npm_config_externalplugins}\" ./plugins-ee",
+    "util:env:unlink-externalplugins": "unlink plugins-ee",
     "util:env:validate": "node ./scripts/validate-engine-versions.js",
-    "util:lingui:extract-with-plugins": "./scripts/lingui-extract-with-plugins",
+    "util:lingui:extract-with-plugins": "npm run util:env:link-externalplugins && ./scripts/lingui-extract-with-plugins",
     "util:scaffold": "node ./scripts/ensureConfig.js",
     "versions": "echo npm: $(npm --version) && echo node: $(node --version)"
   },

--- a/scripts/lingui-extract-with-plugins
+++ b/scripts/lingui-extract-with-plugins
@@ -6,14 +6,11 @@ SCRIPT_PATH="$(dirname "$0")/$(dirname "$(readlink "$0")")"
 source "${SCRIPT_PATH}/utils/message"
 
 function sanityCheck {
-  if [ ! -d ../dcos-ui-plugins-private ]; then
-    warning "../dcos-ui-plugins-private directory not found."
+  if [ ! -d "$SCRIPT_PATH/../plugins-ee" ]; then
+    warning "Extraction tooling currently requires enterprise plugins to be linked with this repo. Please seek assistance from a DC/OS Github admin for more info"
     return 1
-  elif [ ! -f ../dcos-ui-plugins-private/.babelrc ]; then
-    warning "../dcos-ui-plugins-private/.babelrc file not found. Did this script fail previously? Try running with --unpatch to fix"
-    return 1
-  elif [ -f ./.dcos-ui-plugins-private ]; then
-    warning "Temporary symlink already exists. Did this script fail previously? Try running with --unpatch to fix"
+  elif [ ! -f "$SCRIPT_PATH/../.babelrc" ]; then
+    warning "plugins-ee/.babelrc file not found. Did this script fail previously? Try running with --unpatch to fix"
     return 1
   else
     return 0
@@ -25,15 +22,13 @@ function sanityCheck {
 # to the conventional dcos-ui-plugins-private directory and also temporarily hides the .babelrc file
 # which is not useful when followed through the symlink
 function patch {
-  info "Symlinking .dcos-ui-plugins-private for lingui extract tooling"
-  ln -s ../dcos-ui-plugins-private ./.dcos-ui-plugins-private
-  mv ../dcos-ui-plugins-private/.babelrc ../dcos-ui-plugins-private/.tmp.babelrc
+  info "Temporarily renaming .babelrc for lingui extract tooling"
+  mv "$SCRIPT_PATH/../plugins-ee/.babelrc" "$SCRIPT_PATH/../plugins-ee/.tmp.babelrc"
 }
 
 function unpatch {
-  unlink ./.dcos-ui-plugins-private
-  mv ../dcos-ui-plugins-private/.tmp.babelrc ../dcos-ui-plugins-private/.babelrc
-  info "Unlinked .dcos-ui-plugins-private"
+  mv "$SCRIPT_PATH/../plugins-ee/.tmp.babelrc" "$SCRIPT_PATH/../plugins-ee/.babelrc"
+  info "Restored .babelrc"
 }
 
 title "Running lingui extract for dcos-ui and dcos-ui-plugins-private"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,12 @@
       "#PLUGINS/*": ["plugins/*"]
     }
   },
-  "include": ["src/**/*", "packages/**/*", "plugins/**/*", "locale/**/*"],
+  "include": [
+    "src/**/*",
+    "packages/**/*",
+    "plugins/**/*",
+    "plugins-ee/**/*",
+    "locale/**/*"
+  ],
   "exclude": ["node_modules", "src/styles/**/*"]
 }


### PR DESCRIPTION
## Overview

This adds package support for what seems to be the best method of integrating our dev tooling with external plugins: symlinking ../dcos-ui-plugins-private

Here are the changes:

1. adds `npm run util:env:link-externalplugins` and `npm run util:env:unlink-externalplugins` which simply creates and removes the symlink.

2. the symlink is now used to extract lingui messages (a temporary one was created before), and without it, an error message is displayed.  I think this is a good simplification.

3. the symlink is used as a typescript "includes" so that modules can be resolves and other tooling works with our own settings

4. vscode workspace settings have been added to allow the symlink to be ignored by git, but not ignored by the editor. I had to add new entries to search exclude in order to reach some parity with the default setting.


## Testing

- `npm run util:env:link-externalplugins` before taking the next step...
- `npm run lint:ts` to see typescript errors locally. This does not affect CI yet.
- `npm run util:lingui:extract-with-plugins` to ensure lingui extraction still works as expected. This command should also link external plugins as well
- Try out your editor integrations and add appropriate workspace config if necessary

## Trade-offs

- Not a new tradeoff, but open source contributions containing new translation messages are basically not allowed since we require you to clone plugins-private before extraction. This is not ideal.

- If your editor depends on .gitignore to hide files, it may require reconfiguration.


## Screenshots

#### Typescript errors!

![Screen Shot 2019-04-29 at 11 58 52 AM](https://user-images.githubusercontent.com/174332/56916466-2c188380-6a76-11e9-9062-b634280ca8c3.png)

#### Editor integration!

![Screen Shot 2019-04-29 at 11 56 29 AM](https://user-images.githubusercontent.com/174332/56916481-333f9180-6a76-11e9-8f7a-b0b6549e946d.png)
