### PR TITLE
[1.13] fix: adapt task id for 1.12

### DIFF
--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -268,8 +268,7 @@ class MesosStateStore extends GetSetBaseStore {
     return tasks
       .filter(
         task =>
-          task.isStartedByMarathon &&
-          task.id.startsWith(`${taskIdPrefix}.instance`)
+          task.isStartedByMarathon && task.id.startsWith(`${taskIdPrefix}.`)
       )
       .concat(serviceTasks)
       .map(task => MesosStateUtil.flagSDKTask(task, service));


### PR DESCRIPTION
marathon changed task name which break 1.13 UI on tasks that are started from 1.12 marathon

## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
