### PR TITLE
DCOS-53645: omit secret volumes from service display section

### DIFF
--- a/plugins/services/src/js/service-configuration/PodStorageConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodStorageConfigSection.js
@@ -76,6 +76,10 @@ class PodStorageConfigSection extends React.Component {
     const { volumes = [], containers = [] } = this.props.appConfig;
     const volumeSummary = volumes.reduce((memo, volume) => {
       let type = VolumeConstants.type.unknown;
+      if (volume.secret) {
+        // This is a secret volume so it will be displayed separately
+        return memo;
+      }
       if (volume.host != null) {
         type = VolumeConstants.type.host;
       }

--- a/plugins/services/src/js/service-configuration/ServiceStorageConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceStorageConfigSection.js
@@ -15,10 +15,12 @@ class ServiceStorageConfigSection extends ServiceConfigBaseSectionDisplay {
   shouldExcludeItem() {
     const { appConfig } = this.props;
 
-    return !Util.findNestedPropertyInObject(
+    const volumes = Util.findNestedPropertyInObject(
       appConfig,
-      "container.volumes.length"
+      "container.volumes"
     );
+
+    return !volumes.some(v => v.persistent || v.external || v.hostPath);
   }
 
   /**
@@ -143,27 +145,31 @@ class ServiceStorageConfigSection extends ServiceConfigBaseSectionDisplay {
       }
 
       // Host
-      return [
-        {
-          heading: <Trans id={VolumeDefinitions.HOST.name} render="span" />,
-          headingLevel: 2
-        },
-        {
-          key: `container.volumes.${index}.hostPath`,
-          label: <Trans render="span">Host Path</Trans>
-        },
-        {
-          key: `container.volumes.${index}.containerPath`,
-          label: <Trans render="span">Container Path</Trans>
-        },
-        {
-          key: `container.volumes.${index}.mode`,
-          label: <Trans render="span">Mode</Trans>
-        }
-      ];
+      if (volume.hostPath) {
+        return [
+          {
+            heading: <Trans id={VolumeDefinitions.HOST.name} render="span" />,
+            headingLevel: 2
+          },
+          {
+            key: `container.volumes.${index}.hostPath`,
+            label: <Trans render="span">Host Path</Trans>
+          },
+          {
+            key: `container.volumes.${index}.containerPath`,
+            label: <Trans render="span">Container Path</Trans>
+          },
+          {
+            key: `container.volumes.${index}.mode`,
+            label: <Trans render="span">Mode</Trans>
+          }
+        ];
+      }
+
+      return null;
     });
 
-    config.values = config.values.concat(...volumesConfig);
+    config.values = config.values.concat(...volumesConfig.filter(v => v));
 
     return config;
   }


### PR DESCRIPTION
Closes DCOS-53645

On the services review screen, secret volume mounts show up as unknown volumes. These should be omitted from the display.

https://github.com/mesosphere/dcos-ui-plugins-private/pull/1019 adds the ability to review file and env secrets 

## Screenshots

Before:
![Screen Shot 2019-05-23 at 11 18 29 AM](https://user-images.githubusercontent.com/174332/58272793-855d9500-7d4c-11e9-866b-28b97e8ab12f.png)

After:
![Screen Shot 2019-05-23 at 11 16 11 AM](https://user-images.githubusercontent.com/174332/58272801-8abadf80-7d4c-11e9-8cab-83b866a47e7a.png)

## Testing

Add some volumes and some secrets exposed as files in pods or single containers. Verify only the secret volumes are omitted.