### PR TITLE
[DCOS-53296] fix(ui-update): parse build version in data-layer

### DIFF
--- a/src/js/data/ui-update/UIMetadata.ts
+++ b/src/js/data/ui-update/UIMetadata.ts
@@ -1,3 +1,7 @@
+import { parseVersion } from "./utils";
+
+const defaultClientBuild = parseVersion(window.DCOS_UI_VERSION);
+
 export interface UIMetadata {
   clientBuild?: string;
   packageVersion?: string;
@@ -15,6 +19,5 @@ export const UIMetadataSchema = `
 `;
 
 export const DEFAULT_UI_METADATA: UIMetadata = {
-  // @ts-ignore
-  clientBuild: window.DCOS_UI_VERSION
+  clientBuild: defaultClientBuild
 };

--- a/src/js/data/ui-update/__tests__/index-test.ts
+++ b/src/js/data/ui-update/__tests__/index-test.ts
@@ -55,10 +55,10 @@ describe("UI-Update Service data-layer", () => {
             j: {
               data: {
                 ui: {
-                  clientBuild: "unit_test+v2.50.1",
+                  clientBuild: "v2.50.1",
                   packageVersion: "2.50.1",
                   packageVersionIsDefault: false,
-                  serverBuild: "master+v2.50.1+hfges"
+                  serverBuild: "v2.50.1"
                 }
               }
             }
@@ -100,7 +100,7 @@ describe("UI-Update Service data-layer", () => {
               expect(value).toEqual({
                 data: {
                   ui: {
-                    clientBuild: "unit_test+v1.0.0"
+                    clientBuild: "v1.0.0"
                   }
                 }
               });

--- a/src/js/data/ui-update/__tests__/utils-test.ts
+++ b/src/js/data/ui-update/__tests__/utils-test.ts
@@ -1,0 +1,27 @@
+import { parseVersion } from "../utils";
+
+describe("utils", () => {
+  describe("parseVersion", () => {
+    it("handles master build", () => {
+      expect(parseVersion("master+v2.1.0")).toEqual("v2.1.0");
+    });
+
+    it("handles master build with hash", () => {
+      expect(parseVersion("master+v2.1.0+abcdefg")).toEqual("v2.1.0");
+    });
+
+    it("handles local dev build", () => {
+      expect(parseVersion("0.0.0-dev+semantic-release")).toEqual("0.0.0");
+    });
+
+    it("handles release branch build", () => {
+      expect(parseVersion("1.13+v2.1.0")).toEqual("v2.1.0");
+    });
+
+    it("returns provided version if format not received", () => {
+      expect(parseVersion("not_in_expected_format")).toEqual(
+        "not_in_expected_format"
+      );
+    });
+  });
+});

--- a/src/js/data/ui-update/index.ts
+++ b/src/js/data/ui-update/index.ts
@@ -3,6 +3,7 @@ import { map, publishReplay, refCount, retry, switchMap } from "rxjs/operators";
 import { RequestResponse } from "@dcos/http-service";
 import { makeExecutableSchema } from "graphql-tools";
 import { DCOSUIUpdateClient, UIVersionResponse } from "dcos-ui-update-client";
+import { parseVersion } from "./utils";
 
 import {
   UIMetadata,
@@ -34,7 +35,8 @@ function isUIUpdateArgs(args: PossibleMutationArgs): args is UIUpdateArgs {
 export const resolvers = {
   UIMetadata: {
     clientBuild() {
-      return of(window.DCOS_UI_VERSION);
+      const clientBuildVersion = parseVersion(window.DCOS_UI_VERSION);
+      return of(clientBuildVersion);
     },
     packageVersion(_parent = {}, _args = {}, context: QueryContext) {
       if (!context.versionStream) {
@@ -71,9 +73,8 @@ export const resolvers = {
       }
       const version$ = context.versionStream;
       return version$.pipe(
-        map(
-          ({ response }: RequestResponse<UIVersionResponse>) =>
-            response.buildVersion
+        map(({ response }: RequestResponse<UIVersionResponse>) =>
+          parseVersion(response.buildVersion)
         )
       );
     }

--- a/src/js/data/ui-update/utils.ts
+++ b/src/js/data/ui-update/utils.ts
@@ -1,0 +1,18 @@
+const LOCAL_DEV_VERSION = "0.0.0-dev+semantic-release";
+
+export function parseVersion(version: string): string {
+  if (version === LOCAL_DEV_VERSION) {
+    return "0.0.0";
+  }
+  if (!version) {
+    return "";
+  }
+  if (typeof version !== "string") {
+    return "";
+  }
+  const versionSplit = version.split("+");
+  if (versionSplit.length > 1) {
+    return versionSplit[1];
+  }
+  return version;
+}

--- a/tests/_fixtures/ui-settings/default-version.json
+++ b/tests/_fixtures/ui-settings/default-version.json
@@ -1,5 +1,5 @@
 {
   "default": true,
   "packageVersion": "Default",
-  "buildVersion": "0.0.0-dev+semantic-release"
+  "buildVersion": "int-test+v0.0.0"
 }

--- a/tests/_fixtures/ui-settings/version-010.json
+++ b/tests/_fixtures/ui-settings/version-010.json
@@ -1,5 +1,5 @@
 {
   "default": false,
   "packageVersion": "0.1.0",
-  "buildVersion": "0.1.0-dev+semantic-release"
+  "buildVersion": "int-test+v0.1.0"
 }

--- a/tests/_fixtures/ui-settings/version-011.json
+++ b/tests/_fixtures/ui-settings/version-011.json
@@ -1,5 +1,5 @@
 {
   "default": false,
   "packageVersion": "0.1.1",
-  "buildVersion": "0.1.1-dev+semantic-release"
+  "buildVersion": "int-test+v0.1.1"
 }


### PR DESCRIPTION
Updated the ui-update data-layer to parse the build version from string
provided instead of relying on semver.coerce. We currently use the
template of `<branch>+<build_version>(+<build_hash>)?` when branch is
`master` coercing the value gives use the build version, but if the
build is made from a release branch, `1.13` then `1.13` is returned from
semver.coerce instead of our desired build verions after the first `+`.

I added a `parseVersion` utility to the ui-update data-layer to handle
getting the build version from the string assuming the template is
followed. Unit tests for the utility and data-layer were added as well.

- Closes DCOS-53296

## Testing

- running locally update `src/index.html` line 34 from `window.DCOS_UI_VERSION = "0.0.0-dev+semantic-release";` to `window.DCOS_UI_VERSION = "1.13+v2.78.2";`
- navigate to UI-Setting page
- Verify `Installed Version` is `2.78.2` and not `1.13`

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
Before:
![image](https://user-images.githubusercontent.com/1972968/57084219-87898200-6cbf-11e9-845f-729bdfc62ed4.png)
After:
<img width="1074" alt="image" src="https://user-images.githubusercontent.com/1972968/57084365-cb7c8700-6cbf-11e9-9ac6-25e3d2cafc7f.png">
