### PR TITLE
DCOS_OSS-4053: Add Delayed Status to Service overview & Service Detail Breadcrumb

### DIFF
--- a/plugins/services/src/js/constants/ServiceStatus.ts
+++ b/plugins/services/src/js/constants/ServiceStatus.ts
@@ -160,7 +160,7 @@ function fromHttpCode(code: number): Status | null {
 }
 
 function showProgressBar(status: Status): boolean {
-  return [DEPLOYING, WAITING, DELAYED, RECOVERING, DELETING].includes(status);
+  return [DEPLOYING, WAITING, RECOVERING, DELETING].includes(status);
 }
 
 function toIcon(status: Status): StatusIcon | null {

--- a/plugins/services/src/js/structs/Application.js
+++ b/plugins/services/src/js/structs/Application.js
@@ -138,6 +138,10 @@ module.exports = class Application extends Service {
       return ServiceStatus.STOPPED;
     }
 
+    if (this.isDelayed()) {
+      return ServiceStatus.DELAYED;
+    }
+
     if (queue != null && (deployments == null || deployments.length < 1)) {
       return ServiceStatus.RECOVERING;
     }

--- a/plugins/services/src/js/structs/Pod.js
+++ b/plugins/services/src/js/structs/Pod.js
@@ -131,6 +131,10 @@ module.exports = class Pod extends Service {
       return ServiceStatus.STOPPED;
     }
 
+    if (this.isDelayed()) {
+      return ServiceStatus.DELAYED;
+    }
+
     if (scalingInstances !== nonterminalInstances) {
       return ServiceStatus.DEPLOYING;
     }

--- a/src/js/stores/__tests__/DCOSStore-test.js
+++ b/src/js/stores/__tests__/DCOSStore-test.js
@@ -336,7 +336,7 @@ describe("DCOSStore", function() {
       ]);
 
       expect(DCOSStore.serviceTree.getItems()[0].getStatus()).toEqual(
-        "Recovering"
+        "Delayed"
       );
     });
 

