### PR TITLE
DCOS_OSS-4052: Add isDelayed method of Application and Pod

### DIFF
--- a/plugins/services/src/js/structs/Application.js
+++ b/plugins/services/src/js/structs/Application.js
@@ -1,4 +1,5 @@
 import { cleanServiceJSON } from "#SRC/js/utils/CleanJSONUtil";
+import { findNestedPropertyInObject } from "#SRC/js/utils/Util";
 
 import ApplicationSpec from "./ApplicationSpec";
 import FrameworkUtil from "../utils/FrameworkUtil";
@@ -218,5 +219,10 @@ module.exports = class Application extends Service {
 
   findTaskById(taskId) {
     return (this.get("tasks") || []).find(task => task.id === taskId);
+  }
+
+  isDelayed() {
+    const queue = this.getQueue();
+    return findNestedPropertyInObject(queue, "delay.overdue") === false;
   }
 };

--- a/plugins/services/src/js/structs/Pod.js
+++ b/plugins/services/src/js/structs/Pod.js
@@ -1,3 +1,5 @@
+import { findNestedPropertyInObject } from "#SRC/js/utils/Util";
+
 import HealthStatus from "../constants/HealthStatus";
 import PodInstanceList from "./PodInstanceList";
 import PodSpec from "./PodSpec";
@@ -236,5 +238,10 @@ module.exports = class Pod extends Service {
     }
 
     return this._regions;
+  }
+
+  isDelayed() {
+    const queue = this.getQueue();
+    return findNestedPropertyInObject(queue, "delay.overdue") === false;
   }
 };

--- a/plugins/services/src/js/structs/__tests__/Application-test.js
+++ b/plugins/services/src/js/structs/__tests__/Application-test.js
@@ -565,4 +565,37 @@ describe("Application", function() {
       expect(service.findTaskById("unknown")).toEqual(undefined);
     });
   });
+
+  describe("#isDelayed", function() {
+    it("return false when not delayed", function() {
+      const service = new Application({
+        queue: {
+          delay: {
+            overdue: true
+          }
+        }
+      });
+      expect(service.isDelayed()).toEqual(false);
+    });
+
+    it("return false when property is missing", function() {
+      const service = new Application({
+        queue: {
+          delay: {}
+        }
+      });
+      expect(service.isDelayed()).toEqual(false);
+    });
+
+    it("return true when delayed", function() {
+      const service = new Application({
+        queue: {
+          delay: {
+            overdue: false
+          }
+        }
+      });
+      expect(service.isDelayed()).toEqual(true);
+    });
+  });
 });

--- a/plugins/services/src/js/structs/__tests__/Pod-test.js
+++ b/plugins/services/src/js/structs/__tests__/Pod-test.js
@@ -494,4 +494,36 @@ describe("Pod", function() {
       ).toEqual(undefined);
     });
   });
+  describe("#isDelayed", function() {
+    it("return false when not delayed", function() {
+      const pod = new Pod({
+        queue: {
+          delay: {
+            overdue: true
+          }
+        }
+      });
+      expect(pod.isDelayed()).toEqual(false);
+    });
+
+    it("return false when property is missing", function() {
+      const pod = new Pod({
+        queue: {
+          delay: {}
+        }
+      });
+      expect(pod.isDelayed()).toEqual(false);
+    });
+
+    it("return true when delayed", function() {
+      const pod = new Pod({
+        queue: {
+          delay: {
+            overdue: false
+          }
+        }
+      });
+      expect(pod.isDelayed()).toEqual(true);
+    });
+  });
 });


### PR DESCRIPTION
Add isDelayed method to applications and pods
using the marathon endpoint.

Closes https://jira.mesosphere.com/browse/DCOS_OSS-4052

## Testing
1. In `dcos-ui/plugins/services/src/js/structs/Application.js` add `console.log(this.isDelayed())` in the `getName` method.
2. Start a service with normal resource requirements and when it is running, open it and verify that 'true' is shown in the console (because it is not delayed).
3. Start a service with huge resource requirements, open it and verify that `false` is shown in the console (because it is delayed).
Example JSON from the jira:
```
{
"id": "/delayed",
"backoffFactor": 10,
"backoffSeconds": 1,
"cmd": "exit 1",
"container": {
"type": "MESOS",
"volumes": []
},
"cpus": 0.1,
"disk": 0,
"instances": 10,
"maxLaunchDelaySeconds": 3600,
"mem": 10,
"gpus": 0,
"networks": [
{
"mode": "host"
}
],
"portDefinitions": [],
"requirePorts": false,
"upgradeStrategy": {
"maximumOverCapacity": 1,
"minimumHealthCapacity": 1
},
"killSelection": "YOUNGEST_FIRST",
"unreachableStrategy": {
"inactiveAfterSeconds": 0,
"expungeAfterSeconds": 0
},
"healthChecks": [],
"fetch": [],
"constraints": []
}
```
3.5 (Optional) Check the marathon UI `daily-cluster-url/service/marathon/ui/#/apps` to see that it is actually delayed.
4. In `dcos-ui/plugins/services/src/js/structs/Pod.js` add `console.log(this.isDelayed())` in the `getMesosId` method.
5. Start a pod with normal resource requirements and when it is running, open it and verify that 'true' is shown in the console (because it is not delayed).
6. Start a pod with huge resource requirements, open it and verify that `false` is shown in the console (because it is delayed).
Example JSON:
```
{
  "id": "/delayed-pod",
  "version": "2019-05-28T11:20:07.349Z",
  "containers": [
    {
      "name": "container-1",
      "resources": {
        "cpus": 0.1,
        "mem": 10,
        "disk": 0,
        "gpus": 0
      },
      "exec": {
        "command": {
          "shell": "exit 1"
        }
      }
    }
  ],
  "networks": [
    {
      "mode": "host"
    }
  ],
  "scaling": {
    "instances": 10,
    "kind": "fixed"
  },
  "scheduling": {
    "backoff": {
      "backoff": 1,
      "backoffFactor": 1.15,
      "maxLaunchDelay": 300
    },
    "upgrade": {
      "minimumHealthCapacity": 1,
      "maximumOverCapacity": 1
    },
    "killSelection": "YOUNGEST_FIRST",
    "unreachableStrategy": {
      "inactiveAfterSeconds": 0,
      "expungeAfterSeconds": 0
    },
    "placement": {
      "constraints": []
    }
  },
  "executorResources": {
    "cpus": 0.1,
    "mem": 32,
    "disk": 10
  },
  "volumes": [],
  "fetch": []
}
```
7. Verify that the added unit tests make sense.

## Trade-offs
The endpoint sometimes return null, I am not sure why.

## Dependencies
None.

## Screenshots
![Screenshot from 2019-05-27 11-00-17](https://user-images.githubusercontent.com/40791275/58404855-cae0d180-806e-11e9-938d-32cbee8552aa.png)
![Screenshot from 2019-05-27 11-01-18](https://user-images.githubusercontent.com/40791275/58404858-cd432b80-806e-11e9-8ddf-2bd8b6799047.png)

