### PR TITLE
remove `FULL_INTEGRATION_TEST`

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,8 +1,7 @@
 {
   "defaultCommandTimeout": 60000,
   "env": {
-    "CLUSTER_URL": "http://localhost:4200",
-    "FULL_INTEGRATION_TEST": false
+    "CLUSTER_URL": "http://localhost:4200"
   },
 
   "integrationFolder": "tests",

--- a/tests/_support/index.js
+++ b/tests/_support/index.js
@@ -3,34 +3,6 @@ require("./formChildCommands");
 require("./utils/ServicesUtil");
 
 Cypress.Commands.add("configureCluster", function(configuration) {
-  if (Object.keys(configuration).length === 0) {
-    return;
-  }
-
-  if (Cypress.env("FULL_INTEGRATION_TEST")) {
-    // Assume login if not explicitly set to false
-    if (configuration.logIn !== false) {
-      cy.request(
-        "POST",
-        Cypress.env("CLUSTER_URL") + "/acs/api/v1/auth/login",
-        { password: "deleteme", uid: "bootstrapuser" }
-      ).then(function(response) {
-        var cookies = response.headers["set-cookie"];
-        cookies.forEach(function(cookie) {
-          var sessionID = cookie.split("=")[0];
-          // Set cookies for cypress
-          cy.setCookie(sessionID, response.body.token);
-          // Set cookies for application
-          cy.window().then(function(win) {
-            win.document.cookie = cookie;
-          });
-        });
-      });
-    }
-
-    return;
-  }
-
   router.clearRoutes();
   cy.server();
 
@@ -726,12 +698,6 @@ Cypress.Commands.add("configureCluster", function(configuration) {
 
   // Metadata
   router.route(/metadata(\?_timestamp=[0-9]+)?$/, "fx:dcos/metadata");
-});
-
-Cypress.Commands.add("clusterCleanup", function(fn) {
-  if (Cypress.env("FULL_INTEGRATION_TEST")) {
-    fn();
-  }
 });
 
 Cypress.Commands.add("visitUrl", function(options) {

--- a/tests/pages/system/overview/repositories/AddRepositoryFormModal-cy.js
+++ b/tests/pages/system/overview/repositories/AddRepositoryFormModal-cy.js
@@ -46,18 +46,6 @@ describe("Add Repository Form Modal", function() {
       .click();
 
     cy.get(".modal").should("not.exist");
-
-    // Clean up
-    cy.clusterCleanup(function() {
-      cy.get(".page-body-content")
-        .contains("tr", "Here we go!")
-        .find(".button.button-primary-link.button-danger")
-        .invoke("show")
-        .click({ force: true });
-      cy.get(".modal .modal-footer .button.button-danger")
-        .contains("Delete Repository")
-        .click();
-    });
   });
 
   it("displays error in modal after add causes an error", function() {

--- a/tests/pages/system/settings/UISettings-cy.js
+++ b/tests/pages/system/settings/UISettings-cy.js
@@ -1,320 +1,318 @@
 describe("UI Settings", function() {
-  if (!Cypress.env("FULL_INTEGRATION_TEST")) {
-    describe("Versions displayed", function() {
-      it("displays UI version details", function() {
-        cy.configureCluster({
-          plugins: "ui-update-enabled",
-          "ui-settings": "default"
-        });
-
-        cy.visitUrl({ url: "/settings/ui-settings" });
-        cy.get(".breadcrumb__content").contains("UI Settings");
-
-        cy.wait("@getUiVersion");
-        cy.wait("@cosmosListVersions");
-
-        cy.get("div.configuration-map").as("dcosUIDetails");
-
-        cy.get("@dcosUIDetails")
-          .configurationMapValue("Installed Version")
-          .contains("0.0.0");
-
-        cy.get("@dcosUIDetails")
-          .configurationMapValue("Available Version")
-          .contains("0.1.1");
+  describe("Versions displayed", function() {
+    it("displays UI version details", function() {
+      cy.configureCluster({
+        plugins: "ui-update-enabled",
+        "ui-settings": "default"
       });
 
-      it("doesn't display update when there is no update", function() {
-        cy.configureCluster({
-          cosmos: "no-versions",
-          plugins: "ui-update-enabled",
-          "ui-settings": "default"
-        });
+      cy.visitUrl({ url: "/settings/ui-settings" });
+      cy.get(".breadcrumb__content").contains("UI Settings");
 
-        cy.visitUrl({ url: "/settings/ui-settings" });
-        cy.get(".breadcrumb__content").contains("UI Settings");
+      cy.wait("@getUiVersion");
+      cy.wait("@cosmosListVersions");
 
-        cy.wait("@getUiVersion");
-        cy.wait("@cosmosListVersions");
+      cy.get("div.configuration-map").as("dcosUIDetails");
 
-        cy.get("div.configuration-map").as("dcosUIDetails");
+      cy.get("@dcosUIDetails")
+        .configurationMapValue("Installed Version")
+        .contains("0.0.0");
 
-        cy.get("@dcosUIDetails")
-          .configurationMapValue("Installed Version")
-          .contains("0.0.0");
-
-        cy.get("@dcosUIDetails")
-          .configurationMapValue("Available Version")
-          .should("not.exist");
-      });
-
-      it("displays update when not on default version", function() {
-        cy.configureCluster({
-          plugins: "ui-update-enabled",
-          "ui-settings": "v0.1.0"
-        });
-
-        cy.visitUrl({ url: "/settings/ui-settings" });
-        cy.get(".breadcrumb__content").contains("UI Settings");
-
-        cy.wait("@getUiVersion");
-        cy.wait("@cosmosListVersions");
-
-        cy.get("div.configuration-map").as("dcosUIDetails");
-
-        cy.get("@dcosUIDetails")
-          .configurationMapValue("Available Version")
-          .contains("0.1.1");
-      });
-
-      it("displays update when not on default version", function() {
-        cy.configureCluster({
-          plugins: "ui-update-enabled",
-          "ui-settings": "v0.1.1"
-        });
-
-        cy.visitUrl({ url: "/settings/ui-settings" });
-        cy.get(".breadcrumb__content").contains("UI Settings");
-
-        cy.wait("@getUiVersion");
-        cy.wait("@cosmosListVersions");
-
-        cy.get("div.configuration-map").as("dcosUIDetails");
-
-        cy.get("@dcosUIDetails")
-          .configurationMapValue("Available Version")
-          .should("not.exist");
-      });
-
-      it("displays fallback ui on cosmos error", function() {
-        cy.configureCluster({
-          cosmos: "error",
-          plugins: "ui-update-enabled",
-          "ui-settings": "default"
-        });
-
-        cy.visitUrl({ url: "/settings/ui-settings" });
-        cy.get(".breadcrumb__content").contains("UI Settings");
-
-        cy.wait("@cosmosListVersions");
-
-        cy.wait(500);
-
-        cy.get("div.configuration-map").as("dcosUIDetails");
-
-        cy.get("@dcosUIDetails")
-          .configurationMapValue("Installed Version")
-          .contains("0.0.0");
-
-        cy.get("@dcosUIDetails")
-          .configurationMapValue("Available Version")
-          .should("not.exist");
-
-        cy.get("#uiDetailsRollback").should("not.exist");
-      });
+      cy.get("@dcosUIDetails")
+        .configurationMapValue("Available Version")
+        .contains("0.1.1");
     });
 
-    describe("Actions", function() {
-      it("Displays Rollback, Update, Refresh", function() {
-        cy.configureCluster({
-          plugins: "ui-update-enabled",
-          "ui-settings": "v0.1.0"
-        });
-
-        cy.visitUrl({ url: "/settings/ui-settings" });
-        cy.get(".breadcrumb__content").contains("UI Settings");
-
-        cy.wait("@getUiVersion");
-        cy.wait("@cosmosListVersions");
-
-        cy.get("#uiDetailsRollback")
-          .contains("Rollback")
-          .should("not.be.disabled");
-        cy.get("#uiDetailsStartUpdate")
-          .contains("Start Update")
-          .should("not.be.disabled");
-        cy.get("#uiDetailsRefreshVersion")
-          .contains("Refresh page to load")
-          .should("not.be.disabled");
+    it("doesn't display update when there is no update", function() {
+      cy.configureCluster({
+        cosmos: "no-versions",
+        plugins: "ui-update-enabled",
+        "ui-settings": "default"
       });
 
-      it("Displays only rollback if version is current", function() {
-        cy.configureCluster({
-          cosmos: "no-versions",
-          plugins: "ui-update-enabled",
-          "ui-settings": "default"
-        });
+      cy.visitUrl({ url: "/settings/ui-settings" });
+      cy.get(".breadcrumb__content").contains("UI Settings");
 
-        cy.visitUrl({ url: "/settings/ui-settings" });
-        cy.get(".breadcrumb__content").contains("UI Settings");
+      cy.wait("@getUiVersion");
+      cy.wait("@cosmosListVersions");
 
-        cy.wait("@getUiVersion");
-        cy.wait("@cosmosListVersions");
+      cy.get("div.configuration-map").as("dcosUIDetails");
 
-        cy.get("#uiDetailsRollback").contains("Rollback");
-        cy.get("#uiDetailsStartUpdate").should("not.exist");
-        cy.get("#uiDetailsRefreshVersion").should("not.exist");
-      });
+      cy.get("@dcosUIDetails")
+        .configurationMapValue("Installed Version")
+        .contains("0.0.0");
 
-      it("Can perform a version rollback", function() {
-        cy.configureCluster({
-          cosmos: "no-versions",
-          plugins: "ui-update-enabled",
-          "update-service": "reset-pass",
-          "ui-settings": "v0.1.0"
-        });
-
-        cy.visitUrl({ url: "/settings/ui-settings" });
-        cy.get(".breadcrumb__content").contains("UI Settings");
-
-        cy.wait("@getUiVersion");
-        cy.wait("@cosmosListVersions");
-
-        cy.route({
-          method: "GET",
-          url: /dcos-ui-update-service\/api\/v1\/version\//,
-          response: "fx:ui-settings/default-version",
-          headers: {
-            "Content-Type": "application/json"
-          }
-        }).as("getUiVersionRefresh");
-
-        cy.get("#uiDetailsRollback")
-          .contains("Rollback")
-          .click();
-
-        cy.wait("@resetUiVersion");
-
-        cy.get("#uiDetailsRollback").contains("Rolling back...");
-        cy.get("#uiDetailsRollback").should("be.disabled");
-        cy.get("#uiDetailsRefreshVersion").should("not.exist");
-
-        cy.wait("@getUiVersionRefresh", { timeout: 65000 });
-
-        cy.get("#uiDetailsRollback").contains("Rollback");
-        cy.get("#uiDetailsRollback").should("not.be.disabled");
-      });
-
-      it("Can handle a rollback failure", function() {
-        cy.configureCluster({
-          cosmos: "no-versions",
-          plugins: "ui-update-enabled",
-          "update-service": "reset-fail",
-          "ui-settings": "v0.1.0"
-        });
-
-        cy.visitUrl({ url: "/settings/ui-settings" });
-        cy.get(".breadcrumb__content").contains("UI Settings");
-
-        cy.wait("@getUiVersion");
-        cy.wait("@cosmosListVersions");
-
-        cy.get("#uiDetailsRollback")
-          .contains("Rollback")
-          .click();
-
-        cy.wait("@resetUiVersion");
-
-        cy.wait("@getUiVersion", { timeout: 65000 });
-
-        cy.get("#uiDetailsRollback").contains("Rollback Failed!");
-        cy.get("#uiDetailsRollback").should("be.disabled");
-      });
-
-      it("Can perform a version update", function() {
-        cy.configureCluster({
-          plugins: "ui-update-enabled",
-          "update-service": "update-pass",
-          "ui-settings": "default"
-        });
-
-        cy.visitUrl({ url: "/settings/ui-settings" });
-        cy.get(".breadcrumb__content").contains("UI Settings");
-
-        cy.wait("@getUiVersion");
-        cy.wait("@cosmosListVersions");
-
-        // Update Route to return new version
-        cy.route({
-          method: "GET",
-          url: /dcos-ui-update-service\/api\/v1\/version\//,
-          response: "fx:ui-settings/version-011",
-          headers: {
-            "Content-Type": "application/json"
-          }
-        }).as("getUiVersionRefresh");
-
-        cy.get("div.configuration-map").as("dcosUIDetails");
-
-        cy.get("@dcosUIDetails")
-          .configurationMapValue("Installed Version")
-          .contains("0.0.0");
-
-        cy.get("@dcosUIDetails")
-          .configurationMapValue("Available Version")
-          .contains("0.1.1");
-
-        cy.get("#uiDetailsRefreshVersion").should("not.exist");
-
-        cy.get("#uiDetailsStartUpdate").contains("Start Update");
-        cy.get("#uiDetailsStartUpdate").click();
-
-        cy.wait("@updateUiVersion");
-
-        cy.get("#uiDetailsStartUpdate").contains("Updating...");
-        cy.get("#uiDetailsStartUpdate").should("be.disabled");
-
-        cy.get("#uiDetailsRollback").contains("Rollback");
-        cy.get("#uiDetailsRollback").should("be.disabled");
-
-        cy.wait("@getUiVersionRefresh", { timeout: 65000 });
-
-        cy.get("#uiDetailsStartUpdate").should("not.exist");
-
-        cy.get("#uiDetailsRefreshVersion").contains("Refresh page to load");
-        cy.get("#uiDetailsRefreshVersion").should("not.be.disabled");
-
-        cy.get("#uiDetailsRollback").contains("Rollback");
-        cy.get("#uiDetailsRollback").should("not.be.disabled");
-      });
-
-      it("Can handle a version update failure", function() {
-        cy.configureCluster({
-          plugins: "ui-update-enabled",
-          "update-service": "update-fail",
-          "ui-settings": "default"
-        });
-
-        cy.visitUrl({ url: "/settings/ui-settings" });
-        cy.get(".breadcrumb__content").contains("UI Settings");
-
-        cy.wait("@getUiVersion");
-        cy.wait("@cosmosListVersions");
-
-        cy.get("div.configuration-map").as("dcosUIDetails");
-
-        cy.get("@dcosUIDetails")
-          .configurationMapValue("Installed Version")
-          .contains("0.0.0");
-
-        cy.get("@dcosUIDetails")
-          .configurationMapValue("Available Version")
-          .contains("0.1.1");
-
-        cy.get("#uiDetailsStartUpdate")
-          .contains("Start Update")
-          .should("not.be.disabled")
-          .click();
-
-        cy.wait("@updateUiVersion");
-        cy.wait("@getUiVersion");
-
-        cy.get("#uiDetailsStartUpdate").contains("Update Failed!");
-        cy.get("#uiDetailsStartUpdate").should("be.disabled");
-
-        cy.get("#uiDetailsRollback").contains("Rollback");
-        cy.get("#uiDetailsRollback").should("not.be.disabled");
-      });
+      cy.get("@dcosUIDetails")
+        .configurationMapValue("Available Version")
+        .should("not.exist");
     });
-  }
+
+    it("displays update when not on default version", function() {
+      cy.configureCluster({
+        plugins: "ui-update-enabled",
+        "ui-settings": "v0.1.0"
+      });
+
+      cy.visitUrl({ url: "/settings/ui-settings" });
+      cy.get(".breadcrumb__content").contains("UI Settings");
+
+      cy.wait("@getUiVersion");
+      cy.wait("@cosmosListVersions");
+
+      cy.get("div.configuration-map").as("dcosUIDetails");
+
+      cy.get("@dcosUIDetails")
+        .configurationMapValue("Available Version")
+        .contains("0.1.1");
+    });
+
+    it("displays update when not on default version", function() {
+      cy.configureCluster({
+        plugins: "ui-update-enabled",
+        "ui-settings": "v0.1.1"
+      });
+
+      cy.visitUrl({ url: "/settings/ui-settings" });
+      cy.get(".breadcrumb__content").contains("UI Settings");
+
+      cy.wait("@getUiVersion");
+      cy.wait("@cosmosListVersions");
+
+      cy.get("div.configuration-map").as("dcosUIDetails");
+
+      cy.get("@dcosUIDetails")
+        .configurationMapValue("Available Version")
+        .should("not.exist");
+    });
+
+    it("displays fallback ui on cosmos error", function() {
+      cy.configureCluster({
+        cosmos: "error",
+        plugins: "ui-update-enabled",
+        "ui-settings": "default"
+      });
+
+      cy.visitUrl({ url: "/settings/ui-settings" });
+      cy.get(".breadcrumb__content").contains("UI Settings");
+
+      cy.wait("@cosmosListVersions");
+
+      cy.wait(500);
+
+      cy.get("div.configuration-map").as("dcosUIDetails");
+
+      cy.get("@dcosUIDetails")
+        .configurationMapValue("Installed Version")
+        .contains("0.0.0");
+
+      cy.get("@dcosUIDetails")
+        .configurationMapValue("Available Version")
+        .should("not.exist");
+
+      cy.get("#uiDetailsRollback").should("not.exist");
+    });
+  });
+
+  describe("Actions", function() {
+    it("Displays Rollback, Update, Refresh", function() {
+      cy.configureCluster({
+        plugins: "ui-update-enabled",
+        "ui-settings": "v0.1.0"
+      });
+
+      cy.visitUrl({ url: "/settings/ui-settings" });
+      cy.get(".breadcrumb__content").contains("UI Settings");
+
+      cy.wait("@getUiVersion");
+      cy.wait("@cosmosListVersions");
+
+      cy.get("#uiDetailsRollback")
+        .contains("Rollback")
+        .should("not.be.disabled");
+      cy.get("#uiDetailsStartUpdate")
+        .contains("Start Update")
+        .should("not.be.disabled");
+      cy.get("#uiDetailsRefreshVersion")
+        .contains("Refresh page to load")
+        .should("not.be.disabled");
+    });
+
+    it("Displays only rollback if version is current", function() {
+      cy.configureCluster({
+        cosmos: "no-versions",
+        plugins: "ui-update-enabled",
+        "ui-settings": "default"
+      });
+
+      cy.visitUrl({ url: "/settings/ui-settings" });
+      cy.get(".breadcrumb__content").contains("UI Settings");
+
+      cy.wait("@getUiVersion");
+      cy.wait("@cosmosListVersions");
+
+      cy.get("#uiDetailsRollback").contains("Rollback");
+      cy.get("#uiDetailsStartUpdate").should("not.exist");
+      cy.get("#uiDetailsRefreshVersion").should("not.exist");
+    });
+
+    it("Can perform a version rollback", function() {
+      cy.configureCluster({
+        cosmos: "no-versions",
+        plugins: "ui-update-enabled",
+        "update-service": "reset-pass",
+        "ui-settings": "v0.1.0"
+      });
+
+      cy.visitUrl({ url: "/settings/ui-settings" });
+      cy.get(".breadcrumb__content").contains("UI Settings");
+
+      cy.wait("@getUiVersion");
+      cy.wait("@cosmosListVersions");
+
+      cy.route({
+        method: "GET",
+        url: /dcos-ui-update-service\/api\/v1\/version\//,
+        response: "fx:ui-settings/default-version",
+        headers: {
+          "Content-Type": "application/json"
+        }
+      }).as("getUiVersionRefresh");
+
+      cy.get("#uiDetailsRollback")
+        .contains("Rollback")
+        .click();
+
+      cy.wait("@resetUiVersion");
+
+      cy.get("#uiDetailsRollback").contains("Rolling back...");
+      cy.get("#uiDetailsRollback").should("be.disabled");
+      cy.get("#uiDetailsRefreshVersion").should("not.exist");
+
+      cy.wait("@getUiVersionRefresh", { timeout: 65000 });
+
+      cy.get("#uiDetailsRollback").contains("Rollback");
+      cy.get("#uiDetailsRollback").should("not.be.disabled");
+    });
+
+    it("Can handle a rollback failure", function() {
+      cy.configureCluster({
+        cosmos: "no-versions",
+        plugins: "ui-update-enabled",
+        "update-service": "reset-fail",
+        "ui-settings": "v0.1.0"
+      });
+
+      cy.visitUrl({ url: "/settings/ui-settings" });
+      cy.get(".breadcrumb__content").contains("UI Settings");
+
+      cy.wait("@getUiVersion");
+      cy.wait("@cosmosListVersions");
+
+      cy.get("#uiDetailsRollback")
+        .contains("Rollback")
+        .click();
+
+      cy.wait("@resetUiVersion");
+
+      cy.wait("@getUiVersion", { timeout: 65000 });
+
+      cy.get("#uiDetailsRollback").contains("Rollback Failed!");
+      cy.get("#uiDetailsRollback").should("be.disabled");
+    });
+
+    it("Can perform a version update", function() {
+      cy.configureCluster({
+        plugins: "ui-update-enabled",
+        "update-service": "update-pass",
+        "ui-settings": "default"
+      });
+
+      cy.visitUrl({ url: "/settings/ui-settings" });
+      cy.get(".breadcrumb__content").contains("UI Settings");
+
+      cy.wait("@getUiVersion");
+      cy.wait("@cosmosListVersions");
+
+      // Update Route to return new version
+      cy.route({
+        method: "GET",
+        url: /dcos-ui-update-service\/api\/v1\/version\//,
+        response: "fx:ui-settings/version-011",
+        headers: {
+          "Content-Type": "application/json"
+        }
+      }).as("getUiVersionRefresh");
+
+      cy.get("div.configuration-map").as("dcosUIDetails");
+
+      cy.get("@dcosUIDetails")
+        .configurationMapValue("Installed Version")
+        .contains("0.0.0");
+
+      cy.get("@dcosUIDetails")
+        .configurationMapValue("Available Version")
+        .contains("0.1.1");
+
+      cy.get("#uiDetailsRefreshVersion").should("not.exist");
+
+      cy.get("#uiDetailsStartUpdate").contains("Start Update");
+      cy.get("#uiDetailsStartUpdate").click();
+
+      cy.wait("@updateUiVersion");
+
+      cy.get("#uiDetailsStartUpdate").contains("Updating...");
+      cy.get("#uiDetailsStartUpdate").should("be.disabled");
+
+      cy.get("#uiDetailsRollback").contains("Rollback");
+      cy.get("#uiDetailsRollback").should("be.disabled");
+
+      cy.wait("@getUiVersionRefresh", { timeout: 65000 });
+
+      cy.get("#uiDetailsStartUpdate").should("not.exist");
+
+      cy.get("#uiDetailsRefreshVersion").contains("Refresh page to load");
+      cy.get("#uiDetailsRefreshVersion").should("not.be.disabled");
+
+      cy.get("#uiDetailsRollback").contains("Rollback");
+      cy.get("#uiDetailsRollback").should("not.be.disabled");
+    });
+
+    it("Can handle a version update failure", function() {
+      cy.configureCluster({
+        plugins: "ui-update-enabled",
+        "update-service": "update-fail",
+        "ui-settings": "default"
+      });
+
+      cy.visitUrl({ url: "/settings/ui-settings" });
+      cy.get(".breadcrumb__content").contains("UI Settings");
+
+      cy.wait("@getUiVersion");
+      cy.wait("@cosmosListVersions");
+
+      cy.get("div.configuration-map").as("dcosUIDetails");
+
+      cy.get("@dcosUIDetails")
+        .configurationMapValue("Installed Version")
+        .contains("0.0.0");
+
+      cy.get("@dcosUIDetails")
+        .configurationMapValue("Available Version")
+        .contains("0.1.1");
+
+      cy.get("#uiDetailsStartUpdate")
+        .contains("Start Update")
+        .should("not.be.disabled")
+        .click();
+
+      cy.wait("@updateUiVersion");
+      cy.wait("@getUiVersion");
+
+      cy.get("#uiDetailsStartUpdate").contains("Update Failed!");
+      cy.get("#uiDetailsStartUpdate").should("be.disabled");
+
+      cy.get("#uiDetailsRollback").contains("Rollback");
+      cy.get("#uiDetailsRollback").should("not.be.disabled");
+    });
+  });
 });


### PR DESCRIPTION
it looks like someone had the plan to rely on stubs to speed up local testing.
unfortunately that idea has not been shared enough that we make good use of
this. in fact we don't seem to make use of this at all anymore.

under the assumption that `FULL_INTEGRATION_TEST` is never truthy, then unreachable code has been removed as well. that's why `clusterCleanup` had to go as well.


you might want to **review without whitespace changes**!