### PR TITLE
fix: preserve concurrencyPolicy and scheduleId in job json

### DIFF
--- a/src/js/utils/JobUtil.js
+++ b/src/js/utils/JobUtil.js
@@ -84,6 +84,15 @@ const JobUtil = {
       }
     }
 
+    // default values for id and policy
+    let scheduleId = "default";
+    let schedulePolicy = "ALLOW";
+    // preserve id and concurrencyPolicy
+    if (typeof spec.schedules != "undefined" && spec.schedules.length > 0) {
+      scheduleId = spec.schedules[0].id;
+      schedulePolicy = spec.schedules[0].concurrencyPolicy;
+    }
+
     // Reset schedules
     spec.schedules = [];
 
@@ -91,11 +100,11 @@ const JobUtil = {
     // defaults
     if (!schedule || schedule.runOnSchedule) {
       const {
-        id = "default",
+        id = scheduleId,
         enabled = true,
         cron,
         timezone,
-        concurrencyPolicy = "ALLOW",
+        concurrencyPolicy = schedulePolicy,
         startingDeadlineSeconds
       } = schedule || {};
 
@@ -147,12 +156,13 @@ const JobUtil = {
     if (schedule) {
       const {
         id = "default",
-        enabled = true,
+        enabled,
         cron,
         timezone,
         concurrencyPolicy = "ALLOW",
         startingDeadlineSeconds
       } = schedule;
+
       // Transfer schedule as with reasonable defaults
       spec.schedules = [
         {

--- a/src/js/utils/__tests__/JobUtil-test.js
+++ b/src/js/utils/__tests__/JobUtil-test.js
@@ -128,7 +128,8 @@ describe("JobUtil", function() {
         schedules: [
           {
             id: "every-minute",
-            cron: "* * * * *"
+            cron: "* * * * *",
+            enabled: true
           }
         ]
       });


### PR DESCRIPTION
Closes DCOS-54087
Closes COPS-4884

## Overview

If you create a Job with the concurrencyPolicy set to "FORBID", and then edit the job in the UI, the JSON editor shows the policy as "ALLOW"

I was able to reproduce this issue on DC/OS 1.11.2 (customer version), as well as DC/OS 1.11.10.  I was not able to reproduce it on DC/OS 1.12.2 or 1.13, so it looks like maybe something was fixed in the interim. 

## Testing

Steps to reproduce:

1. Submit the job (below) using:  dcos job add job.json
2. Navigate to the Jobs tab in the UI and edit the 'test-job' job
3. In the edit panel, click on the JSON editor

Expected result:

JSON editor shows the concurrencyPolicy as "FORBID"

Observed result:

JSON editor shows the concurrencyPolicy as "ALLOW"

```
{
  "id": "test-job",
  "description": "A job that sleeps regularly",
  "run": {
    "cmd": "sleep 20000",
    "cpus": 0.01,
    "mem": 32,
    "disk": 0
  },
  "schedules": [
    {
      "id": "sleep-schedule",
      "enabled": true,
      "cron": "5 * * * *",
      "concurrencyPolicy": "FORBID"
    }
  ]
}
```

## Notes

This fix is similar to what was applied in 1.12