### PR TITLE
feat: allow for link-tags in headings

### DIFF
--- a/src/js/components/SchemaField.js
+++ b/src/js/components/SchemaField.js
@@ -244,7 +244,7 @@ class SchemaField extends Component {
         {requiredSymbol}
         <FormGroupHeadingContent primary={false}>
           <Tooltip
-            content={description}
+            content={<div dangerouslySetInnerHTML={{ __html: description }} />}
             interactive={true}
             maxWidth={300}
             wrapText={true}


### PR DESCRIPTION
# ⚠️ 	do not merge

this commit has been created while trying to address an internal request
regarding links in form-headings.

the implementation certainly has implications regarding the security of our
website.
everyone with access to the schema definitions can now do evil things to a lot
of users.

⚠️ 	i just realized that in the other occurrences using `dangerouslySetInnerHTML` we pipe our stuff through a markdown-parser first. If we consider going this route that had to be implemented here as well.

here's a screenshot: 
<img width="1272" alt="OS Enterprise 2019-06-12 14-38-54" src="https://user-images.githubusercontent.com/300861/59352327-a5b3ba80-8d20-11e9-9f89-6b66a2444acf.png">
