### PR TITLE
Proposal: chore: remove vscode settings file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ src/resources/raml
 locale/_build/
 locale/*/messages.js
 plugins-ee
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-  "search.exclude": {
-    "**/_build": true,
-    "cypress": true
-  },
-  "search.useIgnoreFiles": false
-}

--- a/README.md
+++ b/README.md
@@ -121,3 +121,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 Authors are listed in [Authors.md file](./Authors.md).
+
+If you are using VS code and used `npm run util:lingui:extract-with-plugins` and want typescript validation errors please include the following settings into your `.vscode/settings.json`
+
+```JSON
+{
+  "search.exclude": {
+    "**/_build": true,
+    "cypress": true
+  },
+  "search.useIgnoreFiles": false,
+  "git.ignoreLimitWarning": true,
+  "[less]": {
+    "editor.formatOnSave": false
+  }
+}
+```


### PR DESCRIPTION
I personally have some specific vs code settings to my dcos-ui workspace. Since we introduced the  `settings.json` to dcos-ui I have to run `git stash` and `git stash pop` regularly. Which means this change has really influenced how I work. Therefore I propose to remove the file again and put a note into the README with the appropriate settings. Then everybody can add these settings if they would like to, and therefore keep their existing settings as well. 

## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
