### PR TITLE
[spike] DCOS-7157: Filter tasks by Failed/Killed status

### DIFF
--- a/plugins/services/src/js/components/dsl/TaskStatusDSLSection.js
+++ b/plugins/services/src/js/components/dsl/TaskStatusDSLSection.js
@@ -13,7 +13,9 @@ import FormGroup from "#SRC/js/components/form/FormGroup";
 
 const EXPRESSION_PARTS = {
   is_active: DSLExpressionPart.attribute("is", "active"),
-  is_completed: DSLExpressionPart.attribute("is", "completed")
+  is_completed: DSLExpressionPart.attribute("is", "completed"),
+  is_failed: DSLExpressionPart.attribute("is", "failed"),
+  is_killed: DSLExpressionPart.attribute("is", "killed")
 };
 
 class TasksStatusDSLSection extends React.Component {
@@ -52,6 +54,24 @@ class TasksStatusDSLSection extends React.Component {
                   type="checkbox"
                 />
                 <Trans render="span">Completed</Trans>
+              </FieldLabel>
+              <FieldLabel>
+                <FieldInput
+                  checked={data.is_failed}
+                  disabled={!enabled}
+                  name="is_failed"
+                  type="checkbox"
+                />
+                <Trans render="span">Failed</Trans>
+              </FieldLabel>
+              <FieldLabel>
+                <FieldInput
+                  checked={data.is_killed}
+                  disabled={!enabled}
+                  name="is_killed"
+                  type="checkbox"
+                />
+                <Trans render="span">Killed</Trans>
               </FieldLabel>
             </FormGroup>
           </div>

--- a/plugins/services/src/js/constants/TaskStates.js
+++ b/plugins/services/src/js/constants/TaskStates.js
@@ -27,7 +27,7 @@ const TaskStates = {
   },
 
   TASK_KILLING: {
-    stateTypes: ["active", "failure"],
+    stateTypes: ["active", "killed"],
     displayName: i18nMark("Killing")
   },
 
@@ -37,7 +37,7 @@ const TaskStates = {
   },
 
   TASK_KILLED: {
-    stateTypes: ["completed", "failure"],
+    stateTypes: ["completed", "killed"],
     displayName: i18nMark("Killed")
   },
 

--- a/plugins/services/src/js/filters/TasksStatusFilter.js
+++ b/plugins/services/src/js/filters/TasksStatusFilter.js
@@ -6,7 +6,9 @@ const LABEL = "is";
 
 const LABEL_TO_STATUS = {
   active: "active",
-  completed: "completed"
+  completed: "completed",
+  failed: "failure",
+  killed: "killed"
 };
 
 /**

--- a/tests/pages/services/TasksTable-cy.js
+++ b/tests/pages/services/TasksTable-cy.js
@@ -232,6 +232,14 @@ describe("Tasks Table", function() {
       cy.get("table tr td.task-table-column-name").should("to.have.length", 4);
     });
 
+    it("Filters tasks that are in failed state", function() {
+      cy.get(".form-control.filter-input-text")
+        .type("{selectall}{backspace}")
+        .type("{selectall}{backspace}");
+      cy.get(".form-control.filter-input-text").type("is:failed");
+      cy.get("table tr td.task-table-column-name").should("to.have.length", 0);
+    });
+
     it("Filters tasks by region", function() {
       cy.get(".form-control.filter-input-text")
         .type("{selectall}{backspace}")


### PR DESCRIPTION
Add the option to filter tasks that have the status
failed or killed. This allows for easier debugging.

Closes https://jira.mesosphere.com/browse/DCOS-7157

## Testing
1. Start a service with failed and killed tasks.
To have failed tasks, the command of the service could be something like `sleep 10 && exit 1`.
2. Open that service.
3. Click the button that opens the filter dropdown menu.
4. Verify that it contains checkboxes for failed and killed statuses.
5. Verify that these filters work as expected.
6. Verify that the old filters still work as expected.
7. Verify that the added tests make sense.

## Trade-offs
I am not sure if it's possible for pods to have a failed status. I will leave the filter as it is, though.

## Dependencies
None.

## Screenshots
### Before
![Screenshot from 2019-05-10 15-17-43](https://user-images.githubusercontent.com/40791275/57526954-7253c980-7337-11e9-8557-d7d647bad73d.png)

### After
![Peek 2019-06-21 11-27](https://user-images.githubusercontent.com/40791275/59909083-90711700-9417-11e9-892c-fa260e24497d.gif)

