### PR TITLE
[1.12] COPS-4710 affecting : Package-specific icons not showing for some services installed from Universe

### DIFF
--- a/plugins/services/src/js/stores/MarathonStore.js
+++ b/plugins/services/src/js/stores/MarathonStore.js
@@ -84,6 +84,7 @@ import {
   VISIBILITY_CHANGE
 } from "../constants/EventTypes";
 import Framework from "../structs/Framework";
+import Application from "../structs/Application";
 import ServiceImages from "../constants/ServiceImages";
 import ServiceTree from "../structs/ServiceTree";
 
@@ -471,7 +472,12 @@ class MarathonStore extends GetSetBaseStore {
     data.items.forEach(item => {
       if (item.items && Array.isArray(item.items)) {
         this.injectGroupsWithPackageImages(item);
-      } else if (ServiceValidatorUtil.isFrameworkResponse(item)) {
+      } else if (
+        (ServiceValidatorUtil.isFrameworkResponse(item) ||
+          ServiceValidatorUtil.isApplicationResponse(item)) &&
+        item.labels &&
+        item.labels.DCOS_PACKAGE_NAME
+      ) {
         item["images"] = CosmosPackagesStore.getPackageImages()[
           item.labels.DCOS_PACKAGE_NAME
         ];
@@ -490,6 +496,14 @@ class MarathonStore extends GetSetBaseStore {
     const apps = groups.reduceItems(function(map, item) {
       if (item instanceof Framework) {
         map[item.getFrameworkName().toLowerCase()] = {
+          health: item.getHealth(),
+          images: item.getImages(),
+          snapshot: item.get()
+        };
+      }
+
+      if (item instanceof Application) {
+        map[item.getName().toLowerCase()] = {
           health: item.getHealth(),
           images: item.getImages(),
           snapshot: item.get()

--- a/plugins/services/src/js/structs/Application.js
+++ b/plugins/services/src/js/structs/Application.js
@@ -66,7 +66,9 @@ module.exports = class Application extends Service {
    * @override
    */
   getImages() {
-    return FrameworkUtil.getServiceImages(this.getMetadata().images);
+    const images = this.getMetadata().images || this.get("images");
+
+    return FrameworkUtil.getServiceImages(images);
   }
 
   /**

--- a/plugins/services/src/js/structs/__tests__/Application-test.js
+++ b/plugins/services/src/js/structs/__tests__/Application-test.js
@@ -111,11 +111,27 @@ describe("Application", function() {
       expect(service.getImages()).toEqual(ServiceImages.NA_IMAGES);
     });
 
-    it("returns correct images", function() {
+    it("returns correct images from metadata", function() {
       const service = new Application({
         labels: {
           DCOS_PACKAGE_METADATA:
             "eyJpbWFnZXMiOiB7ICJpY29uLXNtYWxsIjogImZvby1zbWFsbC5wbmciLCAiaWNvbi1tZWRpdW0iOiAiZm9vLW1lZGl1bS5wbmciLCAiaWNvbi1sYXJnZSI6ICJmb28tbGFyZ2UucG5nIn19"
+        }
+      });
+
+      expect(service.getImages()).toEqual({
+        "icon-small": "foo-small.png",
+        "icon-medium": "foo-medium.png",
+        "icon-large": "foo-large.png"
+      });
+    });
+
+    it("returns correct images from service", function() {
+      const service = new Application({
+        images: {
+          "icon-small": "foo-small.png",
+          "icon-medium": "foo-medium.png",
+          "icon-large": "foo-large.png"
         }
       });
 


### PR DESCRIPTION
1.12 backport of https://github.com/dcos/dcos-ui/pull/3820 .
When testing, don't forget to use `release/1.12` in the private plugins.