### PR TITLE
DCOS-41120: don't show tooltip on services table region cell if it's "N/A"

### DIFF
--- a/plugins/services/src/js/columns/ServicesTableRegionColumn.tsx
+++ b/plugins/services/src/js/columns/ServicesTableRegionColumn.tsx
@@ -9,11 +9,17 @@ import Service from "../structs/Service";
 import ServiceTree from "../structs/ServiceTree";
 import { columnWidthsStorageKey } from "../containers/services/ServicesTable";
 
+const emptyRegionPlaceholder = "N/A";
+
 const ServiceRegion = React.memo(({ regions }: { regions: string }) => (
   <TextCell>
-    <Tooltip elementTag="span" wrapText={true} content={regions}>
-      {regions}
-    </Tooltip>
+    {regions === emptyRegionPlaceholder ? (
+      regions
+    ) : (
+      <Tooltip elementTag="span" wrapText={true} content={regions}>
+        {regions}
+      </Tooltip>
+    )}
   </TextCell>
 ));
 
@@ -26,7 +32,7 @@ export function regionRendererFactory(localRegion: string | undefined) {
     );
 
     if (regions.length === 0) {
-      regions.push("N/A");
+      regions.push(emptyRegionPlaceholder);
     }
 
     return <ServiceRegion regions={regions.join(", ")} />;


### PR DESCRIPTION
## Testing
1. Navigate to the Services table
2. If there aren't already any rows with "N/A" in the region column, add a group from the ellipsis button in the page header
3. Hover the "N/A" text in the region column

No tooltip should be shown

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots
Before:
![RegionTooltip-before](https://user-images.githubusercontent.com/2313998/59226500-1b911800-8ba1-11e9-9386-81e6ad5de1d2.gif)

After:
![RegionTooltip-after](https://user-images.githubusercontent.com/2313998/59226510-2186f900-8ba1-11e9-99cd-7cf7e5b1a134.gif)
