### PR TITLE
DCOS-53692: supporting changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,9 +72,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
-      "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+      "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
       "requires": {
         "esutils": "^2.0.2",
         "lodash": "^4.17.11",
@@ -503,20 +503,30 @@
       "integrity": "sha512-inJlb0Idr6frKKVJNweG4t3BUbrvfSPhtwTuMzjLIUjSjEzu+/bNmSb4FrZcSfOGW9KCsvWY2pP4HMaoKzu86g=="
     },
     "@dcos/ui-kit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@dcos/ui-kit/-/ui-kit-2.0.1.tgz",
-      "integrity": "sha512-JXZhBHgt45Qk9aFDB6LLEc84/cifHaq64339r+rfRjvRbxKjNfcuKZX02d7xutRA+c2d6abwBd/jTx0YBgWaAA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@dcos/ui-kit/-/ui-kit-3.2.0.tgz",
+      "integrity": "sha512-OsHE+NHFYTJ7xbyZ1EDsxaFi8ntK6aMEBdsLnVf6pUI6uBSgwGsnbGBPmZJHzDtYSvRRG6LmliCfHZa2CW8Ifg==",
       "requires": {
+        "downshift": "3.2.10",
         "emotion": "9.2.12",
         "emotion-theming": "9.2.9",
         "focus-trap-react": "4.0.1",
+        "immutable": "^4.0.0-rc.12",
         "memoize-one": "4.0.2",
         "react-click-outside": "3.0.1",
         "react-delegate-component": "1.0.0",
+        "react-draggable": "3.2.1",
         "react-emotion": "9.2.12",
         "react-toggled": "1.2.7",
         "react-transition-group": "2.5.0",
         "react-virtualized": "9.20.1"
+      },
+      "dependencies": {
+        "immutable": {
+          "version": "4.0.0-rc.12",
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0-rc.12.tgz",
+          "integrity": "sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A=="
+        }
       }
     },
     "@emotion/babel-utils": {
@@ -2860,18 +2870,6 @@
         "mkdirp": "^0.5.1",
         "source-map": "^0.5.7",
         "touch": "^2.0.1"
-      },
-      "dependencies": {
-        "babel-plugin-macros": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.5.1.tgz",
-          "integrity": "sha512-xN3KhAxPzsJ6OQTktCanNpIFnnMsCV+t8OloKxIL72D6+SUZYFn9qfklPgef5HyyDtzYZqqb+fs1S12+gQY82Q==",
-          "requires": {
-            "@babel/runtime": "^7.4.2",
-            "cosmiconfig": "^5.2.0",
-            "resolve": "^1.10.0"
-          }
-        }
       }
     },
     "babel-plugin-istanbul": {
@@ -2896,7 +2894,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.4.1.tgz",
       "integrity": "sha512-pUdm8I6LAcKIzh6H2JZ1QUJByg7Im5/llcUHD/T9mTtlaBl/4YkHzvd6oUpT0cjIFgkCadVSHuJNVoNkLqvM1w==",
-      "dev": true,
       "requires": {
         "cosmiconfig": "^5.0.5"
       }
@@ -5409,6 +5406,11 @@
         "webpack-sources": "^1.0.1"
       }
     },
