### PR TITLE
[1.13] COPS-4710 affecting : Package-specific icons not showing for some services installed from Universe

### DIFF
--- a/plugins/services/src/js/stores/MarathonStore.js
+++ b/plugins/services/src/js/stores/MarathonStore.js
@@ -83,6 +83,7 @@ import {
   VISIBILITY_CHANGE
 } from "../constants/EventTypes";
 import Framework from "../structs/Framework";
+import Application from "../structs/Application";
 import ServiceImages from "../constants/ServiceImages";
 import ServiceTree from "../structs/ServiceTree";
 
@@ -470,7 +471,12 @@ class MarathonStore extends GetSetBaseStore {
     data.items.forEach(item => {
       if (item.items && Array.isArray(item.items)) {
         this.injectGroupsWithPackageImages(item);
-      } else if (ServiceValidatorUtil.isFrameworkResponse(item)) {
+      } else if (
+        (ServiceValidatorUtil.isFrameworkResponse(item) ||
+          ServiceValidatorUtil.isApplicationResponse(item)) &&
+        item.labels &&
+        item.labels.DCOS_PACKAGE_NAME
+      ) {
         item["images"] = CosmosPackagesStore.getPackageImages()[
           item.labels.DCOS_PACKAGE_NAME
         ];
@@ -489,6 +495,14 @@ class MarathonStore extends GetSetBaseStore {
     const apps = groups.reduceItems(function(map, item) {
       if (item instanceof Framework) {
         map[item.getFrameworkName().toLowerCase()] = {
+          health: item.getHealth(),
+          images: item.getImages(),
+          snapshot: item.get()
+        };
+      }
+
+      if (item instanceof Application) {
+        map[item.getName().toLowerCase()] = {
           health: item.getHealth(),
           images: item.getImages(),
           snapshot: item.get()

--- a/plugins/services/src/js/structs/Application.js
+++ b/plugins/services/src/js/structs/Application.js
@@ -65,7 +65,9 @@ module.exports = class Application extends Service {
    * @override
    */
   getImages() {
-    return FrameworkUtil.getServiceImages(this.getMetadata().images);
+    const images = this.getMetadata().images || this.get("images");
+
+    return FrameworkUtil.getServiceImages(images);
   }
 
   /**

--- a/plugins/services/src/js/structs/__tests__/Application-test.js
+++ b/plugins/services/src/js/structs/__tests__/Application-test.js
@@ -112,11 +112,27 @@ describe("Application", function() {
       expect(service.getImages()).toEqual(ServiceImages.NA_IMAGES);
     });
 
-    it("returns correct images", function() {
+    it("returns correct images from metadata", function() {
       const service = new Application({
         labels: {
           DCOS_PACKAGE_METADATA:
             "eyJpbWFnZXMiOiB7ICJpY29uLXNtYWxsIjogImZvby1zbWFsbC5wbmciLCAiaWNvbi1tZWRpdW0iOiAiZm9vLW1lZGl1bS5wbmciLCAiaWNvbi1sYXJnZSI6ICJmb28tbGFyZ2UucG5nIn19"
+        }
+      });
+
+      expect(service.getImages()).toEqual({
+        "icon-small": "foo-small.png",
+        "icon-medium": "foo-medium.png",
+        "icon-large": "foo-large.png"
+      });
+    });
+
+    it("returns correct images from service", function() {
+      const service = new Application({
+        images: {
+          "icon-small": "foo-small.png",
+          "icon-medium": "foo-medium.png",
+          "icon-large": "foo-large.png"
         }
       });
 


### PR DESCRIPTION
1.13 backport of https://jira.mesosphere.com/browse/DCOS-51269 .
When testing, don't forget to use `release/1.13` in the private plugins.