### PR TITLE
[spike] DCOS-53725  Disable tracking in the Config

### DIFF
--- a/src/js/config/Config.template.ts
+++ b/src/js/config/Config.template.ts
@@ -26,7 +26,7 @@ export default {
           enabled: true
         },
         tracking: {
-          enabled: true
+          enabled: false
         }
       }
     },


### PR DESCRIPTION
Disable tracking so that we don't send
localhost errors to Sentry from our development.

Closes https://jira.mesosphere.com/browse/DCOS-53725

## Testing
No testing needed.

## Trade-offs
None.

## Dependencies
None.

## Screenshots
None.