--- a/src/styles/components/service-table/styles.less
+++ b/src/styles/components/service-table/styles.less
@@ -44,7 +44,7 @@
     }
 
     .service-status-icon-wrapper {
-      width: 110px;
+      min-width: 110px;
     }
 
     .service-status-progressbar-wrapper {

--- a/tests/_fixtures/marathon-1-pod-group/groups-delayed.json
+++ b/tests/_fixtures/marathon-1-pod-group/groups-delayed.json
@@ -1,0 +1,759 @@
+{
+  "id": "/",
+  "dependencies": [
+
+  ],
+  "version": "2017-04-21T00:23:50.363Z",
+  "apps": [
+
+  ],
+  "groups": [
+
+  ],
+  "pods": [
+    {
+      "id": "/podses",
+      "spec": {
+        "id": "/podses",
+        "labels": {
+
+        },
+        "version": "2017-04-20T22:04:18.48Z",
+        "environment": {
+
+        },
+        "containers": [
+          {
+            "name": "container-1",
+            "resources": {
+              "cpus": 0.001,
+              "mem": 0.001,
+              "disk": 0,
+              "gpus": 0
+            },
+            "endpoints": [
+
+            ],
+            "image": {
+              "kind": "DOCKER",
+              "id": "redis"
+            },
+            "environment": {
+
+            },
+            "volumeMounts": [
+
+            ],
+            "artifacts": [
+
+            ],
+            "labels": {
+
+            }
+          },
+          {
+            "name": "container-2",
+            "resources": {
+              "cpus": 0.001,
+              "mem": 0.001,
+              "disk": 0,
+              "gpus": 0
+            },
+            "endpoints": [
+
+            ],
+            "image": {
+              "kind": "DOCKER",
+              "id": "nginx"
+            },
+            "environment": {
+
+            },
+            "volumeMounts": [
+
+            ],
+            "artifacts": [
+
+            ],
+            "labels": {
+
+            }
+          }
+        ],
+        "secrets": {
+
+        },
+        "volumes": [
+
+        ],
+        "networks": [
+          {
+            "mode": "host",
+            "labels": {
+
+            }
+          }
+        ],
+        "scaling": {
+          "kind": "fixed",
+          "instances": 1
+        },
+        "scheduling": {
+          "backoff": {
+            "backoff": 1,
+            "backoffFactor": 1.15,
+            "maxLaunchDelay": 3600
+          },
+          "upgrade": {
+            "minimumHealthCapacity": 1,
+            "maximumOverCapacity": 1
+          },
+          "placement": {
+            "constraints": [
+
+            ],
+            "acceptedResourceRoles": [
+
+            ]
+          },
+          "killSelection": "YOUNGEST_FIRST",
+          "unreachableStrategy": {
+            "inactiveAfterSeconds": 300,
+            "expungeAfterSeconds": 600
+          }
+        },
+        "executorResources": {
+          "cpus": 0.1,
+          "mem": 32,
+          "disk": 10
+        }
+      },
+      "status": "STABLE",
+      "statusSince": "2017-04-20T22:06:33.371Z",
+      "instances": [
+        {
+          "id": "podses.instance-4cf25ccd-2615-11e7-9101-763097586b99",
+          "status": "STABLE",
+          "statusSince": "2017-04-20T22:06:33.371Z",
+          "conditions": [
+
+          ],
+          "agentHostname": "10.0.0.67",
+          "resources": {
+            "cpus": 0.10200000000000001,
+            "mem": 32.001999999999995,
+            "disk": 10,
+            "gpus": 0
+          },
+          "networks": [
+            {
+              "addresses": [
+                "10.0.0.67"
+              ]
+            }
+          ],
+          "agentId": "b3bd182c-c6d7-463e-8bf0-06cd5807df4e-S5",
+          "containers": [
+            {
+              "name": "container-1",
+              "status": "TASK_RUNNING",
+              "statusSince": "2017-04-20T22:06:33.37Z",
+              "conditions": [
+
+              ],
+              "containerId": "podses.instance-4cf25ccd-2615-11e7-9101-763097586b99.container-1",
+              "endpoints": [
+
+              ],
+              "resources": {
+                "cpus": 0.001,
+                "mem": 0.001,
+                "disk": 0,
+                "gpus": 0
+              },
+              "lastUpdated": "2017-04-20T22:06:33.37Z",
+              "lastChanged": "2017-04-20T22:06:33.37Z"
+            },
+            {
+              "name": "container-2",
+              "status": "TASK_RUNNING",
+              "statusSince": "2017-04-20T22:06:33.371Z",
+              "conditions": [
+
+              ],
+              "containerId": "podses.instance-4cf25ccd-2615-11e7-9101-763097586b99.container-2",
+              "endpoints": [
+
+              ],
+              "resources": {
+                "cpus": 0.001,
+                "mem": 0.001,
+                "disk": 0,
+                "gpus": 0
+              },
+              "lastUpdated": "2017-04-20T22:06:33.371Z",
+              "lastChanged": "2017-04-20T22:06:33.371Z"
+            }
+          ],
+          "specReference": "/v2/pods/podses::versions/2017-04-20T22:04:18.480Z",
+          "lastUpdated": "2017-04-20T22:06:33.371Z",
+          "lastChanged": "2017-04-20T22:06:33.371Z"
+        },
+        {
+          "id": "podses.instance-4cf25ccd-2615-11e7-9101-763097586b98",
+          "status": "STABLE",
+          "statusSince": "2017-04-20T22:06:33.371Z",
+          "conditions": [
+
+          ],
+          "agentHostname": "10.0.1.107",
+          "resources": {
+            "cpus": 0.10200000000000001,
+            "mem": 32.001999999999995,
+            "disk": 10,
+            "gpus": 0
+          },
+          "networks": [
+            {
+              "addresses": [
+                "10.0.1.107"
+              ]
+            }
+          ],
+          "agentId": "b3bd182c-c6d7-463e-8bf0-06cd5807df4e-S4",
+          "containers": [
+            {
+              "name": "container-1",
+              "status": "TASK_RUNNING",
+              "statusSince": "2017-04-20T22:06:33.37Z",
+              "conditions": [
+
+              ],
+              "containerId": "podses.instance-4cf25ccd-2615-11e7-9101-763097586b98.container-1",
+              "endpoints": [
+
+              ],
+              "resources": {
+                "cpus": 0.001,
+                "mem": 0.001,
+                "disk": 0,
+                "gpus": 0
+              },
+              "lastUpdated": "2017-04-20T22:06:33.37Z",
+              "lastChanged": "2017-04-20T22:06:33.37Z"
+            },
+            {
+              "name": "container-2",
+              "status": "TASK_RUNNING",
+              "statusSince": "2017-04-20T22:06:33.371Z",
+              "conditions": [
+
+              ],
+              "containerId": "podses.instance-4cf25ccd-2615-11e7-9101-763097586b98.container-2",
+              "endpoints": [
+
+              ],
+              "resources": {
+                "cpus": 0.001,
+                "mem": 0.001,
+                "disk": 0,
+                "gpus": 0
+              },
+              "lastUpdated": "2017-04-20T22:06:33.371Z",
+              "lastChanged": "2017-04-20T22:06:33.371Z"
+            }
+          ],
+          "specReference": "/v2/pods/podses::versions/2017-04-20T22:04:18.480Z",
+          "lastUpdated": "2017-04-20T22:06:33.371Z",
+          "lastChanged": "2017-04-20T22:06:33.371Z"
+        },
+        {
+          "id": "podses.instance-4cf25ccd-2615-11e7-9101-763097586b97",
+          "status": "STABLE",
+          "statusSince": "2017-04-20T22:06:33.371Z",
+          "conditions": [
+
+          ],
+          "agentHostname": "10.0.1.107",
+          "resources": {
+            "cpus": 0.10200000000000001,
+            "mem": 32.001999999999995,
+            "disk": 10,
+            "gpus": 0
+          },
+          "networks": [
+            {
+              "addresses": [
+                "10.0.1.107"
+              ]
+            }
+          ],
+          "agentId": "b3bd182c-c6d7-463e-8bf0-06cd5807df4e-S4",
+          "containers": [
+            {
+              "name": "container-1",
+              "status": "TASK_RUNNING",
+              "statusSince": "2017-04-20T22:06:33.37Z",
+              "conditions": [
+
+              ],
+              "containerId": "podses.instance-4cf25ccd-2615-11e7-9101-763097586b97.container-1",
+              "endpoints": [
+
+              ],
+              "resources": {
+                "cpus": 0.001,
+                "mem": 0.001,
+                "disk": 0,
+                "gpus": 0
+              },
+              "lastUpdated": "2017-04-20T22:06:33.37Z",
+              "lastChanged": "2017-04-20T22:06:33.37Z"
+            },
+            {
+              "name": "container-2",
+              "status": "TASK_RUNNING",
+              "statusSince": "2017-04-20T22:06:33.371Z",
+              "conditions": [
+
+              ],
+              "containerId": "podses.instance-4cf25ccd-2615-11e7-9101-763097586b97.container-2",
+              "endpoints": [
+
+              ],
+              "resources": {
+                "cpus": 0.001,
+                "mem": 0.001,
+                "disk": 0,
+                "gpus": 0
+              },
+              "lastUpdated": "2017-04-20T22:06:33.371Z",
+              "lastChanged": "2017-04-20T22:06:33.371Z"
+            }
+          ],
+          "specReference": "/v2/pods/podses::versions/2017-04-20T22:04:18.480Z",
+          "lastUpdated": "2017-04-20T22:06:33.371Z",
+          "lastChanged": "2017-04-20T22:06:33.371Z"
+        },
+        {
+          "id": "podses.instance-4cf25ccd-2615-11e7-9101-763097586b96",
+          "status": "STABLE",
+          "statusSince": "2017-04-20T22:06:33.371Z",
+          "conditions": [
+
+          ],
+          "agentHostname": "10.0.1.111",
+          "resources": {
+            "cpus": 0.10200000000000001,
+            "mem": 32.001999999999995,
+            "disk": 10,
+            "gpus": 0
+          },
+          "networks": [
+            {
+              "addresses": [
+                "10.0.1.111"
+              ]
+            }
+          ],
+          "agentId": "b3bd182c-c6d7-463e-8bf0-06cd5807df4e-S3",
+          "containers": [
+            {
+              "name": "container-1",
+              "status": "TASK_RUNNING",
+              "statusSince": "2017-04-20T22:06:33.37Z",
+              "conditions": [
+
+              ],
+              "containerId": "podses.instance-4cf25ccd-2615-11e7-9101-763097586b96.container-1",
+              "endpoints": [
+
+              ],
+              "resources": {
+                "cpus": 0.001,
+                "mem": 0.001,
+                "disk": 0,
+                "gpus": 0
+              },
+              "lastUpdated": "2017-04-20T22:06:33.37Z",
+              "lastChanged": "2017-04-20T22:06:33.37Z"
+            },
+            {
+              "name": "container-2",
+              "status": "TASK_RUNNING",
+              "statusSince": "2017-04-20T22:06:33.371Z",
+              "conditions": [
+
+              ],
+              "containerId": "podses.instance-4cf25ccd-2615-11e7-9101-763097586b96.container-2",
+              "endpoints": [
+
+              ],
+              "resources": {
+                "cpus": 0.001,
+                "mem": 0.001,
+                "disk": 0,
+                "gpus": 0
+              },
+              "lastUpdated": "2017-04-20T22:06:33.371Z",
+              "lastChanged": "2017-04-20T22:06:33.371Z"
+            }
+          ],
+          "specReference": "/v2/pods/podses::versions/2017-04-20T22:04:18.480Z",
+          "lastUpdated": "2017-04-20T22:06:33.371Z",
+          "lastChanged": "2017-04-20T22:06:33.371Z"
+        },
+        {
+          "id": "podses.instance-4cf25ccd-2615-11e7-9101-763097586b95",
+          "status": "STABLE",
+          "statusSince": "2017-04-20T22:06:33.371Z",
+          "conditions": [
+
+          ],
+          "agentHostname": "10.0.1.109",
+          "resources": {
+            "cpus": 0.10200000000000001,
+            "mem": 32.001999999999995,
+            "disk": 10,
+            "gpus": 0
+          },
+          "networks": [
+            {
+              "addresses": [
+                "10.0.1.109"
+              ]
+            }
+          ],
+          "agentId": "b3bd182c-c6d7-463e-8bf0-06cd5807df4e-S2",
+          "containers": [
+            {
+              "name": "container-1",
+              "status": "TASK_RUNNING",
+              "statusSince": "2017-04-20T22:06:33.37Z",
+              "conditions": [
+
+              ],
+              "containerId": "podses.instance-4cf25ccd-2615-11e7-9101-763097586b95.container-1",
+              "endpoints": [
+
+              ],
+              "resources": {
+                "cpus": 0.001,
+                "mem": 0.001,
+                "disk": 0,
+                "gpus": 0
+              },
+              "lastUpdated": "2017-04-20T22:06:33.37Z",
+              "lastChanged": "2017-04-20T22:06:33.37Z"
+            },
+            {
+              "name": "container-2",
+              "status": "TASK_RUNNING",
+              "statusSince": "2017-04-20T22:06:33.371Z",
+              "conditions": [
+
+              ],
+              "containerId": "podses.instance-4cf25ccd-2615-11e7-9101-763097586b95.container-2",
+              "endpoints": [
+
+              ],
+              "resources": {
+                "cpus": 0.001,
+                "mem": 0.001,
+                "disk": 0,
+                "gpus": 0
+              },
+              "lastUpdated": "2017-04-20T22:06:33.371Z",
+              "lastChanged": "2017-04-20T22:06:33.371Z"
+            }
+          ],
+          "specReference": "/v2/pods/podses::versions/2017-04-20T22:04:18.480Z",
+          "lastUpdated": "2017-04-20T22:06:33.371Z",
+          "lastChanged": "2017-04-20T22:06:33.371Z"
+        },
+        {
+          "id": "podses.instance-4cf25ccd-2615-11e7-9101-763097586b94",
+          "status": "STABLE",
+          "statusSince": "2017-04-20T22:06:33.371Z",
+          "conditions": [
+
+          ],
+          "agentHostname": "10.0.5.136",
+          "resources": {
+            "cpus": 0.10200000000000001,
+            "mem": 32.001999999999995,
+            "disk": 10,
+            "gpus": 0
+          },
+          "networks": [
+            {
+              "addresses": [
+                "10.0.5.136"
+              ]
+            }
+          ],
+          "agentId": "b3bd182c-c6d7-463e-8bf0-06cd5807df4e-S1",
+          "containers": [
+            {
+              "name": "container-1",
+              "status": "TASK_RUNNING",
+              "statusSince": "2017-04-20T22:06:33.37Z",
+              "conditions": [
+
+              ],
+              "containerId": "podses.instance-4cf25ccd-2615-11e7-9101-763097586b94.container-1",
+              "endpoints": [
+
+              ],
+              "resources": {
+                "cpus": 0.001,
+                "mem": 0.001,
+                "disk": 0,
+                "gpus": 0
+              },
+              "lastUpdated": "2017-04-20T22:06:33.37Z",
+              "lastChanged": "2017-04-20T22:06:33.37Z"
+            },
+            {
+              "name": "container-2",
+              "status": "TASK_RUNNING",
+              "statusSince": "2017-04-20T22:06:33.371Z",
+              "conditions": [
+
+              ],
+              "containerId": "podses.instance-4cf25ccd-2615-11e7-9101-763097586b94.container-2",
+              "endpoints": [
+
+              ],
+              "resources": {
+                "cpus": 0.001,
+                "mem": 0.001,
+                "disk": 0,
+                "gpus": 0
+              },
+              "lastUpdated": "2017-04-20T22:06:33.371Z",
+              "lastChanged": "2017-04-20T22:06:33.371Z"
+            }
+          ],
+          "specReference": "/v2/pods/podses::versions/2017-04-20T22:04:18.480Z",
+          "lastUpdated": "2017-04-20T22:06:33.371Z",
+          "lastChanged": "2017-04-20T22:06:33.371Z"
+        },
+        {
+          "id": "podses.instance-4cf25ccd-2615-11e7-9101-763097586b93",
+          "status": "STABLE",
+          "statusSince": "2017-04-20T22:06:33.371Z",
+          "conditions": [
+
+          ],
+          "agentHostname": "10.0.5.136",
+          "resources": {
+            "cpus": 0.10200000000000001,
+            "mem": 32.001999999999995,
+            "disk": 10,
+            "gpus": 0
+          },
+          "networks": [
+            {
+              "addresses": [
+                "10.0.5.136"
+              ]
+            }
+          ],
+          "agentId": "b3bd182c-c6d7-463e-8bf0-06cd5807df4e-S0",
+          "containers": [
+            {
+              "name": "container-1",
+              "status": "TASK_RUNNING",
+              "statusSince": "2017-04-20T22:06:33.37Z",
+              "conditions": [
+
+              ],
+              "containerId": "podses.instance-4cf25ccd-2615-11e7-9101-763097586b93.container-1",
+              "endpoints": [
+
+              ],
+              "resources": {
+                "cpus": 0.001,
+                "mem": 0.001,
+                "disk": 0,
+                "gpus": 0
+              },
+              "lastUpdated": "2017-04-20T22:06:33.37Z",
+              "lastChanged": "2017-04-20T22:06:33.37Z"
+            },
+            {
+              "name": "container-2",
+              "status": "TASK_RUNNING",
+              "statusSince": "2017-04-20T22:06:33.371Z",
+              "conditions": [
+
+              ],
+              "containerId": "podses.instance-4cf25ccd-2615-11e7-9101-763097586b93.container-2",
+              "endpoints": [
+
+              ],
+              "resources": {
+                "cpus": 0.001,
+                "mem": 0.001,
+                "disk": 0,
+                "gpus": 0
+              },
+              "lastUpdated": "2017-04-20T22:06:33.371Z",
+              "lastChanged": "2017-04-20T22:06:33.371Z"
+            }
+          ],
+          "specReference": "/v2/pods/podses::versions/2017-04-20T22:04:18.480Z",
+          "lastUpdated": "2017-04-20T22:06:33.371Z",
+          "lastChanged": "2017-04-20T22:06:33.371Z"
+        },
+        {
+          "id": "podses.instance-4cf25ccd-2615-11e7-9101-763097586b92",
+          "status": "STABLE",
+          "statusSince": "2017-04-20T22:06:33.371Z",
+          "conditions": [
+
+          ],
+          "agentHostname": "10.0.1.110",
+          "resources": {
+            "cpus": 0.10200000000000001,
+            "mem": 32.001999999999995,
+            "disk": 10,
+            "gpus": 0
+          },
+          "networks": [
+            {
+              "addresses": [
+                "10.0.1.110"
+              ]
+            }
+          ],
+          "agentId": "b3bd182c-c6d7-463e-8bf0-06cd5807df4e-S0",
+          "containers": [
+            {
+              "name": "container-1",
+              "status": "TASK_RUNNING",
+              "statusSince": "2017-04-20T22:06:33.37Z",
+              "conditions": [
+
+              ],
+              "containerId": "podses.instance-4cf25ccd-2615-11e7-9101-763097586b92.container-1",
+              "endpoints": [
+
+              ],
+              "resources": {
+                "cpus": 0.001,
+                "mem": 0.001,
+                "disk": 0,
+                "gpus": 0
+              },
+              "lastUpdated": "2017-04-20T22:06:33.37Z",
+              "lastChanged": "2017-04-20T22:06:33.37Z"
+            },
+            {
+              "name": "container-2",
+              "status": "TASK_RUNNING",
+              "statusSince": "2017-04-20T22:06:33.371Z",
+              "conditions": [
+
+              ],
+              "containerId": "podses.instance-4cf25ccd-2615-11e7-9101-763097586b92.container-2",
+              "endpoints": [
+
+              ],
+              "resources": {
+                "cpus": 0.001,
+                "mem": 0.001,
+                "disk": 0,
+                "gpus": 0
+              },
+              "lastUpdated": "2017-04-20T22:06:33.371Z",
+              "lastChanged": "2017-04-20T22:06:33.371Z"
+            }
+          ],
+          "specReference": "/v2/pods/podses::versions/2017-04-20T22:04:18.480Z",
+          "lastUpdated": "2017-04-20T22:06:33.371Z",
+          "lastChanged": "2017-04-20T22:06:33.371Z"
+        },
+        {
+          "id": "podses.instance-4cf25ccd-2615-11e7-9101-763097586b90",
+          "status": "STABLE",
+          "statusSince": "2017-04-20T22:06:33.371Z",
+          "conditions": [
+
+          ],
+          "agentHostname": "10.0.5.136",
+          "resources": {
+            "cpus": 0.10200000000000001,
+            "mem": 32.001999999999995,
+            "disk": 10,
+            "gpus": 0
+          },
+          "networks": [
+            {
+              "addresses": [
+                "10.0.5.136"
+              ]
+            }
+          ],
+          "agentId": "b3bd182c-c6d7-463e-8bf0-06cd5807df4e-S1",
+          "containers": [
+            {
+              "name": "container-1",
+              "status": "TASK_RUNNING",
+              "statusSince": "2017-04-20T22:06:33.37Z",
+              "conditions": [
+
+              ],
+              "containerId": "podses.instance-4cf25ccd-2615-11e7-9101-763097586b90.container-1",
+              "endpoints": [
+
+              ],
+              "resources": {
+                "cpus": 0.001,
+                "mem": 0.001,
+                "disk": 0,
+                "gpus": 0
+              },
+              "lastUpdated": "2017-04-20T22:06:33.37Z",
+              "lastChanged": "2017-04-20T22:06:33.37Z"
+            },
+            {
+              "name": "container-2",
+              "status": "TASK_RUNNING",
+              "statusSince": "2017-04-20T22:06:33.371Z",
+              "conditions": [
+
+              ],
+              "containerId": "podses.instance-4cf25ccd-2615-11e7-9101-763097586b90.container-2",
+              "endpoints": [
+
+              ],
+              "resources": {
+                "cpus": 0.001,
+                "mem": 0.001,
+                "disk": 0,
+                "gpus": 0
+              },
+              "lastUpdated": "2017-04-20T22:06:33.371Z",
+              "lastChanged": "2017-04-20T22:06:33.371Z"
+            }
+          ],
+          "specReference": "/v2/pods/podses::versions/2017-04-20T22:04:18.480Z",
+          "lastUpdated": "2017-04-20T22:06:33.371Z",
+          "lastChanged": "2017-04-20T22:06:33.371Z"
+        }
+      ],
+      "terminationHistory": [
+
+      ],
+      "queue": {
+        "delay": {
+          "overdue": false
+        }
+      },
+      "lastUpdated": "2017-04-21T00:53:27.51Z",
+      "lastChanged": "2017-04-20T22:06:33.371Z"
+    }
+  ]
+}

--- a/tests/_fixtures/marathon-1-task/delayed/queue.json
+++ b/tests/_fixtures/marathon-1-task/delayed/queue.json
@@ -1,0 +1,204 @@
+{
+  "queue": [
+      {
+          "app": {
+              "id": "/sleep",
+              "user": "root",
+              "env": {
+                  "MASTER": "zk://172.16.0.12:2181,172.16.0.13:2181,172.16.0.14:2181/mesos"
+              },
+              "instances": 1,
+              "cpus": 0.5,
+              "mem": 128,
+              "disk": 0,
+              "executor": "//cmd",
+              "constraints": [
+                  [
+                      "hostname",
+                      "UNIQUE"
+                  ]
+              ],
+              "uris": [
+                  "http://www.mesosphere.io/index.html"
+              ],
+              "ports": [
+                  10010
+              ],
+              "requirePorts": false,
+              "backoffSeconds": 1,
+              "backoffFactor": 1.15,
+              "maxLaunchDelaySeconds": 3600,
+              "container": {
+                  "type": "DOCKER",
+                  "docker": {
+                      "image": "thomasr/dispatch",
+                      "network": "HOST",
+                      "privileged": false,
+                      "forcePullImage": false
+                  }
+              },
+              "upgradeStrategy": {
+                  "minimumHealthCapacity": 1,
+                  "maximumOverCapacity": 1
+              },
+              "version": "2015-09-30T09:09:17.614Z",
+              "versionInfo": {
+                  "lastScalingAt": "2015-09-30T09:09:17.614Z",
+                  "lastConfigChangeAt": "2015-09-30T09:09:17.614Z"
+              }
+          },
+          "count": 2,
+          "delay": {
+              "timeLeftSeconds": 0,
+              "overdue": false
+          },
+          "since": "2016-02-28T16:41:41.090Z",
+          "processedOffersSummary": {
+              "processedOffersCount": 123,
+              "unusedOffersCount": 123,
+              "lastUnusedOfferAt": "2016-02-28T16:41:41.090Z",
+              "lastUsedOfferAt": "2016-02-28T16:41:41.090Z",
+              "rejectSummaryLastOffers": [
+                  {
+                      "reason": "UnfulfilledRole",
+                      "declined": 0,
+                      "processed": 123
+                  },
+                  {
+                      "reason": "UnfulfilledConstraint",
+                      "declined": 0,
+                      "processed": 123
+                  },
+                  {
+                      "reason": "NoCorrespondingReservationFound",
+                      "declined": 0,
+                      "processed": 123
+                  },
+                  {
+                      "reason": "InsufficientCpus",
+                      "declined": 75,
+                      "processed": 123
+                  },
+                  {
+                      "reason": "InsufficientMemory",
+                      "declined": 15,
+                      "processed": 48
+                  },
+                  {
+                      "reason": "InsufficientDisk",
+                      "declined": 10,
+                      "processed": 33
+                  },
+                  {
+                      "reason": "InsufficientGpus",
+                      "declined": 0,
+                      "processed": 23
+                  },
+                  {
+                      "reason": "InsufficientGpus",
+                      "declined": 0,
+                      "processed": 23
+                  },
+                  {
+                      "reason": "InsufficientPorts",
+                      "declined": 0,
+                      "processed": 46
+                  }
+              ],
+              "rejectSummaryLaunchAttempt": [
+                  {
+                      "reason": "UnfulfilledRole",
+                      "declined": 0,
+                      "processed": 246
+                  },
+                  {
+                      "reason": "UnfulfilledConstraint",
+                      "declined": 0,
+                      "processed": 246
+                  },
+                  {
+                      "reason": "NoCorrespondingReservationFound",
+                      "declined": 0,
+                      "processed": 246
+                  },
+                  {
+                      "reason": "InsufficientCpus",
+                      "declined": 150,
+                      "processed": 246
+                  },
+                  {
+                      "reason": "InsufficientMemory",
+                      "declined": 30,
+                      "processed": 96
+                  },
+                  {
+                      "reason": "InsufficientDisk",
+                      "declined": 20,
+                      "processed": 66
+                  },
+                  {
+                      "reason": "InsufficientGpus",
+                      "declined": 0,
+                      "processed": 46
+                  },
+                  {
+                      "reason": "InsufficientGpus",
+                      "declined": 0,
+                      "processed": 46
+                  },
+                  {
+                      "reason": "InsufficientPorts",
+                      "declined": 0,
+                      "processed": 46
+                  }
+              ]
+          },
+          "lastUnusedOffers": [
+              {
+                  "offer": {
+                      "id": "offer_123",
+                      "agentId": "slave_123",
+                      "hostname": "1.2.3.4",
+                      "resources": [
+                          {
+                              "name": "cpus",
+                              "scalar": 23,
+                              "ranges": [
+                                  {
+                                      "begin": 1,
+                                      "end": 5
+                                  }
+                              ],
+                              "set": [
+                                  "a",
+                                  "b"
+                              ],
+                              "role": "*"
+                          }
+                      ],
+                      "attributes": [
+                          {
+                              "name": "foo",
+                              "scalar": 23,
+                              "ranges": [
+                                  {
+                                      "begin": 1,
+                                      "end": 5
+                                  }
+                              ],
+                              "set": [
+                                  "a",
+                                  "b"
+                              ]
+                          }
+                      ]
+                  },
+                  "timestamp": "2016-02-28T16:41:41.090Z",
+                  "reason": [
+                      "InsufficientMemory"
+                  ]
+              }
+          ]
+      }
+  ]
+}

--- a/tests/_support/index.js
+++ b/tests/_support/index.js
@@ -108,11 +108,27 @@ Cypress.Commands.add("configureCluster", function(configuration) {
     }
   }
 
-  if (configuration.mesos === "1-pod") {
+  if (
+    configuration.mesos === "1-pod" ||
+    configuration.mesos === "1-pod-delayed"
+  ) {
     router
       .route(/history\/last/, "fx:marathon-1-pod-group/summary")
-      .route(/state-summary/, "fx:marathon-1-pod-group/summary")
-      .route(/service\/marathon\/v2\/groups/, "fx:marathon-1-pod-group/groups");
+      .route(/state-summary/, "fx:marathon-1-pod-group/summary");
+
+    if (configuration.mesos === "1-pod") {
+      router.route(
+        /service\/marathon\/v2\/groups/,
+        "fx:marathon-1-pod-group/groups"
+      );
+    }
+
+    if (configuration.mesos === "1-pod-delayed") {
+      router.route(
+        /service\/marathon\/v2\/groups/,
+        "fx:marathon-1-pod-group/groups-delayed"
+      );
+    }
   }
 
   if (configuration.mesos === "1-pod-delayed") {
@@ -317,7 +333,10 @@ Cypress.Commands.add("configureCluster", function(configuration) {
       .route(/state-summary/, "fx:marathon-1-task/summary");
   }
 
-  if (configuration.mesos === "1-service-recovering") {
+  if (
+    configuration.mesos === "1-service-recovering" ||
+    configuration.mesos === "1-service-delayed"
+  ) {
     router
       .route(/service\/marathon\/v2\/apps/, "fx:marathon-1-task/recovering/app")
       .route(
@@ -328,10 +347,37 @@ Cypress.Commands.add("configureCluster", function(configuration) {
         /service\/marathon\/v2\/deployments/,
         "fx:marathon-1-task/recovering/deployments"
       )
-      .route(
+      .route(/history\/minute/, "fx:marathon-1-task/history-minute")
+      .route(/history\/last/, "fx:marathon-1-task/summary")
+      .route(/state-summary/, "fx:marathon-1-task/summary");
+
+    if (configuration.mesos === "1-service-recovering") {
+      router.route(
         /service\/marathon\/v2\/queue/,
         "fx:marathon-1-task/recovering/queue"
+      );
+    }
+
+    if (configuration.mesos === "1-service-delayed") {
+      router.route(
+        /service\/marathon\/v2\/queue/,
+        "fx:marathon-1-task/delayed/queue"
+      );
+    }
+  }
+
+  if (configuration.mesos === "1-service-delayed") {
+    router
+      .route(/service\/marathon\/v2\/apps/, "fx:marathon-1-task/recovering/app")
+      .route(
+        /service\/marathon\/v2\/groups/,
+        "fx:marathon-1-task/recovering/groups"
       )
+      .route(
+        /service\/marathon\/v2\/deployments/,
+        "fx:marathon-1-task/recovering/deployments"
+      )
+      .route(/service\/marathon\/v2\/queue/, "fx:marathon-1-task/delayed/queue")
       .route(/history\/minute/, "fx:marathon-1-task/history-minute")
       .route(/history\/last/, "fx:marathon-1-task/summary")
       .route(/state-summary/, "fx:marathon-1-task/summary");

--- a/tests/pages/services/ServiceTable-cy.js
+++ b/tests/pages/services/ServiceTable-cy.js
@@ -22,6 +22,40 @@ describe("Service Table", function() {
       .click();
   }
 
+  context("Service status", function() {
+    it("shows correct status and icon for a delayed service", function() {
+      cy.configureCluster({
+        mesos: "1-service-delayed",
+        nodeHealth: true
+      });
+
+      cy.visitUrl({ url: "/services/overview" });
+
+      cy.get(".service-status-icon-wrapper")
+        .contains("Delayed")
+        .should("exist"); // Text
+      cy.get(".service-status-icon-wrapper")
+        .find('svg[aria-label="system-yield icon"]')
+        .should("exist"); // Icon
+    });
+
+    it("shows correct status and icon for a delayed pod", function() {
+      cy.configureCluster({
+        mesos: "1-pod-delayed",
+        nodeHealth: true
+      });
+
+      cy.visitUrl({ url: "/services/overview" });
+
+      cy.get(".service-status-icon-wrapper")
+        .contains("Delayed")
+        .should("exist"); // Text
+      cy.get(".service-status-icon-wrapper")
+        .find('svg[aria-label="system-yield icon"]')
+        .should("exist"); // Icon
+    });
+  });
+
   context("Destroy Action", function() {
     beforeEach(function() {
       cy.configureCluster({


### PR DESCRIPTION
Add delayed status to service overview.

Closes https://jira.mesosphere.com/browse/DCOS_OSS-4053

## Testing
1. Start a service with very large resource requirements.
Example JSON from the jira:
```
{
"id": "/delayed",
"backoffFactor": 10,
"backoffSeconds": 1,
"cmd": "exit 1",
"container": {
"type": "MESOS",
"volumes": []
},
"cpus": 0.1,
"disk": 0,
"instances": 10,
"maxLaunchDelaySeconds": 3600,
"mem": 10,
"gpus": 0,
"networks": [
{
"mode": "host"
}
],
"portDefinitions": [],
"requirePorts": false,
"upgradeStrategy": {
"maximumOverCapacity": 1,
"minimumHealthCapacity": 1
},
"killSelection": "YOUNGEST_FIRST",
"unreachableStrategy": {
"inactiveAfterSeconds": 0,
"expungeAfterSeconds": 0
},
"healthChecks": [],
"fetch": [],
"constraints": []
}
```
1.5 (Optional) Check the marathon UI `daily-cluster-url/service/marathon/ui/#/apps` to see if that is actually delayed.
2. In the service table, verify that its status is shown as "Delayed".
3. Verify the same thing for pods.
Example JSON:
```
{
  "id": "/delayed-pod",
  "version": "2019-05-28T11:20:07.349Z",
  "containers": [
    {
      "name": "container-1",
      "resources": {
        "cpus": 0.1,
        "mem": 10,
        "disk": 0,
        "gpus": 0
      },
      "exec": {
        "command": {
          "shell": "exit 1"
        }
      }
    }
  ],
  "networks": [
    {
      "mode": "host"
    }
  ],
  "scaling": {
    "instances": 10,
    "kind": "fixed"
  },
  "scheduling": {
    "backoff": {
      "backoff": 1,
      "backoffFactor": 1.15,
      "maxLaunchDelay": 300
    },
    "upgrade": {
      "minimumHealthCapacity": 1,
      "maximumOverCapacity": 1
    },
    "killSelection": "YOUNGEST_FIRST",
    "unreachableStrategy": {
      "inactiveAfterSeconds": 0,
      "expungeAfterSeconds": 0
    },
    "placement": {
      "constraints": []
    }
  },
  "executorResources": {
    "cpus": 0.1,
    "mem": 32,
    "disk": 10
  },
  "volumes": [],
  "fetch": []
}
```
4. Verify that the added tests make sense.

## Trade-offs
None.

## Dependencies
https://github.com/dcos/dcos-ui/pull/3910

## Screenshots
### Before
![Screenshot from 2019-05-27 13-05-42](https://user-images.githubusercontent.com/40791275/58416752-49e40300-808b-11e9-9372-cae0df4391ec.png)

### After
![Screenshot from 2019-05-28 11-26-18](https://user-images.githubusercontent.com/40791275/58462900-7c4d3900-813b-11e9-9d8d-5e68438764c0.png)
![Screenshot from 2019-05-28 11-35-03](https://user-images.githubusercontent.com/40791275/58463516-ace1a280-813c-11e9-8f35-6f3188ba5f3d.png)

