### PR TITLE
fix: improve error message for invalid env variable name

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -486,6 +486,7 @@
   "Must be specified when using the Docker Engine runtime": "",
   "Must be specified when using the Docker Engine runtime. You can change runtimes under \"Advanced Settings\"": "",
   "Must be unique": "",
+  "Must be valid": "",
   "Must contain a property that matches `||pattern||`": "",
   "Must contain at least one item": "",
   "Must contain at least ||value|| items in the array": "",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -486,6 +486,7 @@
   "Must be specified when using the Docker Engine runtime": "",
   "Must be specified when using the Docker Engine runtime. You can change runtimes under \"Advanced Settings\"": "",
   "Must be unique": "",
+  "Must be valid": "",
   "Must contain a property that matches `||pattern||`": "必须包含匹配 `||pattern||` 的属性",
   "Must contain at least one item": "",
   "Must contain at least ||value|| items in the array": "必须至少包含阵列中的 ||value|| 项",

--- a/plugins/services/src/js/constants/ServiceErrorMessages.js
+++ b/plugins/services/src/js/constants/ServiceErrorMessages.js
@@ -92,7 +92,12 @@ const ServiceErrorMessages = [
     )
   },
   {
-    path: /^environment\./,
+    path: /^environment\.[^.]+$/,
+    type: "GENERIC",
+    message: i18nMark("Must be valid")
+  },
+  {
+    path: /^environment\..*\./,
     type: "GENERIC",
     message: i18nMark("Must be defined")
   }


### PR DESCRIPTION
[DCOS-54437](https://jira.mesosphere.com/browse/DCOS-54437) was written as an error exposing a secret as an env variable for a pod, but when testing I found the provided env variable `1234` was not valid for Marathon. Updated ServiceErrorMessages to treat `evironment.[key]` error paths as an invalid environment variable name and not "must be defined"

## Testing

Define a pod or service with an invalid env variable name:
```json
{
  "environment": {
    "123": "TEST"
  },
  "id": "/",
  "containers": [
    {
      "name": "container-1",
      "resources": {
        "cpus": 0.1,
        "mem": 128
      },
      "exec": {
        "command": {
          "shell": "sleep 1000"
        }
      }
    }
  ],
  "scaling": {
    "instances": 1,
    "kind": "fixed"
  },
  "networks": [
    {
      "mode": "host"
    }
  ],
  "volumes": [],
  "fetch": [],
  "scheduling": {
    "placement": {
      "constraints": []
    }
  }
}
```
2. click review & run, and run service

3. Verify Error message is "Environment variables must be valid." and not "Environment variables must be defined."
## Trade-offs

I added a new entry with a different regex and made the existing error match `environment.[key].+` to retain any existing behavior, but we may just want to replace the existing error message of `Must be defined` with `Must be valid` I took a "safer" approach since I wasn't sure use case where we would get other `evironment.[key].[value]` error paths.

## Dependencies

n/a

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
<img width="984" alt="image" src="https://user-images.githubusercontent.com/1972968/59301302-e5ae6b00-8c56-11e9-96d4-bdc96471a989.png">