+    "compute-scroll-into-view": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.11.tgz",
+      "integrity": "sha512-uUnglJowSe0IPmWOdDtrlHXof5CTIJitfJEyITHBW6zDVOGu9Pjk5puaLM73SLcwak0L4hEjO7Td88/a6P5i7A=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -7155,6 +7157,17 @@
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         }
+      }
+    },
+    "downshift": {
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-3.2.10.tgz",
+      "integrity": "sha512-fEYNbV/qDLUHTxF9wALNe51Xe5zauUhy2sqgYG1CtmAfUFMI30UuSaisU8CD0DEsFSIsaEvsVgtabb6nTEhtaA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "compute-scroll-into-view": "^1.0.9",
+        "prop-types": "^15.6.0",
+        "react-is": "^16.5.2"
       }
     },
     "duplexer": {
@@ -11614,7 +11627,7 @@
     },
     "html-webpack-plugin": {
       "version": "3.2.0",
-      "resolved": "http://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
       "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
       "dev": true,
       "requires": {
@@ -14544,7 +14557,7 @@
     "junit-merge": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/junit-merge/-/junit-merge-1.3.0.tgz",
-      "integrity": "sha512-Kbzxs3OrHaeBhvWEY4/mD4+r2qVd1w0277EyCHHE8Du93kZxTnA701kkyPCEdIRSUmpw8sVwskp5K9o+ZlCaJQ==",
+      "integrity": "sha1-NSGkZskN1yfHj9CXGFECrj8EjVk=",
       "dev": true,
       "requires": {
         "commander": "^2.12.2",
@@ -20389,7 +20402,7 @@
         },
         "external-editor": {
           "version": "2.2.0",
-          "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
           "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
           "dev": true,
           "requires": {
@@ -20427,7 +20440,7 @@
         },
         "node-fetch": {
           "version": "1.6.3",
-          "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
           "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
           "dev": true,
           "requires": {
@@ -20988,7 +21001,8 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -22760,7 +22774,7 @@
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
       "requires": {
         "asap": "~2.0.3"
       }
@@ -23477,6 +23491,22 @@
             "object-assign": "^4.1.1",
             "react-is": "^16.8.1"
           }
+        }
+      }
+    },
+    "react-draggable": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-3.2.1.tgz",
+      "integrity": "sha512-r+3Bs9InID2lyIEbR8UIRVtpn4jgu1ArFEZgIy8vibJjijLSdNLX7rH9U68BBVD4RD9v44RXbaK4EHLyKXzNQw==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "prop-types": "^15.6.0"
+      },
+      "dependencies": {
+        "classnames": {
+          "version": "2.2.6",
+          "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+          "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
         }
       }
     },
@@ -24662,6 +24692,7 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
       "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
+      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -26107,7 +26138,7 @@
     },
     "speed-measure-webpack-plugin": {
       "version": "1.2.2",
-      "resolved": "http://registry.npmjs.org/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.2.2.tgz",
       "integrity": "sha512-OPssnUTAdOwl/ijqToLrYUi8xHxdC9SOVV9e2AxkOC02Hua7+Jkfh3tdFCZxiMbtlghHK5Eyz87kG/XNpeM77w==",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@dcos/http-service": "2.1.0",
     "@dcos/mesos-client": "1.0.0",
     "@dcos/tslint-config": "0.1.1",
-    "@dcos/ui-kit": "2.0.1",
+    "@dcos/ui-kit": "3.2.0",
     "@extension-kid/core": "0.2.4",
     "@lingui/react": "2.7.2",
     "array-sort": "1.0.0",

--- a/plugins/nodes/src/js/columns/__tests__/__snapshots__/NodesTableHealthColumn-test.js.snap
+++ b/plugins/nodes/src/js/columns/__tests__/__snapshots__/NodesTableHealthColumn-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`NodesTableHealthColumn renderer renders with health status 'Healthy' 1`] = `
 <div
-  className="css-1c5c0a1"
+  className="css-6zxkm"
 >
   <span
     className="text-success"
@@ -14,7 +14,7 @@ exports[`NodesTableHealthColumn renderer renders with health status 'Healthy' 1`
 
 exports[`NodesTableHealthColumn renderer renders with health status 'NA' 1`] = `
 <div
-  className="css-1c5c0a1"
+  className="css-6zxkm"
 >
   <span
     className="text-mute"
@@ -26,7 +26,7 @@ exports[`NodesTableHealthColumn renderer renders with health status 'NA' 1`] = `
 
 exports[`NodesTableHealthColumn renderer renders with health status 'Unhealthy' 1`] = `
 <div
-  className="css-1c5c0a1"
+  className="css-6zxkm"
 >
   <span
     className="text-danger"
@@ -38,7 +38,7 @@ exports[`NodesTableHealthColumn renderer renders with health status 'Unhealthy' 
 
 exports[`NodesTableHealthColumn renderer renders with health status 'Warn' 1`] = `
 <div
-  className="css-1c5c0a1"
+  className="css-6zxkm"
 >
   <span
     className="text-warning"

--- a/src/styles/components/form-elements/form-components/field-input/styles.less
+++ b/src/styles/components/form-elements/form-components/field-input/styles.less
@@ -4,7 +4,7 @@
     width: 25%;
   }
 
-  input.field-input-text-narrow {
+  .field-input-text-narrow {
     width: 50%;
   }
 
@@ -16,7 +16,7 @@
         width: 50%;
       }
 
-      input.field-input-text-narrow {
+      .field-input-text-narrow {
         width: 100%;
       }
     }


### PR DESCRIPTION
Supporting changes for mesosphere/dcos-ui-plugins-private#1007. Updates ui-kit version (to be able to use Typeahead) and adjusts a form input style so that it does not need to be applied directly to an input element. See EE PR for more details.
