### PR TITLE
DCOS-52843: make json editor fit v0 spec

### DIFF
--- a/plugins/jobs/src/js/components/JobsForm.tsx
+++ b/plugins/jobs/src/js/components/JobsForm.tsx
@@ -85,11 +85,11 @@ class JobsForm extends React.Component<JobsFormProps> {
 
   getJSONEditorData(jobSpec: JobSpec): JobOutput {
     const jobJSON = jobSpecToOutputParser(jobSpec);
-    if (jobJSON.hasOwnProperty("schedule") && jobJSON.schedule === undefined) {
+    if (jobJSON.hasOwnProperty("schedule") && jobJSON.schedules === undefined) {
       // jobSpecToOutputParser returns object with `schedule: undefined` if there is no schedule present,
       // but this triggers an update of the JSONEditor and leads to issues where the state of the JSON in the
       // editor is replaced with old values.
-      delete jobJSON.schedule;
+      delete jobJSON.schedules;
     }
     return jobJSON;
   }

--- a/plugins/jobs/src/js/components/config/GeneralConfigSection.tsx
+++ b/plugins/jobs/src/js/components/config/GeneralConfigSection.tsx
@@ -12,7 +12,7 @@ class GeneralConfigSection extends BaseConfig<JobOutput> {
     const { config } = this.props;
     switch (row.key) {
       case "containerImage":
-        return !(config.job.run.ucr || config.job.run.docker);
+        return !(config.run.ucr || config.run.docker);
       case undefined:
         return false;
       default:
@@ -34,38 +34,38 @@ class GeneralConfigSection extends BaseConfig<JobOutput> {
           headingLevel: 1
         },
         {
-          key: "job.id",
+          key: "id",
           label: <Trans>Job ID</Trans>
         },
         {
-          key: "job.description",
+          key: "description",
           label: <Trans>Description</Trans>
         },
         {
-          key: "job.run.cpus",
+          key: "run.cpus",
           label: <Trans>CPU</Trans>
         },
         {
-          key: "job.run.mem",
+          key: "run.mem",
           label: <Trans>Mem</Trans>
         },
         {
-          key: "job.run.disk",
+          key: "run.disk",
           label: <Trans>Disk</Trans>
         },
         {
-          key: "job.run.gpus",
+          key: "run.gpus",
           label: <Trans>GPU</Trans>
         },
         {
-          key: "job.run.cmd",
+          key: "run.cmd",
           label: <Trans>Command</Trans>
         },
         {
           key: "containerImage",
           label: <Trans>Container Image</Trans>,
           transformValue(_: any, config: JobOutput) {
-            const { ucr, docker } = config.job.run;
+            const { ucr, docker } = config.run;
             if (ucr) {
               return getDisplayValue(ucr.image && ucr.image.id);
             }

--- a/plugins/jobs/src/js/components/form/ArgsSection.tsx
+++ b/plugins/jobs/src/js/components/form/ArgsSection.tsx
@@ -48,7 +48,7 @@ class ArgsSection extends React.Component<ArgsSectionProps> {
           </FieldLabel>
         );
       }
-      const argErrors = getFieldError(`job.run.args.${index}`, errors);
+      const argErrors = getFieldError(`run.args.${index}`, errors);
 
       return (
         <FormRow key={index}>

--- a/plugins/jobs/src/js/components/form/EnvVarPartial.tsx
+++ b/plugins/jobs/src/js/components/form/EnvVarPartial.tsx
@@ -23,9 +23,9 @@ function getEnvironmentLines(
   showErrors: boolean
 ) {
   return data.map(([key, value], i) => {
-    const valueError = getFieldError(`job.run.env.${key}.value.${i}`, errors);
-    const keyError = getFieldError(`job.run.env.${key}.key`, errors);
-    const envError = getFieldError(`job.run.env.${i}`, errors);
+    const valueError = getFieldError(`run.env.${key}.value.${i}`, errors);
+    const keyError = getFieldError(`run.env.${key}.key`, errors);
+    const envError = getFieldError(`run.env.${i}`, errors);
     return (
       <FormRow key={`env-row-${i}`}>
         <FormGroup
@@ -84,10 +84,10 @@ class EnvVarPartial extends React.Component<EnvVarPartialProps, {}> {
 
     // prettier-ignore
     const envTooltipContent = (
-        <Trans render="span">
-          DC/OS also exposes environment variables for host ports and metadata.
-        </Trans>
-      );
+      <Trans render="span">
+        DC/OS also exposes environment variables for host ports and metadata.
+      </Trans>
+    );
 
     return (
       <div>

--- a/plugins/jobs/src/js/components/form/GeneralFormSection.tsx
+++ b/plugins/jobs/src/js/components/form/GeneralFormSection.tsx
@@ -52,10 +52,10 @@ class GeneralFormSection extends React.Component<GeneralProps> {
     );
     const gpusDisabled = !formData.cmdOnly && formData.container !== "ucr";
 
-    const cpusError = getFieldError("job.run.cpus", errors);
-    const gpusError = getFieldError("job.run.gpus", errors);
-    const memError = getFieldError("job.run.mem", errors);
-    const diskError = getFieldError("job.run.disk", errors);
+    const cpusError = getFieldError("run.cpus", errors);
+    const gpusError = getFieldError("run.gpus", errors);
+    const memError = getFieldError("run.mem", errors);
+    const diskError = getFieldError("run.disk", errors);
 
     return (
       <FormRow>
@@ -150,9 +150,9 @@ class GeneralFormSection extends React.Component<GeneralProps> {
     const containerImage = formData.containerImage;
 
     const containerImageErrors =
-      getFieldError("job.run.docker.image", errors) ||
-      getFieldError("job.run.ucr.image.id", errors);
-    const cmdErrors = getFieldError("job.run.cmd", errors);
+      getFieldError("run.docker.image", errors) ||
+      getFieldError("run.ucr.image.id", errors);
+    const cmdErrors = getFieldError("run.cmd", errors);
 
     return (
       <div className="form-section">
@@ -274,7 +274,7 @@ class GeneralFormSection extends React.Component<GeneralProps> {
       </Trans>
     );
     const descTooltipContent = <Trans>A description of this job.</Trans>;
-    const idError = getFieldError("job.id", errors);
+    const idError = getFieldError("id", errors);
 
     return (
       <div className="form-section">

--- a/plugins/jobs/src/js/components/form/ParametersSection.tsx
+++ b/plugins/jobs/src/js/components/form/ParametersSection.tsx
@@ -40,15 +40,15 @@ class ParametersSection extends React.Component<
 
     return dockerParams.map((parameter: DockerParameter, index: number) => {
       const keyErrors = getFieldError(
-        `job.run.docker.parameters.${index}.key`,
+        `run.docker.parameters.${index}.key`,
         errors
       );
       const valueErrors = getFieldError(
-        `job.run.docker.parameters.${index}.value`,
+        `run.docker.parameters.${index}.value`,
         errors
       );
       const generalParamError = getFieldError(
-        `job.run.docker.parameters.${index}`,
+        `run.docker.parameters.${index}`,
         errors
       );
 

--- a/plugins/jobs/src/js/components/form/PlacementPartial.tsx
+++ b/plugins/jobs/src/js/components/form/PlacementPartial.tsx
@@ -105,19 +105,19 @@ class PlacementPartial extends React.Component<PlacementPartialProps, {}> {
         const valueIsRequired = (OperatorTypes[constraint.operator] || {})
           .requiresValue;
         const operatorErrors = getFieldError(
-          `job.run.placement.constraints.${index}.operator`,
+          `run.placement.constraints.${index}.operator`,
           errors
         );
         const fieldErrors = getFieldError(
-          `job.run.placement.constraints.${index}.attribute`,
+          `run.placement.constraints.${index}.attribute`,
           errors
         );
         const valueErrors = getFieldError(
-          `job.run.placement.constraints.${index}.value`,
+          `run.placement.constraints.${index}.value`,
           errors
         );
         const generalConstraintError = getFieldError(
-          `job.run.placement.constraints.${index}`,
+          `run.placement.constraints.${index}`,
           errors
         );
 

--- a/plugins/jobs/src/js/components/form/RunConfigFormSection.tsx
+++ b/plugins/jobs/src/js/components/form/RunConfigFormSection.tsx
@@ -380,13 +380,13 @@ class RunConfigFormSection extends React.Component<RunConfigSectionProps> {
               <FormGroup
                 className="column-6"
                 showError={Boolean(
-                  showErrors && getFieldError(`job.labels.${i}`, errors)
+                  showErrors && getFieldError(`labels.${i}`, errors)
                 )}
               >
                 <FieldAutofocus>
                   <FieldInput name={`key.${i}.labels`} value={key} />
                   <FieldError>
-                    {getFieldError(`job.labels.${i}`, errors)}
+                    {getFieldError(`labels.${i}`, errors)}
                   </FieldError>
                 </FieldAutofocus>
                 <span className="emphasis form-colon">:</span>

--- a/plugins/jobs/src/js/components/form/ScheduleFormSection.tsx
+++ b/plugins/jobs/src/js/components/form/ScheduleFormSection.tsx
@@ -36,11 +36,11 @@ class ScheduleFormSection extends React.Component<ScheduleSectionProps> {
         lowercase letters (`a-z`). The id may not begin or end with a dash.
       </Trans>
     );
-    const idErrors = getFieldError("schedule.id", errors);
-    const cronErrors = getFieldError("schedule.cron", errors);
-    const timezoneErrors = getFieldError("schedule.timezone", errors);
+    const idErrors = getFieldError("schedules.0.id", errors);
+    const cronErrors = getFieldError("schedules.0.cron", errors);
+    const timezoneErrors = getFieldError("schedules.0.timezone", errors);
     const deadlineErrors = getFieldError(
-      "schedule.startingDeadlineSeconds",
+      "schedules.0.startingDeadlineSeconds",
       errors
     );
 
@@ -83,7 +83,7 @@ class ScheduleFormSection extends React.Component<ScheduleSectionProps> {
               </FormGroupHeading>
             </FieldLabel>
             <FieldInput
-              name="schedule.id"
+              name="id.schedules"
               type="text"
               value={formData.scheduleId}
             />
@@ -103,7 +103,7 @@ class ScheduleFormSection extends React.Component<ScheduleSectionProps> {
               </FormGroupHeading>
             </FieldLabel>
             <FieldInput
-              name="schedule.cron"
+              name="cron.schedules"
               type="text"
               placeholder="* * * * *"
               value={formData.cronSchedule}
@@ -134,7 +134,7 @@ class ScheduleFormSection extends React.Component<ScheduleSectionProps> {
               </FormGroupHeading>
             </FieldLabel>
             <FieldInput
-              name="schedule.timezone"
+              name="timezone.schedules"
               type="text"
               value={formData.timezone}
               placeholder={JobDataPlaceholders.timezone}
@@ -158,7 +158,7 @@ class ScheduleFormSection extends React.Component<ScheduleSectionProps> {
               </FormGroupHeading>
             </FieldLabel>
             <FieldInput
-              name="schedule.startingDeadlineSeconds"
+              name="startingDeadlineSeconds.schedules"
               type="number"
               value={formData.startingDeadline}
               placeholder={JobDataPlaceholders.startingDeadlineSeconds}

--- a/plugins/jobs/src/js/components/form/VolumesFormSection.tsx
+++ b/plugins/jobs/src/js/components/form/VolumesFormSection.tsx
@@ -102,17 +102,14 @@ class VolumesFormSection extends React.Component<VolumesSectionProps> {
         }
 
         const containerPathErrors = getFieldError(
-          `job.run.volumes.${index}.containerPath`,
+          `run.volumes.${index}.containerPath`,
           errors
         );
         const hostPathErrors = getFieldError(
-          `job.run.volumes.${index}.hostPath`,
+          `run.volumes.${index}.hostPath`,
           errors
         );
-        const modeErrors = getFieldError(
-          `job.run.volumes.${index}.mode`,
-          errors
-        );
+        const modeErrors = getFieldError(`run.volumes.${index}.mode`, errors);
 
         return (
           <FormRow key={`volume-${index}`}>

--- a/plugins/jobs/src/js/components/form/helpers/JobFormData.ts
+++ b/plugins/jobs/src/js/components/form/helpers/JobFormData.ts
@@ -26,11 +26,17 @@ export interface JobRun<Env, Secrets> {
   secrets?: Secrets;
 }
 
-export type JobSpecData = Job<ArrayLabels, EnvModel, JobSecretExposure[]>;
+export interface JobSpecData
+  extends Job<ArrayLabels, EnvModel, JobSecretExposure[]> {
+  schedules?: JobSchedule[];
+}
 
 export type JobOutputData = Job<JobLabels, JobEnv, JobSecrets>;
 
-export interface JobOutput {
+export interface JobOutput extends JobOutputData {
+  schedules?: JobSchedule[];
+}
+export interface JobAPIOutput {
   job: JobOutputData;
   schedule?: JobSchedule;
 }
@@ -58,7 +64,6 @@ export interface JobSpec {
   cmdOnly: boolean;
   container?: Container | null;
   job: JobSpecData;
-  schedule?: JobSchedule;
 }
 
 export type EnvModel = Array<[string, string]>;

--- a/plugins/jobs/src/js/components/form/helpers/JobParsers.ts
+++ b/plugins/jobs/src/js/components/form/helpers/JobParsers.ts
@@ -142,25 +142,26 @@ export function jobSpecToOutputParser(jobSpec: JobSpec): JobOutput {
   }
 
   if (
-    jobSpecCopy.schedule &&
-    jobSpecCopy.schedule.startingDeadlineSeconds === ""
+    jobSpecCopy.job.schedules &&
+    Array.isArray(jobSpecCopy.job.schedules) &&
+    jobSpecCopy.job.schedules.length
   ) {
-    delete jobSpecCopy.schedule.startingDeadlineSeconds;
-  }
-  if (jobSpecCopy.schedule) {
-    const filteredSchedule = filterEmptyValues(jobSpecCopy.schedule);
-    if (
-      !Object.keys(filteredSchedule).length ||
-      schedulePropertiesCanBeDiscarded(filteredSchedule)
-    ) {
-      jobSpecCopy.schedule = undefined;
+    const schedule = jobSpecCopy.job.schedules[0];
+    if (schedule && schedule.startingDeadlineSeconds === "") {
+      delete schedule.startingDeadlineSeconds;
+    }
+    if (schedule) {
+      const filteredSchedule = filterEmptyValues(schedule);
+      if (
+        !Object.keys(filteredSchedule).length ||
+        schedulePropertiesCanBeDiscarded(filteredSchedule)
+      ) {
+        delete jobSpecCopy.job.schedules;
+      }
     }
   }
 
-  const jobOutput = {
-    job: jobSpecCopy.job,
-    schedule: jobSpecCopy.schedule
-  };
+  const jobOutput = jobSpecCopy.job;
 
   return Hooks.applyFilter("jobSpecToOutputParser", jobOutput);
 }
@@ -193,6 +194,11 @@ export const jobSpecToFormOutputParser = (jobSpec: JobSpec): FormOutput => {
   );
   const placementConstraints =
     constraints && Array.isArray(constraints) ? constraints : [];
+  const schedules = findNestedPropertyInObject(jobSpec, "job.schedules");
+  let schedule = {};
+  if (schedules && Array.isArray(schedules) && schedules.length) {
+    schedule = schedules[0];
+  }
 
   return {
     jobId: jobSpec.job.id,
@@ -217,36 +223,37 @@ export const jobSpecToFormOutputParser = (jobSpec: JobSpec): FormOutput => {
     labels: jobSpec.job.labels,
     artifacts: run.artifacts,
     args,
-    scheduleId: findNestedPropertyInObject(jobSpec, "schedule.id"),
-    cronSchedule: findNestedPropertyInObject(jobSpec, "schedule.cron"),
-    scheduleEnabled: findNestedPropertyInObject(jobSpec, "schedule.enabled"),
-    timezone: findNestedPropertyInObject(jobSpec, "schedule.timezone"),
+    scheduleId: findNestedPropertyInObject(schedule, "id"),
+    cronSchedule: findNestedPropertyInObject(schedule, "cron"),
+    scheduleEnabled: findNestedPropertyInObject(schedule, "enabled"),
+    timezone: findNestedPropertyInObject(schedule, "timezone"),
     startingDeadline: findNestedPropertyInObject(
-      jobSpec,
-      "schedule.startingDeadlineSeconds"
-    ),
-    concurrencyPolicy: findNestedPropertyInObject(
-      jobSpec,
-      "schedule.concurrencyPolicy"
+      schedule,
+      "startingDeadlineSeconds"
     ),
     volumes: findNestedPropertyInObject(jobSpec, "job.run.volumes") || [],
-    placementConstraints
+    placementConstraints,
+    concurrencyPolicy: findNestedPropertyInObject(schedule, "concurrencyPolicy")
   };
 };
 
 export const removeBlankProperties = (jobSpec: JobOutput): JobOutput => {
   const jobSpecCopy = deepCopy(jobSpec);
-  const job = filterEmptyValues(jobSpecCopy.job);
+  const job = filterEmptyValues(jobSpecCopy);
   job.run = filterEmptyValues(job.run);
-  let schedule = jobSpecCopy.schedule;
+  const schedules = job.schedules;
+  let schedule;
+  if (schedules && Array.isArray(schedules) && schedules.length) {
+    schedule = schedules[0];
+  }
   if (schedule) {
-    const filteredSchedule = filterEmptyValues(jobSpecCopy.schedule);
+    const filteredSchedule = filterEmptyValues(schedule);
     schedule = Object.keys(filteredSchedule).length
       ? filteredSchedule
       : undefined;
   }
-  return {
-    job,
-    schedule
-  };
+  if (!schedule) {
+    delete job.schedules;
+  }
+  return job;
 };

--- a/plugins/jobs/src/js/components/form/helpers/MetronomeJobValidators.ts
+++ b/plugins/jobs/src/js/components/form/helpers/MetronomeJobValidators.ts
@@ -79,7 +79,7 @@ const ensureArray = <T>(something?: T[]): T[] =>
 
 export const MetronomeSpecValidators: MetronomeValidators = {
   validate(formData: JobOutput): FormError[] {
-    const { run } = formData.job;
+    const { run } = formData;
     const parameters = ensureArray(run.docker && run.docker.parameters);
     const constraints = ensureArray(run.placement && run.placement.constraints);
 
@@ -88,54 +88,54 @@ export const MetronomeSpecValidators: MetronomeValidators = {
 
       // IS BOOLEAN
 
-      isBoolean(_ => "job.run.docker.forcePullImage", [run.docker && run.docker.forcePullImage]),
-      isBoolean(_ => "job.run.docker.privileged", [run.docker && run.docker.privileged]),
-      isBoolean(_ => "job.run.ucr.privileged", [run.ucr && run.ucr.privileged]),
-      isBoolean(_ => "job.run.ucr.image.forcePull", [run.ucr && run.ucr.image&& run.ucr.image.forcePull]),
+      isBoolean(_ => "run.docker.forcePullImage", [run.docker && run.docker.forcePullImage]),
+      isBoolean(_ => "run.docker.privileged", [run.docker && run.docker.privileged]),
+      isBoolean(_ => "run.ucr.privileged", [run.ucr && run.ucr.privileged]),
+      isBoolean(_ => "run.ucr.image.forcePull", [run.ucr && run.ucr.image&& run.ucr.image.forcePull]),
 
       // IS NUMBER
 
-      isNumber(_ => "job.run.cpus", [run.cpus]),
-      isNumber(_ => "job.run.disk", [run.disk]),
-      isNumber(_ => "job.run.gpus", [run.gpus]),
-      isNumber(_ => "job.run.maxLaunchDelay", [run.maxLaunchDelay]),
-      isNumber(_ => "job.run.mem", [run.mem]),
-      isNumber(_ => "job.run.restart.activeDeadlineSeconds", [run.restart && run.restart.activeDeadlineSeconds]),
-      isNumber(_ => "job.run.taskKillGracePeriodSeconds", [run.taskKillGracePeriodSeconds]),
+      isNumber(_ => "run.cpus", [run.cpus]),
+      isNumber(_ => "run.disk", [run.disk]),
+      isNumber(_ => "run.gpus", [run.gpus]),
+      isNumber(_ => "run.maxLaunchDelay", [run.maxLaunchDelay]),
+      isNumber(_ => "run.mem", [run.mem]),
+      isNumber(_ => "run.restart.activeDeadlineSeconds", [run.restart && run.restart.activeDeadlineSeconds]),
+      isNumber(_ => "run.taskKillGracePeriodSeconds", [run.taskKillGracePeriodSeconds]),
 
       // IS OBJECT
 
-      isObject(_ => "job.labels", [formData.job.labels]),
-      isObject(_ => "job.run.docker", [run.docker]),
-      isObject(_ => "job.run.env", [run.env]),
-      isObject(_ => "job.run.ucr", [run.ucr]),
-      isObject(_ => "job.run.ucr.image", [run.ucr && run.ucr.image]),
+      isObject(_ => "labels", [formData.labels]),
+      isObject(_ => "run.docker", [run.docker]),
+      isObject(_ => "run.env", [run.env]),
+      isObject(_ => "run.ucr", [run.ucr]),
+      isObject(_ => "run.ucr.image", [run.ucr && run.ucr.image]),
 
       // IS PRESENT
 
-      isPresent(_ => "job.id", [formData.job.id]),
-      isPresent(_ => "job.run.cpus", [run.cpus]),
-      isPresent(_ => "job.run.disk", [run.disk]),
-      isPresent(_ => "job.run.mem", [run.mem]),
-      isPresent(i => `job.labels.${i}.key`, Object.keys(formData.job.labels || [])),
-      isPresent(i => `job.run.artifacts.${i}.uri`, (run.artifacts || []).map(_ => _.uri)),
-      isPresent(i => `job.run.docker.parameters.${i}.key`, parameters.map(_ => _.key)),
-      isPresent(i => `job.run.docker.parameters.${i}.value`, parameters.map(_ => _.value)),
+      isPresent(_ => "id", [formData.id]),
+      isPresent(_ => "run.cpus", [run.cpus]),
+      isPresent(_ => "run.disk", [run.disk]),
+      isPresent(_ => "run.mem", [run.mem]),
+      isPresent(i => `labels.${i}.key`, Object.keys(formData.labels || [])),
+      isPresent(i => `run.artifacts.${i}.uri`, (run.artifacts || []).map(_ => _.uri)),
+      isPresent(i => `run.docker.parameters.${i}.key`, parameters.map(_ => _.key)),
+      isPresent(i => `run.docker.parameters.${i}.value`, parameters.map(_ => _.value)),
 
       // IS STRING
 
-      isString(_ => "job.id", [formData.job.id]),
-      isString(_ => "job.run.cmd", [run.cmd]),
-      isString(_ => "job.run.docker.image", [run.docker && run.docker.image]),
-      isString(_ => "job.run.restart.policy", [run.restart && run.restart.policy]),
-      isString(_ => "job.run.ucr.image.id", [run.ucr && run.ucr.image && run.ucr.image.id]),
-      isString(_ => "job.run.user", [run.user]),
-      isString(i => `job.labels.${i}.key`, Object.keys(formData.job.labels || [])),
-      isString(i => `job.labels.${i}.value`, Object.values(formData.job.labels || [])),
-      isString(i => `job.run.args.${i}`, run.args || []),
-      isString(i => `job.run.artifacts.${i}.uri`, (run.artifacts || []).map(_ => _.uri)),
-      isString(i => `job.run.docker.parameters.${i}.key`, parameters.map(_ => _.key)),
-      isString(i => `job.run.docker.parameters.${i}.value`, parameters.map(_ => _.value)),
+      isString(_ => "id", [formData.id]),
+      isString(_ => "run.cmd", [run.cmd]),
+      isString(_ => "run.docker.image", [run.docker && run.docker.image]),
+      isString(_ => "run.restart.policy", [run.restart && run.restart.policy]),
+      isString(_ => "run.ucr.image.id", [run.ucr && run.ucr.image && run.ucr.image.id]),
+      isString(_ => "run.user", [run.user]),
+      isString(i => `labels.${i}.key`, Object.keys(formData.labels || [])),
+      isString(i => `labels.${i}.value`, Object.values(formData.labels || [])),
+      isString(i => `run.args.${i}`, run.args || []),
+      isString(i => `run.artifacts.${i}.uri`, (run.artifacts || []).map(_ => _.uri)),
+      isString(i => `run.docker.parameters.${i}.key`, parameters.map(_ => _.key)),
+      isString(i => `run.docker.parameters.${i}.value`, parameters.map(_ => _.value)),
       isString(i => `job.run.placement.constraints.${i}.operator`, constraints.map(_ => _.operator)),
       isString(i => `job.run.placement.constraints.${i}.attribute`, constraints.map(_ => _.attribute)),
       isString(i => `job.run.placement.constraints.${i}.value`, constraints.map(_ => _.value))
@@ -148,7 +148,7 @@ export const MetronomeSpecValidators: MetronomeValidators = {
    * Ensure ID contains only allowed characters.
    */
   jobIdIsValid(formData: JobOutput): FormError[] {
-    const jobId = findNestedPropertyInObject(formData, "job.id");
+    const jobId = findNestedPropertyInObject(formData, "id");
     const jobIdRegex = /^([a-z0-9]([a-z0-9-]*[a-z0-9]+)*)([.][a-z0-9]([a-z0-9-]*[a-z0-9]+)*)*$/;
     const message = i18nMark(
       "ID must be at least 1 character and may only contain digits (`0-9`), dashes (`-`), and lowercase letters (`a-z`). The ID may not begin or end with a dash"
@@ -161,15 +161,14 @@ export const MetronomeSpecValidators: MetronomeValidators = {
     // browsers for longer strings that end with a "-".
     return jobId && !jobId.endsWith("-") && jobIdRegex.test(jobId)
       ? []
-      : [{ path: ["job", "id"], message }];
+      : [{ path: ["id"], message }];
   },
 
   /**
    * Ensure that the user has provided either one of `cmd` or `args`, or a container image field.
    * Ensure that the user has not provided both `cmd` and `args`.
    */
-  containsCmdArgsOrContainer(formData: JobOutput): FormError[] {
-    const { job } = formData;
+  containsCmdArgsOrContainer(job: JobOutput): FormError[] {
     const hasCmd = findNestedPropertyInObject(job, "run.cmd");
     const hasArgs =
       findNestedPropertyInObject(job, "run.args") &&
@@ -183,11 +182,11 @@ export const MetronomeSpecValidators: MetronomeValidators = {
 
       return [
         {
-          path: ["job", "run", "cmd"],
+          path: ["run", "cmd"],
           message: notBothMessage
         },
         {
-          path: ["job", "run", "args"],
+          path: ["run", "args"],
           message: notBothMessage
         }
       ];
@@ -218,14 +217,14 @@ export const MetronomeSpecValidators: MetronomeValidators = {
     );
 
     const containerImageErrorPath = job.run.ucr
-      ? ["job", "run", "ucr", "image", "id"]
+      ? ["run", "ucr", "image", "id"]
       : job.run.docker
-      ? ["job", "run", "docker", "image"]
+      ? ["run", "docker", "image"]
       : [];
 
     return [
-      { path: ["job", "run", "cmd"], message },
-      { path: ["job", "run", "args"], message },
+      { path: ["run", "cmd"], message },
+      { path: ["run", "args"], message },
       { path: containerImageErrorPath, message }
     ];
   },
@@ -234,11 +233,11 @@ export const MetronomeSpecValidators: MetronomeValidators = {
    * Ensure there is a container image if a container is specified
    */
   mustContainImageOnDockerOrUCR(formData: JobOutput) {
-    const docker = findNestedPropertyInObject(formData, "job.run.docker");
+    const docker = findNestedPropertyInObject(formData, "run.docker");
     if (docker && !docker.image) {
       return [
         {
-          path: ["job", "run", "docker", "image"],
+          path: ["run", "docker", "image"],
           message: i18nMark(
             "Must be specified when using the Docker Engine runtime"
           )
@@ -246,11 +245,11 @@ export const MetronomeSpecValidators: MetronomeValidators = {
       ];
     }
 
-    const ucr = findNestedPropertyInObject(formData, "job.run.ucr");
+    const ucr = findNestedPropertyInObject(formData, "run.ucr");
     if (ucr && (!ucr.image || !ucr.image.id)) {
       return [
         {
-          path: ["job", "run", "ucr", "image", "id"],
+          path: ["run", "ucr", "image", "id"],
           message: i18nMark("Must be specified when using UCR")
         }
       ];
@@ -263,12 +262,12 @@ export const MetronomeSpecValidators: MetronomeValidators = {
    * Ensure GPUs are used only with UCR
    */
   gpusOnlyWithUCR(formData: JobOutput) {
-    const gpus = findNestedPropertyInObject(formData, "job.run.gpus");
-    const docker = findNestedPropertyInObject(formData, "job.run.docker");
+    const gpus = findNestedPropertyInObject(formData, "run.gpus");
+    const docker = findNestedPropertyInObject(formData, "run.docker");
     if ((gpus || gpus === 0) && docker) {
       return [
         {
-          path: ["job", "run", "gpus"],
+          path: ["run", "gpus"],
           message: i18nMark("GPUs are only available with UCR")
         }
       ];
@@ -278,16 +277,16 @@ export const MetronomeSpecValidators: MetronomeValidators = {
   },
 
   oneOfUcrOrDocker(formData: JobOutput) {
-    const docker = findNestedPropertyInObject(formData, "job.run.docker");
-    const ucr = findNestedPropertyInObject(formData, "job.run.ucr");
+    const docker = findNestedPropertyInObject(formData, "run.docker");
+    const ucr = findNestedPropertyInObject(formData, "run.ucr");
     if (docker && ucr) {
       return [
         {
-          path: ["job", "run", "docker"],
+          path: ["run", "docker"],
           message: i18nMark("Only one of UCR or Docker is allowed")
         },
         {
-          path: ["job", "run", "ucr"],
+          path: ["run", "ucr"],
           message: i18nMark("Only one of UCR or Docker is allowed")
         }
       ];
@@ -296,21 +295,21 @@ export const MetronomeSpecValidators: MetronomeValidators = {
   },
 
   checkTypesOfUcrProps(formData: JobOutput) {
-    const ucr = findNestedPropertyInObject(formData, "job.run.ucr");
+    const ucr = findNestedPropertyInObject(formData, "run.ucr");
     const errors: FormError[] = [];
 
     if (ucr == undefined) {
       return errors;
     }
 
-    const kind = findNestedPropertyInObject(formData, "job.run.ucr.image.kind");
+    const kind = findNestedPropertyInObject(formData, "run.ucr.image.kind");
 
     if (
       kind != undefined &&
       (kind !== UcrImageKind.Docker && kind !== UcrImageKind.Appc)
     ) {
       errors.push({
-        path: ["job", "run", "ucr", "image", "kind"],
+        path: ["run", "ucr", "image", "kind"],
         message: i18nMark("Image kind must be one of `docker` or `appc`")
       });
     }
@@ -318,28 +317,28 @@ export const MetronomeSpecValidators: MetronomeValidators = {
   },
 
   valuesAreWithinRange(formData: JobOutput) {
-    const cpus = findNestedPropertyInObject(formData, "job.run.cpus");
-    const mem = findNestedPropertyInObject(formData, "job.run.mem");
-    const disk = findNestedPropertyInObject(formData, "job.run.disk");
+    const cpus = findNestedPropertyInObject(formData, "run.cpus");
+    const mem = findNestedPropertyInObject(formData, "run.mem");
+    const disk = findNestedPropertyInObject(formData, "run.disk");
     const errors = [];
 
     if (cpus != undefined && typeof cpus === "number" && cpus < 0.01) {
       errors.push({
-        path: ["job", "run", "cpus"],
+        path: ["run", "cpus"],
         message: i18nMark("Minimum value is 0.01")
       });
     }
 
     if (mem != undefined && typeof mem === "number" && mem < 32) {
       errors.push({
-        path: ["job", "run", "mem"],
+        path: ["run", "mem"],
         message: i18nMark("Minimum value is 32")
       });
     }
 
     if (disk != undefined && typeof disk === "number" && disk < 0) {
       errors.push({
-        path: ["job", "run", "disk"],
+        path: ["run", "disk"],
         message: i18nMark("Minimum value is 0")
       });
     }
@@ -348,11 +347,11 @@ export const MetronomeSpecValidators: MetronomeValidators = {
   },
 
   gpusWithinRange(formData: JobOutput) {
-    const gpus = findNestedPropertyInObject(formData, "job.run.gpus");
+    const gpus = findNestedPropertyInObject(formData, "run.gpus");
     if (gpus && typeof gpus === "number" && gpus < 0) {
       return [
         {
-          path: ["job", "run", "gpus"],
+          path: ["run", "gpus"],
           message: i18nMark("Minimum value is 0")
         }
       ];
@@ -361,13 +360,13 @@ export const MetronomeSpecValidators: MetronomeValidators = {
   },
 
   noEmptyArgs(formData: JobOutput) {
-    const args = formData.job.run.args;
+    const args = formData.run.args;
     const errors: FormError[] = [];
     if (args && Array.isArray(args)) {
       args.forEach((arg, index) => {
         if (arg === "" || arg == undefined) {
           errors.push({
-            path: ["job", "run", "args", `${index}`],
+            path: ["run", "args", `${index}`],
             message: i18nMark("Arg cannot be empty")
           });
         }
@@ -377,13 +376,13 @@ export const MetronomeSpecValidators: MetronomeValidators = {
   },
 
   argsUsedOnlyWithDocker(formData: JobOutput) {
-    const args = formData.job.run.args;
-    const docker = formData.job.run.docker;
+    const args = formData.run.args;
+    const docker = formData.run.docker;
 
     if (args && !docker) {
       return [
         {
-          path: ["job", "run", "args"],
+          path: ["run", "args"],
           message: i18nMark("Args can only be used with Docker")
         }
       ];
@@ -392,7 +391,7 @@ export const MetronomeSpecValidators: MetronomeValidators = {
   },
 
   noDuplicateArgs(formData: JobOutput) {
-    const args = formData.job.run && formData.job.run.args;
+    const args = formData.run && formData.run.args;
     const errors: FormError[] = [];
     const map: { [key: string]: number } = {};
     const dupIndex: number[] = [];
@@ -411,7 +410,7 @@ export const MetronomeSpecValidators: MetronomeValidators = {
 
       dupIndex.forEach(errorIndex => {
         errors.push({
-          path: ["job", "run", "args", `${errorIndex}`],
+          path: ["run", "args", `${errorIndex}`],
           message: i18nMark("No duplicate args")
         });
       });
@@ -420,7 +419,7 @@ export const MetronomeSpecValidators: MetronomeValidators = {
   },
 
   noDuplicateParams(formData: JobOutput) {
-    const docker = formData.job.run && formData.job.run.docker;
+    const docker = formData.run && formData.run.docker;
     const errors: FormError[] = [];
     const map: { [key: string]: number } = {};
     const dupIndex: number[] = [];
@@ -440,7 +439,7 @@ export const MetronomeSpecValidators: MetronomeValidators = {
 
       dupIndex.forEach(errorIndex => {
         errors.push({
-          path: ["job", "run", "docker", "parameters", `${errorIndex}`],
+          path: ["run", "docker", "parameters", `${errorIndex}`],
           message: i18nMark("No duplicate parameters")
         });
       });
@@ -449,11 +448,16 @@ export const MetronomeSpecValidators: MetronomeValidators = {
   },
 
   scheduleHasId(formData: JobOutput) {
-    const { schedule } = formData;
-    if (schedule && !schedule.id) {
+    const { schedules } = formData;
+    if (
+      schedules &&
+      Array.isArray(schedules) &&
+      schedules.length &&
+      !schedules[0].id
+    ) {
       return [
         {
-          path: ["schedule", "id"],
+          path: ["schedules", "0", "id"],
           message: i18nMark("ID is required")
         }
       ];
@@ -462,11 +466,16 @@ export const MetronomeSpecValidators: MetronomeValidators = {
   },
 
   scheduleHasCron(formData: JobOutput) {
-    const { schedule } = formData;
-    if (schedule && !schedule.cron) {
+    const { schedules } = formData;
+    if (
+      schedules &&
+      Array.isArray(schedules) &&
+      schedules.length &&
+      !schedules[0].cron
+    ) {
       return [
         {
-          path: ["schedule", "cron"],
+          path: ["schedules", "0", "cron"],
           message: i18nMark("CRON schedule is required")
         }
       ];
@@ -475,40 +484,46 @@ export const MetronomeSpecValidators: MetronomeValidators = {
   },
 
   scheduleIdIsValid(formData: JobOutput) {
-    const { schedule } = formData;
+    const { schedules } = formData;
     const idRegex = /^([a-z0-9][a-z0-9\\-]*[a-z0-9]+)$/;
     const message = i18nMark(
       "ID must be at least 2 characters and may only contain digits (`0-9`), dashes (`-`), and lowercase letters (`a-z`). The ID may not begin or end with a dash"
     );
-    if (!schedule) {
+    if (!schedules || !Array.isArray(schedules) || !schedules.length) {
       return [];
     }
+    const schedule = schedules[0];
     if (schedule.id && typeof schedule.id !== "string") {
       return [
         {
-          path: ["schedule", "id"],
+          path: ["schedules", "0", "id"],
           message: i18nMark("Schedule ID must be a string")
         }
       ];
     }
     return schedule && schedule.id && idRegex.test(schedule.id)
       ? []
-      : [{ path: ["schedule", "id"], message }];
+      : [{ path: ["schedules", "0", "id"], message }];
   },
 
   scheduleStartingDeadlineIsValid(formData: JobOutput) {
-    const { schedule } = formData;
+    const { schedules } = formData;
     const errors = [];
-    if (schedule && schedule.startingDeadlineSeconds != undefined) {
-      if (typeof schedule.startingDeadlineSeconds !== "number") {
+    if (
+      schedules &&
+      Array.isArray(schedules) &&
+      schedules.length &&
+      schedules[0].startingDeadlineSeconds != undefined
+    ) {
+      if (typeof schedules[0].startingDeadlineSeconds !== "number") {
         errors.push({
-          path: ["schedule", "startingDeadlineSeconds"],
+          path: ["schedules", "0", "startingDeadlineSeconds"],
           message: i18nMark("Starting deadline must be a number")
         });
       }
-      if (schedule.startingDeadlineSeconds < 1) {
+      if (schedules[0].startingDeadlineSeconds < 1) {
         errors.push({
-          path: ["schedule", "startingDeadlineSeconds"],
+          path: ["schedules", "0", "startingDeadlineSeconds"],
           message: i18nMark("Minimum value is 1")
         });
       }
@@ -517,9 +532,11 @@ export const MetronomeSpecValidators: MetronomeValidators = {
   },
 
   constraintsAreArray(formData: JobOutput): FormError[] {
-    const path = "job.run.placement.constraints";
+    const path = "run.placement.constraints";
 
-    return isArray(_ => path, [findNestedPropertyInObject(formData, path)])([]);
+    return isArray(_ => path, [
+      findNestedPropertyInObject(formData, `job.${path}`)
+    ])([]);
   }
 };
 
@@ -537,20 +554,20 @@ function volumesAreComplete(formData: JobSpec) {
       }
       if (volume.containerPath == null || volume.containerPath === "") {
         errors.push({
-          path: ["job", "run", "volumes", `${index}`, "containerPath"],
+          path: ["run", "volumes", `${index}`, "containerPath"],
           message: i18nMark("Container path is required")
         });
       }
       if (!volume.hasOwnProperty("secret")) {
         if (volume.hostPath == null || volume.hostPath === "") {
           errors.push({
-            path: ["job", "run", "volumes", `${index}`, "hostPath"],
+            path: ["run", "volumes", `${index}`, "hostPath"],
             message: i18nMark("Host path is required")
           });
         }
         if (volume.mode == null || volume.mode === "") {
           errors.push({
-            path: ["job", "run", "volumes", `${index}`, "mode"],
+            path: ["run", "volumes", `${index}`, "mode"],
             message: i18nMark("Mode is required")
           });
         }
@@ -574,25 +591,25 @@ function checkVolumePropertyTypes(formData: JobSpec) {
       }
       if (typeof volume.containerPath !== "string") {
         errors.push({
-          path: ["job", "run", "volumes", `${index}`, "containerPath"],
+          path: ["run", "volumes", `${index}`, "containerPath"],
           message: stringMsg
         });
       }
       if (!volume.hasOwnProperty("secret")) {
         if (typeof volume.hostPath !== "string") {
           errors.push({
-            path: ["job", "run", "volumes", `${index}`, "hostPath"],
+            path: ["run", "volumes", `${index}`, "hostPath"],
             message: stringMsg
           });
         }
         if (typeof volume.mode !== "string") {
           errors.push({
-            path: ["job", "run", "volumes", `${index}`, "mode"],
+            path: ["run", "volumes", `${index}`, "mode"],
             message: stringMsg
           });
         } else if (volume.mode !== "RO" && volume.mode !== "RW") {
           errors.push({
-            path: ["job", "run", "volumes", `${index}`, "mode"],
+            path: ["run", "volumes", `${index}`, "mode"],
             message: i18nMark("Mode must be one of: RO, RW")
           });
         }
@@ -629,7 +646,7 @@ export function constraintsAreComplete(formData: JobSpec) {
       }
       if (operator == null || operator === "" || isOnlyWhitespace(operator)) {
         errors.push({
-          path: ["job", "run", "placement", "constraints", `${i}`, "operator"],
+          path: ["run", "placement", "constraints", `${i}`, "operator"],
           message: i18nMark("Operator is required")
         });
       }
@@ -639,7 +656,7 @@ export function constraintsAreComplete(formData: JobSpec) {
         isOnlyWhitespace(attribute)
       ) {
         errors.push({
-          path: ["job", "run", "placement", "constraints", `${i}`, "attribute"],
+          path: ["run", "placement", "constraints", `${i}`, "attribute"],
           message: i18nMark("Field is required")
         });
       }
@@ -648,7 +665,7 @@ export function constraintsAreComplete(formData: JobSpec) {
         (value == null || value === "" || isOnlyWhitespace(value))
       ) {
         errors.push({
-          path: ["job", "run", "placement", "constraints", `${i}`, "value"],
+          path: ["run", "placement", "constraints", `${i}`, "value"],
           message: i18nMark("Value is required")
         });
       }
@@ -682,20 +699,20 @@ export function validateSpec(jobSpec: JobSpec): FormError[] {
     if (v && !isObjectUtil(v)) {
       if (k == null || k === "") {
         envVarsErrors.push({
-          path: ["job", "run", "env", `${i}`],
+          path: ["run", "env", `${i}`],
           message: presentMsg
         });
       }
       if (typeof v !== "string") {
         envVarsErrors.push({
-          path: ["job", "run", "env", k, "value", `${i}`],
+          path: ["run", "env", k, "value", `${i}`],
           message: stringMsg
         });
       }
     }
     if (k && (v == null || v === "")) {
       envVarsErrors.push({
-        path: ["job", "run", "env", k, "value", `${i}`],
+        path: ["run", "env", k, "value", `${i}`],
         message: presentMsg
       });
     }
@@ -704,7 +721,7 @@ export function validateSpec(jobSpec: JobSpec): FormError[] {
     if (map[envVarKey].length > 1) {
       map[envVarKey].forEach(index => {
         envVarsErrors.push({
-          path: ["job", "run", "env", `${index}`],
+          path: ["run", "env", `${index}`],
           message: envsMsg
         });
       });
@@ -719,8 +736,8 @@ export function validateSpec(jobSpec: JobSpec): FormError[] {
   );
 
   return pipe(
-    allUniq(_ => "job.labels", [labels], labelsMsg),
-    isUniqIn(labels)(i => `job.labels.${i}`, labels, labelsMsg)
+    allUniq(_ => "labels", [labels], labelsMsg),
+    isUniqIn(labels)(i => `labels.${i}`, labels, labelsMsg)
   )([])
     .concat(envVarsErrors)
     .concat(volumesErrors)

--- a/plugins/jobs/src/js/components/form/helpers/__tests__/JobParsers-test.ts
+++ b/plugins/jobs/src/js/components/form/helpers/__tests__/JobParsers-test.ts
@@ -20,9 +20,9 @@ describe("JobParsers", () => {
       };
 
       const parsed = jobSpecToOutputParser(input as JobSpec);
-      expect(parsed.job.run.docker).toBe(undefined);
-      expect(parsed.job.run.ucr).toBe(undefined);
-      expect(parsed.job.run.gpus).toBe(0);
+      expect(parsed.run.docker).toBe(undefined);
+      expect(parsed.run.ucr).toBe(undefined);
+      expect(parsed.run.gpus).toBe(0);
     });
 
     it("returns object with only container property indicated by `container` if cmdOnly false", () => {
@@ -38,8 +38,8 @@ describe("JobParsers", () => {
       };
 
       const parsed = jobSpecToOutputParser(input as JobSpec);
-      expect(parsed.job.run.docker).toEqual({});
-      expect(parsed.job.run.ucr).toBe(undefined);
+      expect(parsed.run.docker).toEqual({});
+      expect(parsed.run.ucr).toBe(undefined);
     });
 
     it("returns object with only docker and no gpus if `container` is docker and cmdOnly is false", () => {
@@ -56,9 +56,9 @@ describe("JobParsers", () => {
       };
 
       const parsed = jobSpecToOutputParser(input as JobSpec);
-      expect(parsed.job.run.docker).toEqual({});
-      expect(parsed.job.run.ucr).toBe(undefined);
-      expect(parsed.job.run.gpus).toBe(undefined);
+      expect(parsed.run.docker).toEqual({});
+      expect(parsed.run.ucr).toBe(undefined);
+      expect(parsed.run.gpus).toBe(undefined);
     });
   });
 

--- a/plugins/jobs/src/js/components/form/helpers/__tests__/MetronomeJobValidators-test.ts
+++ b/plugins/jobs/src/js/components/form/helpers/__tests__/MetronomeJobValidators-test.ts
@@ -7,30 +7,30 @@ import { JobOutput } from "../JobFormData";
 
 const JOBID_ERRORS = [
   {
-    path: ["job", "id"],
+    path: ["id"],
     message:
       "ID must be at least 1 character and may only contain digits (`0-9`), dashes (`-`), and lowercase letters (`a-z`). The ID may not begin or end with a dash"
   }
 ];
 const CMDARGSERROR = [
   {
-    path: ["job", "run", "cmd"],
+    path: ["run", "cmd"],
     message: "Please specify only one of `cmd` or `args`"
   },
   {
-    path: ["job", "run", "args"],
+    path: ["run", "args"],
     message: "Please specify only one of `cmd` or `args`"
   }
 ];
 
 const CMDARGSCONTAINERERROR = [
   {
-    path: ["job", "run", "cmd"],
+    path: ["run", "cmd"],
     message:
       "You must specify a command, an argument or a container with an image"
   },
   {
-    path: ["job", "run", "args"],
+    path: ["run", "args"],
     message:
       "You must specify a command, an argument or a container with an image"
   },
@@ -43,88 +43,88 @@ const CMDARGSCONTAINERERROR = [
 
 const MUSTCONTAINIMAGEFORDOCKER = [
   {
-    path: ["job", "run", "docker", "image"],
+    path: ["run", "docker", "image"],
     message: "Must be specified when using the Docker Engine runtime"
   }
 ];
 
 const MUSTCONTAINIMAGEFORUCR = [
   {
-    path: ["job", "run", "ucr", "image", "id"],
+    path: ["run", "ucr", "image", "id"],
     message: "Must be specified when using UCR"
   }
 ];
 
 const GPUSERROR = [
   {
-    path: ["job", "run", "gpus"],
+    path: ["run", "gpus"],
     message: "GPUs are only available with UCR"
   }
 ];
 
 const CPURANGEERROR = [
   {
-    path: ["job", "run", "cpus"],
+    path: ["run", "cpus"],
     message: "Minimum value is 0.01"
   }
 ];
 
 const MEMRANGEERROR = [
   {
-    path: ["job", "run", "mem"],
+    path: ["run", "mem"],
     message: "Minimum value is 32"
   }
 ];
 
 const DISKRANGEERROR = [
   {
-    path: ["job", "run", "disk"],
+    path: ["run", "disk"],
     message: "Minimum value is 0"
   }
 ];
 
 const GPURANGEERROR = [
   {
-    path: ["job", "run", "gpus"],
+    path: ["run", "gpus"],
     message: "Minimum value is 0"
   }
 ];
 
 const EMPTYARGGERROR = [
   {
-    path: ["job", "run", "args", "0"],
+    path: ["run", "args", "0"],
     message: "Arg cannot be empty"
   }
 ];
 
 const ARGSWITHOUTDOCKERERROR = [
   {
-    path: ["job", "run", "args"],
+    path: ["run", "args"],
     message: "Args can only be used with Docker"
   }
 ];
 
 const UCRANDDOCKERERROR = [
   {
-    path: ["job", "run", "docker"],
+    path: ["run", "docker"],
     message: "Only one of UCR or Docker is allowed"
   },
   {
-    path: ["job", "run", "ucr"],
+    path: ["run", "ucr"],
     message: "Only one of UCR or Docker is allowed"
   }
 ];
 
 const SCHEDULEIDERROR = [
   {
-    path: ["schedule", "id"],
+    path: ["schedules", "0", "id"],
     message: "ID is required"
   }
 ];
 
 const SCHEDULEIDREGEXERROR = [
   {
-    path: ["schedule", "id"],
+    path: ["schedules", "0", "id"],
     message:
       "ID must be at least 2 characters and may only contain digits (`0-9`), dashes (`-`), and lowercase letters (`a-z`). The ID may not begin or end with a dash"
   }
@@ -132,33 +132,31 @@ const SCHEDULEIDREGEXERROR = [
 
 const CRONERROR = [
   {
-    path: ["schedule", "cron"],
+    path: ["schedules", "0", "cron"],
     message: "CRON schedule is required"
   }
 ];
 
 const STARTINGDEADLINETYPEERROR = [
   {
-    path: ["schedule", "startingDeadlineSeconds"],
+    path: ["schedules", "0", "startingDeadlineSeconds"],
     message: "Starting deadline must be a number"
   }
 ];
 
 const STARTINGDEADLINEVALUEERROR = [
   {
-    path: ["schedule", "startingDeadlineSeconds"],
+    path: ["schedules", "0", "startingDeadlineSeconds"],
     message: "Minimum value is 1"
   }
 ];
 
 const validJobSpec = (): JobOutput => ({
-  job: {
-    id: "id",
-    run: {
-      cpus: 1,
-      mem: 128,
-      disk: 32
-    }
+  id: "id",
+  run: {
+    cpus: 1,
+    mem: 128,
+    disk: 32
   }
 });
 
@@ -166,17 +164,17 @@ describe("MetronomeSpecValidators", () => {
   describe("#jobIdIsValid", () => {
     it("returns error if id is not a string", () => {
       const spec: any = validJobSpec();
-      spec.job.id = 123;
+      spec.id = 123;
 
       expect(MetronomeSpecValidators.validate(spec)).toContainEqual({
-        path: ["job", "id"],
+        path: ["id"],
         message: "Must be a string"
       });
     });
 
     it("returns error if id contains special characters", () => {
       const spec: any = validJobSpec();
-      spec.job.id = "test$";
+      spec.id = "test$";
 
       expect(MetronomeSpecValidators.jobIdIsValid(spec as JobOutput)).toEqual(
         JOBID_ERRORS
@@ -185,9 +183,7 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if id contains uppercase letters", () => {
       const spec = {
-        job: {
-          id: "Test"
-        }
+        id: "Test"
       };
       expect(MetronomeSpecValidators.jobIdIsValid(spec as JobOutput)).toEqual(
         JOBID_ERRORS
@@ -196,9 +192,7 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if id starts with a dash", () => {
       const spec = {
-        job: {
-          id: "-test"
-        }
+        id: "-test"
       };
       expect(MetronomeSpecValidators.jobIdIsValid(spec as JobOutput)).toEqual(
         JOBID_ERRORS
@@ -207,9 +201,7 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if id ends with a dash", () => {
       const spec = {
-        job: {
-          id: "test-"
-        }
+        id: "test-"
       };
       expect(MetronomeSpecValidators.jobIdIsValid(spec as JobOutput)).toEqual(
         JOBID_ERRORS
@@ -218,9 +210,7 @@ describe("MetronomeSpecValidators", () => {
 
     it("does not return error for id with lowercase letters and dashes", () => {
       const spec = {
-        job: {
-          id: "test-1"
-        }
+        id: "test-1"
       };
       expect(MetronomeSpecValidators.jobIdIsValid(spec as JobOutput)).toEqual(
         []
@@ -231,10 +221,8 @@ describe("MetronomeSpecValidators", () => {
   describe("#containsCmdArgsOrContainer", () => {
     it("returns no errors if `cmd` defined", () => {
       const spec = {
-        job: {
-          run: {
-            cmd: "sleep 100"
-          }
+        run: {
+          cmd: "sleep 100"
         }
       };
       expect(
@@ -244,10 +232,8 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns no errors if `args` defined", () => {
       const spec = {
-        job: {
-          run: {
-            args: ["sleep 100"]
-          }
+        run: {
+          args: ["sleep 100"]
         }
       };
       expect(
@@ -257,11 +243,9 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns no errors if `run.docker.image` defined", () => {
       const spec = {
-        job: {
-          run: {
-            docker: {
-              image: "foo"
-            }
+        run: {
+          docker: {
+            image: "foo"
           }
         }
       };
@@ -272,12 +256,10 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns no errors if `run.ucr.image.id` defined", () => {
       const spec = {
-        job: {
-          run: {
-            ucr: {
-              image: {
-                id: "foo"
-              }
+        run: {
+          ucr: {
+            image: {
+              id: "foo"
             }
           }
         }
@@ -289,11 +271,9 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if both `args` and `cmd` are defined", () => {
       const spec = {
-        job: {
-          run: {
-            args: ["sleep 100"],
-            cmd: "sleep 100"
-          }
+        run: {
+          args: ["sleep 100"],
+          cmd: "sleep 100"
         }
       };
       expect(
@@ -302,7 +282,7 @@ describe("MetronomeSpecValidators", () => {
     });
 
     it("returns all errors if neither is defined", () => {
-      const spec = { job: { run: {} } };
+      const spec = { run: {} };
       expect(
         MetronomeSpecValidators.containsCmdArgsOrContainer(spec as JobOutput)
       ).toEqual(CMDARGSCONTAINERERROR);
@@ -312,10 +292,8 @@ describe("MetronomeSpecValidators", () => {
   describe("#mustContainImageOnDockerOrUCR", () => {
     it("returns error if runtime is docker but image is missing", () => {
       const spec = {
-        job: {
-          run: {
-            docker: {}
-          }
+        run: {
+          docker: {}
         }
       };
       expect(
@@ -325,26 +303,26 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns an error if docker is present but is not an object", () => {
       const spec: any = validJobSpec();
-      spec.job.run.docker = "not an object";
+      spec.run.docker = "not an object";
       expect(MetronomeSpecValidators.validate(spec)).toContainEqual({
         message: "Must be an object",
-        path: ["job", "run", "docker"]
+        path: ["run", "docker"]
       });
     });
 
     it("returns an error if ucr is present but is not an object", () => {
       const spec: any = validJobSpec();
-      spec.job.run.ucr = "not an object";
+      spec.run.ucr = "not an object";
 
       expect(MetronomeSpecValidators.validate(spec)).toContainEqual({
         message: "Must be an object",
-        path: ["job", "run", "ucr"]
+        path: ["run", "ucr"]
       });
     });
 
     it("does not return error if runtime docker and image is specified", () => {
       const spec: any = validJobSpec();
-      spec.job.run.docker = { image: "foo" };
+      spec.run.docker = { image: "foo" };
       expect(
         MetronomeSpecValidators.mustContainImageOnDockerOrUCR(spec)
       ).toEqual([]);
@@ -352,7 +330,7 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if runtime is ucr but image is missing", () => {
       const spec: any = validJobSpec();
-      spec.job.run.ucr = {};
+      spec.run.ucr = {};
 
       expect(
         MetronomeSpecValidators.mustContainImageOnDockerOrUCR(spec as JobOutput)
@@ -361,7 +339,7 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if runtime is ucr but image.id is missing", () => {
       const spec: any = validJobSpec();
-      spec.job.run.ucr = { image: {} };
+      spec.run.ucr = { image: {} };
 
       expect(
         MetronomeSpecValidators.mustContainImageOnDockerOrUCR(spec as JobOutput)
@@ -370,7 +348,7 @@ describe("MetronomeSpecValidators", () => {
 
     it("does not return error if runtime is ucr and image.id is specified", () => {
       const spec: any = validJobSpec();
-      spec.job.run.ucr = { image: { id: "foo" } };
+      spec.run.ucr = { image: { id: "foo" } };
 
       expect(
         MetronomeSpecValidators.mustContainImageOnDockerOrUCR(spec as JobOutput)
@@ -381,13 +359,11 @@ describe("MetronomeSpecValidators", () => {
   describe("#gpusOnlyWithUCR", () => {
     it("returns no errors when gpus are used with ucr", () => {
       const spec = {
-        job: {
-          run: {
-            gpus: 0,
-            ucr: {
-              image: {
-                id: "foo"
-              }
+        run: {
+          gpus: 0,
+          ucr: {
+            image: {
+              id: "foo"
             }
           }
         }
@@ -399,12 +375,10 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error when gpus are used with docker", () => {
       const spec = {
-        job: {
-          run: {
-            gpus: 0,
-            docker: {
-              image: "foo"
-            }
+        run: {
+          gpus: 0,
+          docker: {
+            image: "foo"
           }
         }
       };
@@ -415,10 +389,8 @@ describe("MetronomeSpecValidators", () => {
 
     it("does not return error when gpus are used without explicit container", () => {
       const spec = {
-        job: {
-          run: {
-            gpus: 0
-          }
+        run: {
+          gpus: 0
         }
       };
       expect(
@@ -435,44 +407,44 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if id is not specified", () => {
       const spec = validJobSpec();
-      delete spec.job.id;
+      delete spec.id;
       expect(MetronomeSpecValidators.validate(spec as JobOutput)).toEqual([
-        { message: "Must be present", path: ["job", "id"] }
+        { message: "Must be present", path: ["id"] }
       ]);
     });
 
     it("returns error if cpus is not specified", () => {
       const spec = validJobSpec();
-      delete spec.job.run.cpus;
+      delete spec.run.cpus;
       expect(MetronomeSpecValidators.validate(spec as JobOutput)).toEqual([
-        { message: "Must be present", path: ["job", "run", "cpus"] }
+        { message: "Must be present", path: ["run", "cpus"] }
       ]);
     });
 
     it("returns error if mem is not specified", () => {
       const spec = validJobSpec();
-      delete spec.job.run.mem;
+      delete spec.run.mem;
       expect(MetronomeSpecValidators.validate(spec as JobOutput)).toEqual([
-        { message: "Must be present", path: ["job", "run", "mem"] }
+        { message: "Must be present", path: ["run", "mem"] }
       ]);
     });
 
     it("returns error if disk is not specified", () => {
       const spec = validJobSpec();
-      delete spec.job.run.disk;
+      delete spec.run.disk;
       expect(MetronomeSpecValidators.validate(spec as JobOutput)).toEqual([
-        { message: "Must be present", path: ["job", "run", "disk"] }
+        { message: "Must be present", path: ["run", "disk"] }
       ]);
     });
 
     it("returns all errors if no base required fields are specified", () => {
-      const spec = { job: { run: {} } };
+      const spec = { run: {} };
 
       expect(MetronomeSpecValidators.validate(spec as any)).toEqual([
-        { message: "Must be present", path: ["job", "id"] },
-        { message: "Must be present", path: ["job", "run", "cpus"] },
-        { message: "Must be present", path: ["job", "run", "disk"] },
-        { message: "Must be present", path: ["job", "run", "mem"] }
+        { message: "Must be present", path: ["id"] },
+        { message: "Must be present", path: ["run", "cpus"] },
+        { message: "Must be present", path: ["run", "disk"] },
+        { message: "Must be present", path: ["run", "mem"] }
       ]);
     });
   });
@@ -480,13 +452,11 @@ describe("MetronomeSpecValidators", () => {
   describe("#valuesAreWithinRange", () => {
     it("does not return error if values are all within acceptable range", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            cpus: 1,
-            mem: 32,
-            disk: 0
-          }
+        id: "id",
+        run: {
+          cpus: 1,
+          mem: 32,
+          disk: 0
         }
       };
       expect(MetronomeSpecValidators.valuesAreWithinRange(spec)).toEqual([]);
@@ -494,10 +464,8 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if cpus is not within range", () => {
       const spec = {
-        job: {
-          run: {
-            cpus: 0
-          }
+        run: {
+          cpus: 0
         }
       };
       expect(
@@ -507,10 +475,8 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if mem is not within range", () => {
       const spec = {
-        job: {
-          run: {
-            mem: 0
-          }
+        run: {
+          mem: 0
         }
       };
       expect(
@@ -520,10 +486,8 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if disk is not within range", () => {
       const spec = {
-        job: {
-          run: {
-            disk: -1
-          }
+        run: {
+          disk: -1
         }
       };
       expect(
@@ -533,12 +497,10 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns all errors if no base required fields are specified", () => {
       const spec = {
-        job: {
-          run: {
-            disk: -1,
-            cpus: 0,
-            mem: 0
-          }
+        run: {
+          disk: -1,
+          cpus: 0,
+          mem: 0
         }
       };
       expect(
@@ -550,11 +512,9 @@ describe("MetronomeSpecValidators", () => {
   describe("#gpusWithinRange", () => {
     it("does not return error if gpus >= 0", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            gpus: 0
-          }
+        id: "id",
+        run: {
+          gpus: 0
         }
       };
       expect(
@@ -564,10 +524,8 @@ describe("MetronomeSpecValidators", () => {
 
     it("does not return error if gpus not present", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {}
-        }
+        id: "id",
+        run: {}
       };
       expect(
         MetronomeSpecValidators.gpusWithinRange(spec as JobOutput)
@@ -576,10 +534,8 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if gpus < 0", () => {
       const spec = {
-        job: {
-          run: {
-            gpus: -1
-          }
+        run: {
+          gpus: -1
         }
       };
       expect(
@@ -591,7 +547,7 @@ describe("MetronomeSpecValidators", () => {
   describe("#parametersHaveStringKeyAndValue", () => {
     it("does not return error if parameters have both key and value", () => {
       const spec = validJobSpec();
-      spec.job.run.docker = {
+      spec.run.docker = {
         image: "",
         parameters: [{ key: "key", value: "value" }]
       };
@@ -600,41 +556,37 @@ describe("MetronomeSpecValidators", () => {
 
     it("does not return error if there are no parameters", () => {
       const spec = validJobSpec();
-      spec.job.run.docker = undefined;
+      spec.run.docker = undefined;
       expect(MetronomeSpecValidators.validate(spec)).toEqual([]);
     });
 
     it("does not return error if parameters are an empty array", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            docker: {
-              parameters: []
-            }
+        id: "id",
+        run: {
+          docker: {
+            parameters: []
           }
         }
       };
 
       expect(MetronomeSpecValidators.validate(spec as any)).not.toContainEqual({
         message: "Must be present",
-        path: ["job", "run", "docker", "parameters", "0", "value"]
+        path: ["run", "docker", "parameters", "0", "value"]
       });
     });
 
     it("returns error if a parameters has an empty key", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            docker: {
-              parameters: [
-                {
-                  key: "",
-                  value: "value"
-                }
-              ]
-            }
+        id: "id",
+        run: {
+          docker: {
+            parameters: [
+              {
+                key: "",
+                value: "value"
+              }
+            ]
           }
         }
       };
@@ -642,23 +594,21 @@ describe("MetronomeSpecValidators", () => {
         MetronomeSpecValidators.validate(spec as JobOutput)
       ).toContainEqual({
         message: "Must be present",
-        path: ["job", "run", "docker", "parameters", "0", "key"]
+        path: ["run", "docker", "parameters", "0", "key"]
       });
     });
 
     it("returns error if a parameters has an empty value", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            docker: {
-              parameters: [
-                {
-                  key: "key",
-                  value: ""
-                }
-              ]
-            }
+        id: "id",
+        run: {
+          docker: {
+            parameters: [
+              {
+                key: "key",
+                value: ""
+              }
+            ]
           }
         }
       };
@@ -667,7 +617,7 @@ describe("MetronomeSpecValidators", () => {
         MetronomeSpecValidators.validate(spec as JobOutput)
       ).toContainEqual({
         message: "Must be present",
-        path: ["job", "run", "docker", "parameters", "0", "value"]
+        path: ["run", "docker", "parameters", "0", "value"]
       });
     });
   });
@@ -675,11 +625,9 @@ describe("MetronomeSpecValidators", () => {
   describe("#noEmptyArgs", () => {
     it("does not return error if no args are empty", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            args: ["arg"]
-          }
+        id: "id",
+        run: {
+          args: ["arg"]
         }
       };
       expect(MetronomeSpecValidators.noEmptyArgs(spec as JobOutput)).toEqual(
@@ -689,10 +637,8 @@ describe("MetronomeSpecValidators", () => {
 
     it("does not return error if there are no args", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {}
-        }
+        id: "id",
+        run: {}
       };
       expect(MetronomeSpecValidators.noEmptyArgs(spec as JobOutput)).toEqual(
         []
@@ -701,11 +647,9 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if an arg is an empty string", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            args: [""]
-          }
+        id: "id",
+        run: {
+          args: [""]
         }
       };
       expect(MetronomeSpecValidators.noEmptyArgs(spec as JobOutput)).toEqual(
@@ -717,12 +661,10 @@ describe("MetronomeSpecValidators", () => {
   describe("#argsUsedOnlyWithDocker", () => {
     it("does not return error if args are used with docker", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            args: [],
-            docker: {}
-          }
+        id: "id",
+        run: {
+          args: [],
+          docker: {}
         }
       };
       expect(
@@ -732,10 +674,8 @@ describe("MetronomeSpecValidators", () => {
 
     it("does not return error if there are no args", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {}
-        }
+        id: "id",
+        run: {}
       };
       expect(
         MetronomeSpecValidators.argsUsedOnlyWithDocker(spec as JobOutput)
@@ -744,11 +684,9 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if args are used without docker", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            args: ["arg"]
-          }
+        id: "id",
+        run: {
+          args: ["arg"]
         }
       };
       expect(
@@ -760,11 +698,9 @@ describe("MetronomeSpecValidators", () => {
   describe("#oneOfUcrOrDocker", () => {
     it("does not return error if neither docker or ucr are present", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            cmd: "cmd"
-          }
+        id: "id",
+        run: {
+          cmd: "cmd"
         }
       };
       expect(
@@ -774,11 +710,9 @@ describe("MetronomeSpecValidators", () => {
 
     it("does not return error if only ucr is present", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            ucr: {}
-          }
+        id: "id",
+        run: {
+          ucr: {}
         }
       };
       expect(
@@ -788,11 +722,9 @@ describe("MetronomeSpecValidators", () => {
 
     it("does not return error if only docker is present", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            docker: {}
-          }
+        id: "id",
+        run: {
+          docker: {}
         }
       };
       expect(
@@ -802,12 +734,10 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if both ucr and docker are present", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            docker: {},
-            ucr: {}
-          }
+        id: "id",
+        run: {
+          docker: {},
+          ucr: {}
         }
       };
       expect(
@@ -819,11 +749,9 @@ describe("MetronomeSpecValidators", () => {
   describe("#noDuplicateParams", () => {
     it("does not return error if there are no params", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            docker: {}
-          }
+        id: "id",
+        run: {
+          docker: {}
         }
       };
       expect(
@@ -833,12 +761,10 @@ describe("MetronomeSpecValidators", () => {
 
     it("does not return error if there is one param", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            docker: {
-              parameters: [{ key: "key", value: "value" }]
-            }
+        id: "id",
+        run: {
+          docker: {
+            parameters: [{ key: "key", value: "value" }]
           }
         }
       };
@@ -849,15 +775,13 @@ describe("MetronomeSpecValidators", () => {
 
     it("does not return error if there are no duplicate params", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            docker: {
-              parameters: [
-                { key: "key", value: "value" },
-                { key: "key2", value: "value" }
-              ]
-            }
+        id: "id",
+        run: {
+          docker: {
+            parameters: [
+              { key: "key", value: "value" },
+              { key: "key2", value: "value" }
+            ]
           }
         }
       };
@@ -868,25 +792,23 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns an error if there are duplicate params", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            docker: {
-              parameters: [
-                { key: "key", value: "value" },
-                { key: "key", value: "value" }
-              ]
-            }
+        id: "id",
+        run: {
+          docker: {
+            parameters: [
+              { key: "key", value: "value" },
+              { key: "key", value: "value" }
+            ]
           }
         }
       };
       const errors = [
         {
-          path: ["job", "run", "docker", "parameters", "0"],
+          path: ["run", "docker", "parameters", "0"],
           message: "No duplicate parameters"
         },
         {
-          path: ["job", "run", "docker", "parameters", "1"],
+          path: ["run", "docker", "parameters", "1"],
           message: "No duplicate parameters"
         }
       ];
@@ -899,10 +821,8 @@ describe("MetronomeSpecValidators", () => {
   describe("#noDuplicateArgs", () => {
     it("does not return error if there are no args", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {}
-        }
+        id: "id",
+        run: {}
       };
       expect(
         MetronomeSpecValidators.noDuplicateArgs(spec as JobOutput)
@@ -911,11 +831,9 @@ describe("MetronomeSpecValidators", () => {
 
     it("does not return error if there is one param", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            args: ["arg"]
-          }
+        id: "id",
+        run: {
+          args: ["arg"]
         }
       };
       expect(
@@ -925,11 +843,9 @@ describe("MetronomeSpecValidators", () => {
 
     it("does not return error if there are no duplicate params", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            args: ["arg1", "arg2"]
-          }
+        id: "id",
+        run: {
+          args: ["arg1", "arg2"]
         }
       };
       expect(
@@ -939,20 +855,18 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns an error if there are duplicate params", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            args: ["arg", "arg"]
-          }
+        id: "id",
+        run: {
+          args: ["arg", "arg"]
         }
       };
       const errors = [
         {
-          path: ["job", "run", "args", "0"],
+          path: ["run", "args", "0"],
           message: "No duplicate args"
         },
         {
-          path: ["job", "run", "args", "1"],
+          path: ["run", "args", "1"],
           message: "No duplicate args"
         }
       ];
@@ -965,41 +879,41 @@ describe("MetronomeSpecValidators", () => {
   describe("#checkTypesOfJobRunProps", () => {
     it("returns error if cmd is not a string", () => {
       const spec = validJobSpec() as any;
-      spec.job.run.cmd = 123;
+      spec.run.cmd = 123;
 
       expect(MetronomeSpecValidators.validate(spec)).toContainEqual({
         message: "Must be a string",
-        path: ["job", "run", "cmd"]
+        path: ["run", "cmd"]
       });
     });
 
     it("returns error if cpus is not a number", () => {
       const spec = validJobSpec() as any;
-      spec.job.run.cpus = "123";
+      spec.run.cpus = "123";
 
       expect(MetronomeSpecValidators.validate(spec)).toContainEqual({
         message: "Must be a number",
-        path: ["job", "run", "cpus"]
+        path: ["run", "cpus"]
       });
     });
 
     it("returns error if disk is not a number", () => {
       const spec = validJobSpec() as any;
-      spec.job.run.disk = "123";
+      spec.run.disk = "123";
 
       expect(MetronomeSpecValidators.validate(spec)).toContainEqual({
         message: "Must be a number",
-        path: ["job", "run", "disk"]
+        path: ["run", "disk"]
       });
     });
 
     it("returns error if mem is not a number", () => {
       const spec = validJobSpec() as any;
-      spec.job.run.mem = "123";
+      spec.run.mem = "123";
 
       expect(MetronomeSpecValidators.validate(spec)).toContainEqual({
         message: "Must be a number",
-        path: ["job", "run", "mem"]
+        path: ["run", "mem"]
       });
     });
   });
@@ -1007,31 +921,31 @@ describe("MetronomeSpecValidators", () => {
   describe("#isString", () => {
     it("returns error if image is not a string", () => {
       const spec = validJobSpec() as any;
-      spec.job.run.docker = { image: 123 };
+      spec.run.docker = { image: 123 };
 
       expect(MetronomeSpecValidators.validate(spec)).toContainEqual({
         message: "Must be a string",
-        path: ["job", "run", "docker", "image"]
+        path: ["run", "docker", "image"]
       });
     });
 
     it("returns error if forcePullImage is not a boolean", () => {
       const spec = validJobSpec() as any;
-      spec.job.run.docker = { forcePullImage: 123 };
+      spec.run.docker = { forcePullImage: 123 };
 
       expect(MetronomeSpecValidators.validate(spec)).toContainEqual({
         message: "Must be a boolean",
-        path: ["job", "run", "docker", "forcePullImage"]
+        path: ["run", "docker", "forcePullImage"]
       });
     });
 
     it("returns error if privileged is not a boolean", () => {
       const spec = validJobSpec() as any;
-      spec.job.run.docker = { privileged: 123 };
+      spec.run.docker = { privileged: 123 };
 
       expect(MetronomeSpecValidators.validate(spec)).toContainEqual({
         message: "Must be a boolean",
-        path: ["job", "run", "docker", "privileged"]
+        path: ["run", "docker", "privileged"]
       });
     });
   });
@@ -1039,16 +953,14 @@ describe("MetronomeSpecValidators", () => {
   describe("#checkTypesOfUcrProps", () => {
     it("does not return error if ucr properties have correc type", () => {
       const spec = {
-        job: {
-          run: {
-            ucr: {
-              image: {
-                id: "image",
-                kind: "docker",
-                forcePull: true
-              },
-              privileged: false
-            }
+        run: {
+          ucr: {
+            image: {
+              id: "image",
+              kind: "docker",
+              forcePull: true
+            },
+            privileged: false
           }
         }
       };
@@ -1059,9 +971,7 @@ describe("MetronomeSpecValidators", () => {
 
     it("does not return error if no ucr", () => {
       const spec = {
-        job: {
-          run: {}
-        }
+        run: {}
       };
       expect(MetronomeSpecValidators.checkTypesOfUcrProps(spec as any)).toEqual(
         []
@@ -1070,42 +980,40 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if image is not an object", () => {
       const spec = validJobSpec() as any;
-      spec.job.run.ucr = { image: 123 };
+      spec.run.ucr = { image: 123 };
 
       expect(MetronomeSpecValidators.validate(spec)).toContainEqual({
         message: "Must be an object",
-        path: ["job", "run", "ucr", "image"]
+        path: ["run", "ucr", "image"]
       });
     });
 
     it("returns error if privileged is not a boolean", () => {
       const spec = validJobSpec() as any;
-      spec.job.run.ucr = { privileged: 123 };
+      spec.run.ucr = { privileged: 123 };
 
       expect(MetronomeSpecValidators.validate(spec)).toContainEqual({
         message: "Must be a boolean",
-        path: ["job", "run", "ucr", "privileged"]
+        path: ["run", "ucr", "privileged"]
       });
     });
 
     it("returns error if id is not a string", () => {
       const spec = validJobSpec() as any;
-      spec.job.run.ucr = { image: { id: 123 } };
+      spec.run.ucr = { image: { id: 123 } };
 
       expect(MetronomeSpecValidators.validate(spec)).toContainEqual({
         message: "Must be a string",
-        path: ["job", "run", "ucr", "image", "id"]
+        path: ["run", "ucr", "image", "id"]
       });
     });
 
     it("returns error if kind is not `docker` or `appc`", () => {
       const spec = {
-        job: {
-          run: {
-            ucr: {
-              image: {
-                kind: 123
-              }
+        run: {
+          ucr: {
+            image: {
+              kind: 123
             }
           }
         }
@@ -1113,7 +1021,7 @@ describe("MetronomeSpecValidators", () => {
       expect(MetronomeSpecValidators.checkTypesOfUcrProps(spec as any)).toEqual(
         [
           {
-            path: ["job", "run", "ucr", "image", "kind"],
+            path: ["run", "ucr", "image", "kind"],
             message: "Image kind must be one of `docker` or `appc`"
           }
         ]
@@ -1122,11 +1030,11 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if forcePull is not a boolean", () => {
       const spec = validJobSpec() as any;
-      spec.job.run.ucr = { image: { forcePull: 123 } };
+      spec.run.ucr = { image: { forcePull: 123 } };
 
       expect(MetronomeSpecValidators.validate(spec)).toContainEqual({
         message: "Must be a boolean",
-        path: ["job", "run", "ucr", "image", "forcePull"]
+        path: ["run", "ucr", "image", "forcePull"]
       });
     });
   });
@@ -1134,11 +1042,9 @@ describe("MetronomeSpecValidators", () => {
   describe("#scheduleHasId", () => {
     it("does not return error if there is no schedule", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            cmd: "cmd"
-          }
+        id: "id",
+        run: {
+          cmd: "cmd"
         }
       };
       expect(MetronomeSpecValidators.scheduleHasId(spec as JobOutput)).toEqual(
@@ -1148,13 +1054,11 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if schedule present without id", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            ucr: {}
-          }
+        id: "id",
+        run: {
+          ucr: {}
         },
-        schedule: {}
+        schedules: [{}]
       };
       expect(MetronomeSpecValidators.scheduleHasId(spec as JobOutput)).toEqual(
         SCHEDULEIDERROR
@@ -1165,11 +1069,9 @@ describe("MetronomeSpecValidators", () => {
   describe("#scheduleIdIsValid", () => {
     it("does not return error if there is no schedule", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            cmd: "cmd"
-          }
+        id: "id",
+        run: {
+          cmd: "cmd"
         }
       };
       expect(
@@ -1179,13 +1081,11 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if schedule id is invalid", () => {
       const spec = {
-        job: {
-          id: "-id",
-          run: {
-            ucr: {}
-          }
+        id: "-id",
+        run: {
+          ucr: {}
         },
-        schedule: {}
+        schedules: [{}]
       };
       expect(
         MetronomeSpecValidators.scheduleIdIsValid(spec as JobOutput)
@@ -1196,11 +1096,9 @@ describe("MetronomeSpecValidators", () => {
   describe("#scheduleHasCron", () => {
     it("does not return error if there is no schedule", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            cmd: "cmd"
-          }
+        id: "id",
+        run: {
+          cmd: "cmd"
         }
       };
       expect(
@@ -1210,13 +1108,11 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if schedule is present without cron", () => {
       const spec = {
-        job: {
-          id: "-id",
-          run: {
-            ucr: {}
-          }
+        id: "-id",
+        run: {
+          ucr: {}
         },
-        schedule: {}
+        schedules: [{}]
       };
       expect(
         MetronomeSpecValidators.scheduleHasCron(spec as JobOutput)
@@ -1227,11 +1123,9 @@ describe("MetronomeSpecValidators", () => {
   describe("#scheduleStartingDeadlineIsValid", () => {
     it("does not return error if there is no schedule", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            cmd: "cmd"
-          }
+        id: "id",
+        run: {
+          cmd: "cmd"
         }
       };
       expect(
@@ -1243,15 +1137,15 @@ describe("MetronomeSpecValidators", () => {
 
     it("does not return error if starting deadline is number > 0", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            cmd: "cmd"
-          }
+        id: "id",
+        run: {
+          cmd: "cmd"
         },
-        schedule: {
-          startingDeadlineSeconds: 1
-        }
+        schedules: [
+          {
+            startingDeadlineSeconds: 1
+          }
+        ]
       };
       expect(
         MetronomeSpecValidators.scheduleStartingDeadlineIsValid(
@@ -1262,15 +1156,15 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if starting deadline is number less than 1", () => {
       const spec = {
-        job: {
-          id: "-id",
-          run: {
-            ucr: {}
-          }
+        id: "-id",
+        run: {
+          ucr: {}
         },
-        schedule: {
-          startingDeadlineSeconds: 0
-        }
+        schedules: [
+          {
+            startingDeadlineSeconds: 0
+          }
+        ]
       };
       expect(
         MetronomeSpecValidators.scheduleStartingDeadlineIsValid(
@@ -1281,15 +1175,15 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if starting deadline is not a number", () => {
       const spec = {
-        job: {
-          id: "-id",
-          run: {
-            ucr: {}
-          }
+        id: "-id",
+        run: {
+          ucr: {}
         },
-        schedule: {
-          startingDeadlineSeconds: "not a number"
-        }
+        schedules: [
+          {
+            startingDeadlineSeconds: "not a number"
+          }
+        ]
       };
       expect(
         MetronomeSpecValidators.scheduleStartingDeadlineIsValid(spec as any)
@@ -1349,7 +1243,7 @@ describe("MetronomeSpecValidators", () => {
       };
       expect(MetronomeSpecValidators.constraintsAreArray(spec as any)).toEqual([
         {
-          path: ["job", "run", "placement", "constraints"],
+          path: ["run", "placement", "constraints"],
           message: "Constraints must be an array"
         }
       ]);
@@ -1414,7 +1308,7 @@ describe("#constraintsAreComplete", () => {
     };
     expect(constraintsAreComplete(spec as any)).toEqual([
       {
-        path: ["job", "run", "placement", "constraints", "0", "value"],
+        path: ["run", "placement", "constraints", "0", "value"],
         message: "Value is required"
       }
     ]);
@@ -1437,7 +1331,7 @@ describe("#constraintsAreComplete", () => {
     };
     expect(constraintsAreComplete(spec as any)).toEqual([
       {
-        path: ["job", "run", "placement", "constraints", "0", "attribute"],
+        path: ["run", "placement", "constraints", "0", "attribute"],
         message: "Field is required"
       }
     ]);
@@ -1460,7 +1354,7 @@ describe("#constraintsAreComplete", () => {
     };
     expect(constraintsAreComplete(spec as any)).toEqual([
       {
-        path: ["job", "run", "placement", "constraints", "0", "operator"],
+        path: ["run", "placement", "constraints", "0", "operator"],
         message: "Operator is required"
       }
     ]);
@@ -1486,9 +1380,9 @@ describe("validateSpec", () => {
       const message = "Cannot have multiple labels with the same key";
 
       expect(validateSpec(spec as any)).toEqual([
-        { path: ["job", "labels"], message },
-        { path: ["job", "labels", "0"], message },
-        { path: ["job", "labels", "1"], message }
+        { path: ["labels"], message },
+        { path: ["labels", "0"], message },
+        { path: ["labels", "1"], message }
       ]);
     });
   });
@@ -1511,8 +1405,8 @@ describe("validateSpec", () => {
         "Cannot have multiple environment variables with the same key";
 
       expect(validateSpec(spec as any)).toEqual([
-        { path: ["job", "run", "env", "0"], message },
-        { path: ["job", "run", "env", "1"], message }
+        { path: ["run", "env", "0"], message },
+        { path: ["run", "env", "1"], message }
       ]);
     });
   });

--- a/plugins/jobs/src/js/components/form/reducers/JobReducers.ts
+++ b/plugins/jobs/src/js/components/form/reducers/JobReducers.ts
@@ -20,8 +20,12 @@ import {
   containerImageReducers
 } from "./ContainerReducers";
 import { placementReducers } from "./PlacementReducers";
-import { enabledReducers, concurrencyPolicyReducers } from "./ScheduleReducers";
 import { volumesReducers } from "./VolumesReducers";
+import {
+  enabledReducers,
+  concurrencyPolicyReducers,
+  schedulesReducers
+} from "./ScheduleReducers";
 
 type DefaultReducerFunction = (
   value: string,
@@ -78,6 +82,7 @@ const combinedReducers: CombinedReducers = {
   concurrencyPolicy: concurrencyPolicyReducers,
   volumes: volumesReducers,
   placementConstraints: placementReducers,
+  schedules: schedulesReducers,
   labels,
   artifacts,
   activeDeadlineSeconds,

--- a/plugins/jobs/src/js/components/form/reducers/JsonReducers.ts
+++ b/plugins/jobs/src/js/components/form/reducers/JsonReducers.ts
@@ -13,68 +13,59 @@ export const jsonReducers = {
     const valueCopy = deepCopy(value);
 
     if (
-      !valueCopy.job ||
-      Object.prototype.toString.call(valueCopy.job) !== "[object Object]"
+      !valueCopy ||
+      Object.prototype.toString.call(valueCopy) !== "[object Object]"
     ) {
       const newState = {
         job: stateCopy.job,
-        schedule: {
-          ...stateCopy.schedule,
-          ...valueCopy.schedule
-        },
         cmdOnly: stateCopy.cmdOnly,
         container: stateCopy.container
       };
-      if (!Object.keys(newState.schedule).length) {
-        newState.schedule = undefined;
-      }
       return newState;
     }
 
     // Can't check `typeof run === "object"` because that will return true for
     // arrays, null...
     if (
-      !valueCopy.job.run ||
-      Object.prototype.toString.call(valueCopy.job.run) !== "[object Object]"
+      !valueCopy.run ||
+      Object.prototype.toString.call(valueCopy.run) !== "[object Object]"
     ) {
       const newState = {
         cmdOnly: stateCopy.cmdOnly,
         container: stateCopy.container,
         job: {
           ...stateCopy.job,
-          ...valueCopy.job,
+          ...valueCopy,
           run: {
             ...stateCopy.job.run
           }
-        },
-        schedule: valueCopy.schedule
+        }
       };
       return newState;
     }
 
-    valueCopy.job.labels = isObject(valueCopy.job.labels)
-      ? Object.entries(valueCopy.job.labels)
-      : valueCopy.job.labels;
+    valueCopy.labels = isObject(valueCopy.labels)
+      ? Object.entries(valueCopy.labels)
+      : valueCopy.labels;
 
-    valueCopy.job.run.env = isObject(valueCopy.job.run.env)
-      ? Object.entries(valueCopy.job.run.env)
-      : valueCopy.job.run.env;
+    valueCopy.run.env = isObject(valueCopy.run.env)
+      ? Object.entries(valueCopy.run.env)
+      : valueCopy.run.env;
 
-    const cmdOnly = !(valueCopy.job.run.docker || valueCopy.job.run.ucr);
+    const cmdOnly = !(valueCopy.run.docker || valueCopy.run.ucr);
 
     // Try to assign `container` based first off of whether the new value from JSON contains a `docker` or
     // `ucr` property. If not, check if the previous state had a `container` specified (remember the last container
     // option the user had chosen). Finally, default to "ucr".
-    const container = valueCopy.job.run.docker
+    const container = valueCopy.run.docker
       ? Container.Docker
-      : valueCopy.job.run.ucr
+      : valueCopy.run.ucr
       ? Container.UCR
       : stateCopy.container || Container.UCR;
 
     const newState = {
       ...stateCopy,
-      job: valueCopy.job,
-      schedule: valueCopy.schedule,
+      job: valueCopy,
       cmdOnly,
       container
     };

--- a/plugins/jobs/src/js/components/form/reducers/ScheduleReducers.ts
+++ b/plugins/jobs/src/js/components/form/reducers/ScheduleReducers.ts
@@ -10,13 +10,16 @@ import { schedulePropertiesCanBeDiscarded } from "../helpers/ScheduleUtil";
 export const enabledReducers = {
   [JobFormActionType.Set]: (_: any, state: JobSpec) => {
     const stateCopy = deepCopy(state);
-    if (!stateCopy.schedule) {
-      stateCopy.schedule = {};
+    if (!stateCopy.job.schedules) {
+      stateCopy.job.schedules = [];
     }
-    const prevValue = Boolean(stateCopy.schedule.enabled);
-    stateCopy.schedule.enabled = !prevValue;
-    if (schedulePropertiesCanBeDiscarded(stateCopy.schedule)) {
-      stateCopy.schedule = undefined;
+    if (!stateCopy.job.schedules.length) {
+      stateCopy.job.schedules.push({});
+    }
+    const prevValue = Boolean(stateCopy.job.schedules[0].enabled);
+    stateCopy.job.schedules[0].enabled = !prevValue;
+    if (schedulePropertiesCanBeDiscarded(stateCopy.job.schedules[0])) {
+      stateCopy.job.schedules = undefined;
     }
     return stateCopy;
   }
@@ -25,17 +28,58 @@ export const enabledReducers = {
 export const concurrencyPolicyReducers = {
   [JobFormActionType.Set]: (_: any, state: JobSpec) => {
     const stateCopy = deepCopy(state);
-    if (!stateCopy.schedule) {
-      stateCopy.schedule = {};
+    if (!stateCopy.job.schedules) {
+      stateCopy.job.schedules = [];
     }
-    const prevValue = stateCopy.schedule.concurrencyPolicy;
-    stateCopy.schedule.concurrencyPolicy =
+    if (!stateCopy.job.schedules.length) {
+      stateCopy.job.schedules.push({});
+    }
+    const prevValue = stateCopy.job.schedules[0].concurrencyPolicy;
+    stateCopy.job.schedules[0].concurrencyPolicy =
       !prevValue || prevValue === ConcurrentPolicy.Forbid
-        ? (stateCopy.schedule.concurrencyPolicy = ConcurrentPolicy.Allow)
-        : (stateCopy.schedule.concurrencyPolicy = ConcurrentPolicy.Forbid);
-    if (schedulePropertiesCanBeDiscarded(stateCopy.schedule)) {
-      stateCopy.schedule = undefined;
+        ? (stateCopy.job.schedules[0].concurrencyPolicy =
+            ConcurrentPolicy.Allow)
+        : (stateCopy.job.schedules[0].concurrencyPolicy =
+            ConcurrentPolicy.Forbid);
+    if (schedulePropertiesCanBeDiscarded(stateCopy.job.schedules[0])) {
+      stateCopy.job.schedules = undefined;
     }
     return stateCopy;
+  }
+};
+
+function updateScheduleAt(state: JobSpec, path: string[], value: any) {
+  const stateCopy = deepCopy(state);
+  const assignProp = path[0];
+  if (!assignProp) {
+    throw Error(`can not set a prop without a path`);
+  }
+  if (!stateCopy.job.schedules) {
+    stateCopy.job.schedules = [];
+  }
+
+  if (Array.isArray(stateCopy.job.schedules)) {
+    if (!stateCopy.job.schedules.length) {
+      stateCopy.job.schedules.push({});
+    }
+    stateCopy.job.schedules[0][assignProp] = value;
+  }
+
+  return stateCopy;
+}
+
+export const schedulesReducers = {
+  [JobFormActionType.Set]: (value: string, state: JobSpec, path: string[]) => {
+    return updateScheduleAt(state, path, value);
+  },
+
+  [JobFormActionType.SetNum]: (
+    value: string,
+    state: JobSpec,
+    path: string[]
+  ) => {
+    const numValue = parseFloat(value);
+    const newValue = !isNaN(numValue) ? numValue : "";
+    return updateScheduleAt(state, path, newValue);
   }
 };

--- a/plugins/jobs/src/js/components/form/reducers/__tests__/JobReducers-test.ts
+++ b/plugins/jobs/src/js/components/form/reducers/__tests__/JobReducers-test.ts
@@ -50,16 +50,14 @@ describe("JobReducers", () => {
     describe("Override action", () => {
       it("overrides current state with JSON value while maintaining container options", () => {
         const jsonValue = {
-          job: {
-            id: "newId",
-            description: "desc",
-            run: {
-              cmd: "foo",
-              cpus: 1,
-              disk: 0,
-              mem: 32,
-              gpus: 0
-            }
+          id: "newId",
+          description: "desc",
+          run: {
+            cmd: "foo",
+            cpus: 1,
+            disk: 0,
+            mem: 32,
+            gpus: 0
           }
         };
         const expected = {
@@ -90,18 +88,16 @@ describe("JobReducers", () => {
 
       it("adds container image value to both container objects in job spec if present", () => {
         const jsonValue = {
-          job: {
-            id: "newId",
-            description: "desc",
-            run: {
-              cmd: "foo",
-              cpus: 1,
-              disk: 0,
-              mem: 32,
-              gpus: 0,
-              docker: {
-                image: "bar"
-              }
+          id: "newId",
+          description: "desc",
+          run: {
+            cmd: "foo",
+            cpus: 1,
+            disk: 0,
+            mem: 32,
+            gpus: 0,
+            docker: {
+              image: "bar"
             }
           }
         };

--- a/plugins/jobs/src/js/data/JobModel.ts
+++ b/plugins/jobs/src/js/data/JobModel.ts
@@ -36,7 +36,7 @@ import {
   JobSchema
 } from "#PLUGINS/jobs/src/js/types/Job";
 import { JobLink, JobLinkSchema } from "#PLUGINS/jobs/src/js/types/JobLink";
-import { JobOutput } from "../components/form/helpers/JobFormData";
+import { JobAPIOutput } from "../components/form/helpers/JobFormData";
 import { JobSchedule } from "../types/JobSchedule";
 
 export interface Query {
@@ -52,11 +52,11 @@ export interface ResolverArgs {
   pollingInterval: number;
   runJob: (id: string) => Observable<RequestResponse<JobLink>>;
   createJob: (
-    data: JobOutput
+    data: JobAPIOutput
   ) => Observable<RequestResponse<MetronomeJobDetailResponse>>;
   updateJob: (
     id: string,
-    data: JobOutput,
+    data: JobAPIOutput,
     existingSchedule?: boolean
   ) => Observable<RequestResponse<MetronomeJobDetailResponse>>;
   updateSchedule: (

--- a/src/js/events/MetronomeClient.ts
+++ b/src/js/events/MetronomeClient.ts
@@ -5,7 +5,7 @@ import { Observable, throwError } from "rxjs";
 import Config from "../config/Config";
 import {
   JobSchedule,
-  JobOutput
+  JobAPIOutput
 } from "plugins/jobs/src/js/components/form/helpers/JobFormData";
 import { switchMap, catchError } from "rxjs/operators";
 // Add interface information: https://jira.mesosphere.com/browse/DCOS-37725
@@ -160,7 +160,7 @@ const defaultHeaders = {
 };
 
 export function createJob(
-  data: JobOutput
+  data: JobAPIOutput
 ): Observable<RequestResponse<JobDetailResponse>> {
   const jobRequest = request(`${Config.metronomeAPI}/v1/jobs`, {
     method: "POST",
@@ -208,7 +208,7 @@ export function deleteJob(
 
 export function updateJob(
   jobID: string,
-  data: JobOutput,
+  data: JobAPIOutput,
   existingSchedule: boolean = true
 ): Observable<RequestResponse<JobDetailResponse>> {
   const updateJobRequest = request(`${Config.metronomeAPI}/v1/jobs/${jobID}`, {

--- a/tests/pages/jobs/JobJSONEditor-cy.js
+++ b/tests/pages/jobs/JobJSONEditor-cy.js
@@ -9,7 +9,7 @@ describe("Job JSON Editor", function() {
   });
 
   it("renders proper JSON for a simple job", function() {
-    const jobName = "job-with-inline-shell-script";
+    const jobName = "simple";
     const fullJobName = `${Cypress.env("TEST_UUID")}.${jobName}`;
     const cmdline = "while true; do echo 'test' ; sleep 100 ; done";
 
@@ -55,22 +55,20 @@ describe("Job JSON Editor", function() {
       .asJson()
       .should("deep.equal", [
         {
-          job: {
-            id: fullJobName,
-            description: "",
-            run: {
-              cpus: 1,
-              mem: 32,
-              disk: 0,
-              cmd: cmdline
-            }
+          id: fullJobName,
+          description: "",
+          run: {
+            cpus: 1,
+            mem: 32,
+            disk: 0,
+            cmd: cmdline
           }
         }
       ]);
   });
 
   it("renders proper JSON for a job with default container image", function() {
-    const jobName = "job-with-docker-config";
+    const jobName = "default";
     const fullJobName = `${Cypress.env("TEST_UUID")}.${jobName}`;
     const cmdline = "while true; do echo 'test' ; sleep 100 ; done";
 
@@ -123,20 +121,18 @@ describe("Job JSON Editor", function() {
       .asJson()
       .should("deep.equal", [
         {
-          job: {
-            id: fullJobName,
-            description: "",
-            run: {
-              cpus: 1,
-              mem: 32,
-              disk: 0,
-              gpus: 1,
-              cmd: cmdline,
-              ucr: {
-                image: {
-                  id: "nginx",
-                  kind: "docker"
-                }
+          id: fullJobName,
+          description: "",
+          run: {
+            cpus: 1,
+            mem: 32,
+            disk: 0,
+            gpus: 1,
+            cmd: cmdline,
+            ucr: {
+              image: {
+                id: "nginx",
+                kind: "docker"
               }
             }
           }
@@ -180,7 +176,7 @@ describe("Job JSON Editor", function() {
   });
 
   it("renders proper JSON for a job using UCR with advanced options", () => {
-    const jobName = "job-with-ucr-config";
+    const jobName = "ucr";
     const fullJobName = `${Cypress.env("TEST_UUID")}.${jobName}`;
     const cmdline = "while true; do echo 'test' ; sleep 100 ; done";
 
@@ -269,29 +265,27 @@ describe("Job JSON Editor", function() {
       .asJson()
       .should("deep.equal", [
         {
-          job: {
-            id: fullJobName,
-            description: "",
-            run: {
-              cpus: 1,
-              mem: 32,
-              disk: 0,
-              gpus: 1,
-              cmd: cmdline,
-              ucr: {
-                image: {
-                  id: "nginx",
-                  kind: "docker",
-                  forcePull: true
-                }
-              },
-              maxLaunchDelay: 1,
-              taskKillGracePeriodSeconds: 2,
-              user: "user1",
-              restart: {
-                policy: "ON_FAILURE",
-                activeDeadlineSeconds: 3
+          id: fullJobName,
+          description: "",
+          run: {
+            cpus: 1,
+            mem: 32,
+            disk: 0,
+            gpus: 1,
+            cmd: cmdline,
+            ucr: {
+              image: {
+                id: "nginx",
+                kind: "docker",
+                forcePull: true
               }
+            },
+            maxLaunchDelay: 1,
+            taskKillGracePeriodSeconds: 2,
+            user: "user1",
+            restart: {
+              policy: "ON_FAILURE",
+              activeDeadlineSeconds: 3
             }
           }
         }
@@ -299,7 +293,7 @@ describe("Job JSON Editor", function() {
   });
 
   it("renders proper JSON for a job using Docker with advanced options", () => {
-    const jobName = "job-with-docker-config";
+    const jobName = "docker";
     const fullJobName = `${Cypress.env("TEST_UUID")}.${jobName}`;
     const cmdline = "while true; do echo 'test' ; sleep 100 ; done";
 
@@ -361,19 +355,17 @@ describe("Job JSON Editor", function() {
       .asJson()
       .should("deep.equal", [
         {
-          job: {
-            id: fullJobName,
-            description: "",
-            run: {
-              cpus: 1,
-              mem: 32,
-              disk: 0,
-              cmd: cmdline,
-              docker: {
-                image: "nginx",
-                forcePullImage: true,
-                privileged: true
-              }
+          id: fullJobName,
+          description: "",
+          run: {
+            cpus: 1,
+            mem: 32,
+            disk: 0,
+            cmd: cmdline,
+            docker: {
+              image: "nginx",
+              forcePullImage: true,
+              privileged: true
             }
           }
         }
@@ -381,7 +373,7 @@ describe("Job JSON Editor", function() {
   });
 
   it("renders proper JSON for a job using Docker with parameters", () => {
-    const jobName = "job-with-docker-config";
+    const jobName = "params";
     const fullJobName = `${Cypress.env("TEST_UUID")}.${jobName}`;
     const cmdline = "while true; do echo 'test' ; sleep 100 ; done";
     const dockerParam = {
@@ -460,20 +452,18 @@ describe("Job JSON Editor", function() {
       .asJson()
       .should("deep.equal", [
         {
-          job: {
-            id: fullJobName,
-            description: "",
-            run: {
-              cpus: 1,
-              mem: 32,
-              disk: 0,
-              cmd: cmdline,
-              docker: {
-                image: "nginx",
-                forcePullImage: true,
-                privileged: true,
-                parameters: [dockerParam]
-              }
+          id: fullJobName,
+          description: "",
+          run: {
+            cpus: 1,
+            mem: 32,
+            disk: 0,
+            cmd: cmdline,
+            docker: {
+              image: "nginx",
+              forcePullImage: true,
+              privileged: true,
+              parameters: [dockerParam]
             }
           }
         }
@@ -481,7 +471,7 @@ describe("Job JSON Editor", function() {
   });
 
   it("renders proper JSON for a job using Docker with args", () => {
-    const jobName = "job-with-docker-config";
+    const jobName = "args";
     const fullJobName = `${Cypress.env("TEST_UUID")}.${jobName}`;
     const cmdline = "while true; do echo 'test' ; sleep 100 ; done";
     const arg = "arg";
@@ -553,20 +543,18 @@ describe("Job JSON Editor", function() {
       .asJson()
       .should("deep.equal", [
         {
-          job: {
-            id: fullJobName,
-            description: "",
-            run: {
-              args: [arg],
-              cpus: 1,
-              mem: 32,
-              disk: 0,
-              cmd: cmdline,
-              docker: {
-                image: "nginx",
-                forcePullImage: true,
-                privileged: true
-              }
+          id: fullJobName,
+          description: "",
+          run: {
+            args: [arg],
+            cpus: 1,
+            mem: 32,
+            disk: 0,
+            cmd: cmdline,
+            docker: {
+              image: "nginx",
+              forcePullImage: true,
+              privileged: true
             }
           }
         }
@@ -574,7 +562,7 @@ describe("Job JSON Editor", function() {
   });
 
   it("renders proper JSON for a job with a schedule", () => {
-    const jobName = "job-with-schedule";
+    const jobName = "schedule";
     const fullJobName = `${Cypress.env("TEST_UUID")}.${jobName}`;
     const cmdline = "while true; do echo 'test' ; sleep 100 ; done";
     const scheduleId = "schedule-id";
@@ -647,30 +635,30 @@ describe("Job JSON Editor", function() {
       .asJson()
       .should("deep.equal", [
         {
-          job: {
-            id: fullJobName,
-            description: "",
-            run: {
-              cpus: 1,
-              mem: 32,
-              disk: 0,
-              cmd: cmdline
-            }
+          id: fullJobName,
+          description: "",
+          run: {
+            cpus: 1,
+            mem: 32,
+            disk: 0,
+            cmd: cmdline
           },
-          schedule: {
-            enabled: true,
-            startingDeadlineSeconds: startingDeadline,
-            id: scheduleId,
-            timezone,
-            cron,
-            concurrencyPolicy: "ALLOW"
-          }
+          schedules: [
+            {
+              enabled: true,
+              startingDeadlineSeconds: startingDeadline,
+              id: scheduleId,
+              timezone,
+              cron,
+              concurrencyPolicy: "ALLOW"
+            }
+          ]
         }
       ]);
   });
 
   it("renders proper JSON for a job using environment variables", () => {
-    const jobName = "job-with-env-vars";
+    const jobName = "env";
     const fullJobName = `${Cypress.env("TEST_UUID")}.${jobName}`;
     const cmdline = "while true; do echo 'test' ; sleep 100 ; done";
     const envVar = {
@@ -728,17 +716,15 @@ describe("Job JSON Editor", function() {
       .asJson()
       .should("deep.equal", [
         {
-          job: {
-            id: fullJobName,
-            description: "",
-            run: {
-              cpus: 1,
-              mem: 32,
-              disk: 0,
-              cmd: cmdline,
-              env: {
-                [envVar.key]: envVar.value
-              }
+          id: fullJobName,
+          description: "",
+          run: {
+            cpus: 1,
+            mem: 32,
+            disk: 0,
+            cmd: cmdline,
+            env: {
+              [envVar.key]: envVar.value
             }
           }
         }
@@ -746,7 +732,7 @@ describe("Job JSON Editor", function() {
   });
 
   it("renders proper JSON for a job with volumes", () => {
-    const jobName = "job-with-volume";
+    const jobName = "volume";
     const fullJobName = `${Cypress.env("TEST_UUID")}.${jobName}`;
     const cmdline = "while true; do echo 'test' ; sleep 100 ; done";
     const volume = {
@@ -809,23 +795,21 @@ describe("Job JSON Editor", function() {
       .asJson()
       .should("deep.equal", [
         {
-          job: {
-            id: fullJobName,
-            description: "",
-            run: {
-              cpus: 1,
-              mem: 32,
-              disk: 0,
-              cmd: cmdline,
-              volumes: [volume]
-            }
+          id: fullJobName,
+          description: "",
+          run: {
+            cpus: 1,
+            mem: 32,
+            disk: 0,
+            cmd: cmdline,
+            volumes: [volume]
           }
         }
       ]);
   });
 
   it("renders proper JSON for a job with a constraint", () => {
-    const jobName = "job-with-constraint";
+    const jobName = "constraint";
     const fullJobName = `${Cypress.env("TEST_UUID")}.${jobName}`;
     const cmdline = "while true; do echo 'test' ; sleep 100 ; done";
     const constraint = {
@@ -889,17 +873,15 @@ describe("Job JSON Editor", function() {
       .asJson()
       .should("deep.equal", [
         {
-          job: {
-            id: fullJobName,
-            description: "",
-            run: {
-              cpus: 1,
-              mem: 32,
-              disk: 0,
-              cmd: cmdline,
-              placement: {
-                constraints: [constraint]
-              }
+          id: fullJobName,
+          description: "",
+          run: {
+            cpus: 1,
+            mem: 32,
+            disk: 0,
+            cmd: cmdline,
+            placement: {
+              constraints: [constraint]
             }
           }
         }


### PR DESCRIPTION
Make the JSON editor contents of the job form appear to be in metronome V0 spec format. Send payload to the API in V1 format.

**Note**: Please read/consider tradeoffs

Closes DCOS-52843

## Testing

Try interacting with the jobs form and all of its sections. Try adding jobs, editing jobs, etc. Try editing using form only, JSON editor only, a combination of both.

This is a fairly major change so the potential for bugs is high.

## Trade-offs

I'm hesitant about these changes so here are some points to consider:
- This is not a typical "bug fix." This changes the behaviour of the jobs form in a non-trivial way
- These changes are designed to allow users to continue using V0 formatted jobs despite the fact that we've moved on to V1 format behind the scenes. This could raise the questions: what benefit are we getting from using V1 format now? Are we potentially building in technical debt in exchange for backwards compatibility? 
- Server errors are returned with paths corresponding to v1 spec

## Dependencies

mesosphere/dcos-ui-plugins-private#996

## Screenshots

Note changes to the JSON structure in the editor.

Before:
<img width="1209" alt="Screen Shot 2019-05-06 at 5 07 19 PM" src="https://user-images.githubusercontent.com/19582796/57262543-732be900-7021-11e9-917d-9d3f1d011ad2.png">

After:
<img width="1210" alt="Screen Shot 2019-05-06 at 4 59 52 PM" src="https://user-images.githubusercontent.com/19582796/57262328-74104b00-7020-11e9-9b91-15d1a426c22d.png">
