### PR TITLE
[spike] DCOS-52108: JSON erros in service creation are not being reset

### DIFF
--- a/plugins/services/src/js/components/modals/CreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/CreateServiceModal.js
@@ -420,6 +420,7 @@ class CreateServiceModal extends Component {
         this.setState({
           activeTab: null,
           apiErrors: [],
+          formErrors: [],
           serviceFormErrors: [],
           servicePickerActive: false,
           serviceFormActive: true,
@@ -434,6 +435,7 @@ class CreateServiceModal extends Component {
         this.setState({
           activeTab: null,
           apiErrors: [],
+          formErrors: [],
           serviceFormErrors: [],
           servicePickerActive: false,
           serviceFormActive: true,
@@ -448,6 +450,7 @@ class CreateServiceModal extends Component {
         this.setState({
           activeTab: null,
           apiErrors: [],
+          formErrors: [],
           serviceFormErrors: [],
           servicePickerActive: false,
           serviceJsonActive: true,

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -276,6 +276,68 @@ describe("Service Form Modal", function() {
           cy.get(".infoBoxWrapper").should("not.be.visible");
           cy.get("input[name=id]").should("have.value", "/foo");
         });
+
+        context("Clearing JSON errors when re-opening", function() {
+          beforeEach(function() {
+            openServiceModal();
+          });
+
+          it("clears JSON errors when re-opening the single container service form", function() {
+            openServiceForm(); // Select "Single container".
+            cy.get(".modal .toggle-button + span").click(); // Open the JSON Editor.
+            cy.get(".button")
+              .contains("Review & Run")
+              .click(); // Try to submit.
+            cy.get(".ace_error").should("exist"); // Verify errors in the JSON.
+            cy.get(".modal-header button")
+              .contains("Back")
+              .click(); // Go back.
+            cy.contains("button", "Discard").click(); // Confirm.
+            openServiceForm(); // Select "Single container" again.
+            cy.get(".ace_editor").should("exist"); // The JSON Editor should be open.
+            cy.get(".ace_error").should("not.exist"); // Verify no errors in the JSON.
+          });
+
+          it("clears JSON errors when re-opening the pod form", function() {
+            cy.get(".create-service-modal-service-picker-option")
+              .contains("Multi-container (Pod)")
+              .click(); // Select "Pod".
+            cy.get(".modal .toggle-button + span").click(); // Open the JSON Editor.
+            cy.get(".form-group")
+              .find('.form-control[name="id"]')
+              .type("{backspace}"); // Introduce an error by deleting the ID.
+            cy.get(".button")
+              .contains("Review & Run")
+              .click(); // Try to submit.
+            cy.get(".ace_error").should("exist"); // Verify errors in the JSON.
+            cy.get(".modal-header button")
+              .contains("Back")
+              .click(); // Go back.
+            cy.contains("button", "Discard").click(); // Confirm.
+            cy.get(".create-service-modal-service-picker-option")
+              .contains("Multi-container (Pod)")
+              .click(); // Select "Pod" again.
+            cy.get(".ace_editor").should("exist"); // The JSON Editor should be open.
+            cy.get(".ace_error").should("not.exist"); // Verify no errors in the JSON.
+          });
+
+          it("clears JSON errors when re-opening the JSON form", function() {
+            cy.get(".create-service-modal-service-picker-option")
+              .contains("JSON Configuration")
+              .click(); // Select "JSON Configuration".
+            cy.get(".button")
+              .contains("Review & Run")
+              .click(); // Try to submit.
+            cy.get(".ace_error").should("exist"); // Verify errors in the JSON.
+            cy.get(".modal-header button")
+              .contains("Back")
+              .click(); // Go back.
+            cy.get(".create-service-modal-service-picker-option")
+              .contains("JSON Configuration")
+              .click(); // Select "JSON Configuration" again.
+            cy.get(".ace_error").should("not.exist"); // Verify no errors in the JSON.
+          });
+        });
       });
     });
 


### PR DESCRIPTION
Fix reappeaing JSON errors for better user experience.

Closes https://jira.mesosphere.com/browse/DCOS-52108

## Testing
1. Go to service tab.
2. Try to add a new service with the default configuration (it will produce errors).
3. Open the JSON.
4. Go back.
5. Open the service form again.
6. Verify that there are no errors in the JSON.
7. Verify the same for Pod and JSON (for Pod you have to introduce an error, for example by deleting the ID).
8. Verify that the added tests make sense.

## Trade-offs
Sometimes clicking the back button triggers `onChange` in the form, which shows the errors. This is not introduced by this PR.
I created a jira to track this: https://jira.mesosphere.com/browse/DCOS-54264 .

## Dependencies
None.

## Screenshots
### Before
![Peek 2019-05-23 14-06](https://user-images.githubusercontent.com/40791275/58248267-5bb06800-7d64-11e9-80aa-e7fe2fbdfb20.gif)

### After
![Peek 2019-05-23 13-58](https://user-images.githubusercontent.com/40791275/58248285-623edf80-7d64-11e9-8ea0-6c6ffc527424.gif)
