### PR TITLE
add crypess:open to make better use of cypress during development

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -10,6 +10,5 @@
   "supportFile": "tests/_support",
   "waitForAnimations": true,
   "videoUploadOnPasses": false,
-  "numTestsKeptInMemory": 0,
   "chromeWebSecurity": false
 }

--- a/package.json
+++ b/package.json
@@ -192,13 +192,14 @@
     "webpack-merge": "4.1.1"
   },
   "scripts": {
-    "analyzebundle": "NODE_ENV=production npx webpack --config ./webpack/webpack.analyze.js",
+    "analyzebundle": "NODE_ENV=production webpack --config ./webpack/webpack.analyze.js",
     "build:assets": "npm run clean && ./scripts/lingui-compile && NODE_ENV=production webpack --colors --config ./webpack/webpack.production.js",
     "build:validate": "scripts/validate-build dist/assets/*.js",
     "build": "npm run lint && ([ -z \"${npm_config_externalplugins}\" ] || npm run lint:plugins) && npm test && npm run build:assets && npm run build:validate",
     "clean": "rm -rf dist locale/_build",
+    "cypress:open": "cypress open --config fixturesFolder=tests/_fixtures",
     "lint:commits": "./node_modules/.bin/commitlint",
-    "lint:es": "npx eslint --ignore-path .gitignore **/*.js",
+    "lint:es": "eslint --ignore-path .gitignore **/*.js",
     "lint:plugins": "PLUGINS=$npm_config_externalplugins; npm run lint:es -- \"$PLUGINS/**/*.js\" && npm run lint:styles -- \"$PLUGINS/**/*.less\"",
     "lint:styles": "bash -c 'opts=$@ ; set -f; if [[ $# -lt 1 ]]; then opts=\"{src/styles,plugins,packages}/**/*.less\"; fi ; stylelint ${opts}' 0",
     "lint:ts": "tslint -c tslint.json --project tsconfig.json",

--- a/scripts/utils/tests-functions
+++ b/scripts/utils/tests-functions
@@ -38,7 +38,7 @@ function executeCypress() {
     ${CYPRESS_HEADED:+"--headed"} \
     ${CYPRESS_NO_EXIT:+"--no-exit"} \
     --spec "${FILE}" \
-    --config "screenshotsFolder=${OUTPUT_PATH}/screenshots,video=${RECORD_VIDEO},videosFolder=${OUTPUT_PATH}/videos,integrationFolder=${TESTS_FOLDER},supportFile=${TESTS_FOLDER}/_support,fixturesFolder=${TESTS_FOLDER}/_fixtures" \
+    --config "numTestsKeptInMemory=0,screenshotsFolder=${OUTPUT_PATH}/screenshots,video=${RECORD_VIDEO},videosFolder=${OUTPUT_PATH}/videos,integrationFolder=${TESTS_FOLDER},supportFile=${TESTS_FOLDER}/_support,fixturesFolder=${TESTS_FOLDER}/_fixtures" \
     --reporter junit \
     ${CYPRESS_ENV:-""} \
     --reporter-options "mochaFile=${OUTPUT_PATH}/result.xml"


### PR DESCRIPTION
if you open cypress and change a test file, it actually reruns that file. when
paired with `.only` on a single test case, it looks like writing integration
tests will be waaaay more convenient for me, as the feedback cycle actually
feels quite convenient.

without the `fixtures` config in place a `npx cypress open` would fail for me on most tests.

this also enables snapshots in development mode!

![snaps](https://user-images.githubusercontent.com/300861/57854529-c0aa1200-77e8-11e9-999e-667bde30cf26.gif)
