### PR TITLE
[spike] DCOS_OSS-1577  Wrap task logs and remove horizontal scrollbars

### DIFF
--- a/src/styles/components/code/styles.less
+++ b/src/styles/components/code/styles.less
@@ -7,6 +7,8 @@
       border-radius: @code-border-radius;
       border-style: @code-block-prettyprint-border-style;
       flex-basis: @code-block-prettyprint-flex-basis;
+      white-space: pre-wrap;
+      word-wrap: break-word;
 
       &.inverse {
         border-color: @code-block-prettyprint-border-color-inverse;

--- a/tests/pages/nodes/node/tasks/NodesTaskDetailPage-cy.js
+++ b/tests/pages/nodes/node/tasks/NodesTaskDetailPage-cy.js
@@ -7,17 +7,36 @@ describe("Nodes Task Detail Page", function() {
   });
 
   context("Navigate to node task detail page", function() {
-    it("navigates to node task detail page", function() {
-      cy.visitUrl({ url: "/nodes", identify: true });
-      cy.get("a.table-cell-link-primary")
-        .eq(0)
-        .click({ force: true });
-      cy.get("a.table-cell-link-secondary")
-        .eq(0)
-        .click();
-      cy.hash().should("match", /nodes\/[a-zA-Z0-9-]+\/tasks\/[a-zA-Z0-9-]+/);
+    context("Navigate to the tabs", function() {
+      beforeEach(function() {
+        cy.visitUrl({ url: "/nodes", identify: true, fakeAnalytics: true });
+        cy.get("a.table-cell-link-primary")
+          .eq(0)
+          .click({ force: true });
+        cy.get("a.table-cell-link-secondary")
+          .eq(0)
+          .click();
+        cy.hash().should("match", /nodes\/[a-zA-Z0-9-]+\/tasks\/[a-zA-Z0-9-]+/);
+      });
 
-      cy.get("h1.configuration-map-heading").contains("Configuration");
+      it("navigates to node task detail page", function() {
+        cy.get("h1.configuration-map-heading").contains("Configuration");
+      });
+
+      it("navigates to node task files page", function() {
+        cy.get(".menu-tabbed-item-label")
+          .contains("Files")
+          .click();
+        cy.get(".control-group").contains("Working Directory");
+        cy.get("table.table").should("exist");
+      });
+
+      it("navigates to node task logs page", function() {
+        cy.get(".menu-tabbed-item-label")
+          .contains("Logs")
+          .click();
+        cy.get("pre.prettyprint").should("exist");
+      });
     });
 
     it("loads page with data after hard reload", function() {


### PR DESCRIPTION
Wrap the text in logs to hide the vertical scrollbar
and enable users to find information more efficiently.

Closes https://jira.mesosphere.com/browse/DCOS_OSS-1577

## Testing
1. Start a service or catalog package.
2. Open it.
3. Click on an instance.
4. Open the logs tab.
5. Verify that the text is wrapped and the logs don't have a vertical scrollbar.
6. Go to Nodes, click on a node, open an instance and verify the same.
7. Verify that the added tests make sense.

## Trade-offs
Added some tests, but I couldn't find a way to test this change directly. My ideas of checking the content and checking that the field is not scrollable didn't work.

## Dependencies
None.

## Screenshots
### Before
![Screenshot from 2019-05-10 13-38-00](https://user-images.githubusercontent.com/40791275/57521407-dfac2e00-7328-11e9-9a15-d7b589c8adc7.png)
![Screenshot from 2019-05-10 13-38-09](https://user-images.githubusercontent.com/40791275/57521411-e175f180-7328-11e9-9daf-dcffe4cf3988.png)

### After
![Screenshot from 2019-05-10 12-35-03](https://user-images.githubusercontent.com/40791275/57521249-66acd680-7328-11e9-819f-fb19922c6c81.png)
![Screenshot from 2019-05-10 12-35-15](https://user-images.githubusercontent.com/40791275/57521252-690f3080-7328-11e9-8707-5eec6e88da39.png)
