### PR TITLE
[1.13] DCOS-54491: Framework configuration form tab bug on Firefox <=63 on Windows/Linux

### DIFF
--- a/src/styles/components/menu-tabbed/styles.less
+++ b/src/styles/components/menu-tabbed/styles.less
@@ -11,11 +11,13 @@
   }
 
   .menu-tabbed-container-fixed {
+    // force the menu to it's own composite layer to fix a bug in
+    // Firefox 63 and below on Windows and Linux
+    transform: translateZ(0);
 
     .menu-tabbed-vertical {
       height: 100%;
       position: fixed;
-      top: 135px;
     }
   }
 


### PR DESCRIPTION
## Testing
1. Open Firefox version 63 or older on a Windows or Linux machine (if you need an invite to our BrowserStack account, ping me)
2. Go to the Catalog, pick a framework, and click "Review & Run" to open the framework configuration form

The tabs on the left should all be clickable

## Trade-offs
I wasn't able to find what exactly changed between 1.12 and 1.13 that surfaced this bug, so this is just a quick fix

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots
Before:
![FrameworkConfigFFTabFix_before](https://user-images.githubusercontent.com/2313998/58600349-51a1d400-8252-11e9-8b29-7ae94ffdca05.gif)


After:
![FrameworkConfigFFTabFix_after](https://user-images.githubusercontent.com/2313998/58600368-5d8d9600-8252-11e9-8160-c60dec5c2e97.gif)