### PR TITLE
DCOS-43588: UI doesn't reflect executor's resources for Pods on the Services page

### DIFF
--- a/plugins/services/src/js/structs/Service.js
+++ b/plugins/services/src/js/structs/Service.js
@@ -116,12 +116,24 @@ module.exports = class Service extends Item {
       gpus = 0,
       disk = 0
     } = this.getSpec().getResources();
+    let executorCpus = 0;
+    let executorMem = 0;
+    let executorGpus = 0;
+    let executorDisk = 0;
+
+    if (this.getSpec().get("executorResources")) {
+      const executor = this.getSpec().get("executorResources");
+      executorCpus = executor.cpus ? executor.cpus : 0;
+      executorMem = executor.mem ? executor.mem : 0;
+      executorGpus = executor.gpus ? executor.gpus : 0;
+      executorDisk = executor.disk ? executor.disk : 0;
+    }
 
     return {
-      cpus: cpus * instances,
-      mem: mem * instances,
-      gpus: gpus * instances,
-      disk: disk * instances
+      cpus: (cpus + executorCpus) * instances,
+      mem: (mem + executorMem) * instances,
+      gpus: (gpus + executorGpus) * instances,
+      disk: (disk + executorDisk) * instances
     };
   }
 

--- a/plugins/services/src/js/structs/__tests__/Service-test.js
+++ b/plugins/services/src/js/structs/__tests__/Service-test.js
@@ -30,6 +30,138 @@ describe("Service", function() {
         disk: 0
       });
     });
+
+    it("returns correct resource data for a single instance", function() {
+      expect(
+        new Service({
+          getSpec() {
+            return {
+              get(attribute) {
+                return this[attribute];
+              },
+              getResources() {
+                return {
+                  cpus: 20,
+                  mem: 10,
+                  gpus: 0,
+                  disk: 0
+                };
+              }
+            };
+          },
+          getInstancesCount() {
+            return 1;
+          }
+        }).getResources()
+      ).toEqual({
+        cpus: 20,
+        mem: 10,
+        gpus: 0,
+        disk: 0
+      });
+    });
+
+    it("returns correct resource data for multiple instances", function() {
+      expect(
+        new Service({
+          getSpec() {
+            return {
+              get(attribute) {
+                return this[attribute];
+              },
+              getResources() {
+                return {
+                  cpus: 20,
+                  mem: 10,
+                  gpus: 0,
+                  disk: 0
+                };
+              }
+            };
+          },
+          getInstancesCount() {
+            return 2;
+          }
+        }).getResources()
+      ).toEqual({
+        cpus: 40,
+        mem: 20,
+        gpus: 0,
+        disk: 0
+      });
+    });
+
+    it("returns correct resource data for a single instance with executor resources", function() {
+      expect(
+        new Service({
+          getSpec() {
+            return {
+              get(attribute) {
+                return this[attribute];
+              },
+              getResources() {
+                return {
+                  cpus: 20,
+                  mem: 10,
+                  gpus: 0,
+                  disk: 0
+                };
+              },
+              executorResources: {
+                cpus: 10,
+                mem: 10,
+                gpus: 0,
+                disk: 0
+              }
+            };
+          },
+          getInstancesCount() {
+            return 1;
+          }
+        }).getResources()
+      ).toEqual({
+        cpus: 30,
+        mem: 20,
+        gpus: 0,
+        disk: 0
+      });
+    });
+
+    it("returns correct resource data for multiple instances with executor resources", function() {
+      expect(
+        new Service({
+          getSpec() {
+            return {
+              get(attribute) {
+                return this[attribute];
+              },
+              getResources() {
+                return {
+                  cpus: 20,
+                  mem: 10,
+                  gpus: 0,
+                  disk: 0
+                };
+              },
+              executorResources: {
+                cpus: 10,
+                mem: 10,
+                gpus: 0,
+                disk: 0
+              }
+            };
+          },
+          getInstancesCount() {
+            return 2;
+          }
+        }).getResources()
+      ).toEqual({
+        cpus: 60,
+        mem: 40,
+        gpus: 0,
+        disk: 0
+      });
+    });
   });
 
   describe("#getRegions", function() {


### PR DESCRIPTION
Include executor resources when showing
pods in the services table.

Closes https://jira.mesosphere.com/browse/DCOS-43588

This PR is work in progress and is still missing tests.

## Testing
1. Go to services tab.
2. Create a pod.
3. In the services table, verify that the resource columns also show executor resources. Compare them with the resources when clicking on the pod. In my example:
![Снимка от 2019-05-23 19-10-18](https://user-images.githubusercontent.com/40791275/58268621-6b44a680-7d8e-11e9-9e9e-da7dd2a8f137.png)
4. Verify that the added tests make sense.

## Trade-offs
None.

## Dependencies
None.

## Screenshots
### Before
![Снимка от 2019-05-23 19-05-01](https://user-images.githubusercontent.com/40791275/58268376-038e5b80-7d8e-11e9-937b-dfc8b7e88480.png)

### After
![Снимка от 2019-05-23 19-03-07](https://user-images.githubusercontent.com/40791275/58268390-08530f80-7d8e-11e9-81f3-c0cf0c46b177.png)
