### PR TITLE
DCOS-46214: Sorting in Active Deployments modal is broken

### DIFF
--- a/plugins/services/src/js/components/DeploymentsModal.js
+++ b/plugins/services/src/js/components/DeploymentsModal.js
@@ -25,6 +25,7 @@ import ServiceUtil from "#PLUGINS/services/src/js/utils/ServiceUtil";
 import ProgressBar from "#SRC/js/components/ProgressBar";
 import StringUtil from "#SRC/js/utils/StringUtil";
 import TimeAgo from "#SRC/js/components/TimeAgo";
+import TableUtil from "#SRC/js/utils/TableUtil";
 
 import defaultServiceImage from "../../img/icon-service-default-small@2x.png";
 import MarathonActions from "../events/MarathonActions";
@@ -37,7 +38,7 @@ const columnClasses = {
 };
 const columnHeadings = ResourceTableUtil.renderHeading({
   id: i18nMark("Affected Services"),
-  startTime: i18nMark("Started"),
+  version: i18nMark("Started"),
   status: i18nMark("Status"),
   action: null
 });
@@ -177,6 +178,10 @@ class DeploymentsModal extends mixin(StoreMixin) {
   }
 
   getColumns() {
+    const sortFunction = TableUtil.getSortFunction("id", function(item, prop) {
+      return item[prop];
+    });
+
     return [
       {
         className: columnClassNameGetter,
@@ -187,8 +192,10 @@ class DeploymentsModal extends mixin(StoreMixin) {
       {
         className: columnClassNameGetter,
         heading: columnHeadings,
-        prop: "startTime",
-        render: this.renderStartTime
+        prop: "version",
+        render: this.renderStartTime,
+        sortable: true,
+        sortFunction
       },
       {
         className: columnClassNameGetter,

--- a/tests/_fixtures/deployments/three-deployments.json
+++ b/tests/_fixtures/deployments/three-deployments.json
@@ -1,0 +1,107 @@
+[
+  {
+    "id": "b4f69082-6f96-4c92-a778-37bf61c59686",
+    "version": "2016-07-05T17:54:37.134Z",
+    "affectedApps": [
+      "/kafka"
+    ],
+    "steps": [
+      {
+        "actions": [
+          {
+            "action": "StartApplication",
+            "app": "/kafka"
+          }
+        ]
+      },
+      {
+        "actions": [
+          {
+            "action": "ScaleApplication",
+            "app": "/kafka"
+          }
+        ]
+      }
+    ],
+    "currentActions": [
+      {
+        "action": "ScaleApplication",
+        "app": "/kafka",
+        "readinessCheckResults": [
+          {
+            "name": "cassandraUpdateProgress",
+            "taskId": "kafka.8a29a459-42d9-11e6-b767-1ea433350c2b",
+            "ready": false,
+            "lastResponse": {
+              "status": 504,
+              "contentType": "text/plain",
+              "body": "Marathon could not query http://10.0.2.243:15790/v1/plan: Connection attempt to 10.0.2.243:15790 failed"
+            }
+          },
+          {
+            "name": "cassandraUpdateProgress",
+            "taskId": "kafka.93bd3c2b-42f2-11e6-b767-1ea433350c2b",
+            "ready": false,
+            "lastResponse": {
+              "status": 503,
+              "contentType": "application/json",
+              "body": "{\"phases\":[{\"id\":\"5f9c9c05-faff-45b1-aa57-4f4d0aada233\",\"name\":\"Reconciliation\",\"blocks\":[{\"id\":\"e91d36fd-4504-4e8e-8d96-fc22e5b7149f\",\"status\":\"Pending\",\"name\":\"Reconciliation\",\"message\":\"Reconciliation pending\",\"has_decision_point\":false}],\"status\":\"Pending\"},{\"id\":\"bd320876-6ece-4fb1-a506-7e3f4f34b62d\",\"name\":\"Update to: 1aee477f-7751-4a9a-a0dd-79948789ff76\",\"blocks\":[{\"id\":\"e9d11c20-fe67-4239-8c29-7447a73bd9a1\",\"status\":\"Pending\",\"name\":\"broker-0\",\"message\":\"Broker-0 is Pending\",\"has_decision_point\":false},{\"id\":\"7e97125f-5701-45f0-84d5-a079ea3faf28\",\"status\":\"Pending\",\"name\":\"broker-1\",\"message\":\"Broker-1 is Pending\",\"has_decision_point\":false},{\"id\":\"0aeb40d1-5c96-4362-9455-42a9b9f9915c\",\"status\":\"Pending\",\"name\":\"broker-2\",\"message\":\"Broker-2 is Pending\",\"has_decision_point\":false}],\"status\":\"Pending\"}],\"errors\":[],\"status\":\"Pending\"}"
+            }
+          }
+        ]
+      }
+    ],
+    "currentStep": 2,
+    "totalSteps": 2
+  },
+  {
+    "affectedApps": ["/spark/spark-history-stale"],
+    "affectedPods": [],
+    "currentActions": [
+      {
+        "action": "StopApplication",
+        "app": "/spark/spark-history-stale",
+        "readinessCheckResults": []
+      }
+    ],
+    "currentStep": 1,
+    "id": "staleId",
+    "steps": [
+      {
+        "actions": [
+          {
+            "action": "StopApplication",
+            "app": "/spark/spark-history-stale"
+          }
+        ]
+      }
+    ],
+    "totalSteps": 1,
+    "version": "2018-11-20T01:12:31.465Z"
+  },
+  {
+    "affectedApps": ["/spark/spark-history-stale"],
+    "affectedPods": [],
+    "currentActions": [
+      {
+        "action": "StopApplication",
+        "app": "/spark/spark-history-stale",
+        "readinessCheckResults": []
+      }
+    ],
+    "currentStep": 1,
+    "id": "staleId-2",
+    "steps": [
+      {
+        "actions": [
+          {
+            "action": "StopApplication",
+            "app": "/spark/spark-history-stale"
+          }
+        ]
+      }
+    ],
+    "totalSteps": 1,
+    "version": "2019-01-20T01:12:31.465Z"
+  }
+]

--- a/tests/pages/services/DeploymentsModal-cy.js
+++ b/tests/pages/services/DeploymentsModal-cy.js
@@ -182,4 +182,60 @@ describe("Deployments Modal", function() {
       cy.get(".deployments-table-column-status").contains("StopApplication");
     });
   });
+
+  context("Sorting", function() {
+    beforeEach(function() {
+      cy.server().route(
+        /marathon\/v2\/deployments/,
+        "fx:deployments/three-deployments"
+      );
+      openDeploymentsModal();
+    });
+
+    it("sorts by started", function() {
+      cy.get(".table-header-title")
+        .contains("Started")
+        .click();
+      cy.get(".caret--visible")
+        .prev()
+        .contains("Started")
+        .should("exist");
+
+      // First, second and third row.
+      cy.get("tbody")
+        .children()
+        .eq(0)
+        .contains("b4f69082-6f96-4c92-a778-37bf61c59686")
+        .should("exist"); // July 2016
+      cy.get("tbody")
+        .children()
+        .eq(1)
+        .contains("staleId")
+        .should("exist"); // November 2018
+      cy.get("tbody")
+        .children()
+        .eq(2)
+        .contains("staleId-2")
+        .should("exist"); // January 2019
+
+      cy.get(".table-header-title")
+        .contains("Started")
+        .click();
+      cy.get("tbody")
+        .children()
+        .eq(2)
+        .contains("b4f69082-6f96-4c92-a778-37bf61c59686")
+        .should("exist");
+      cy.get("tbody")
+        .children()
+        .eq(1)
+        .contains("staleId")
+        .should("exist");
+      cy.get("tbody")
+        .children()
+        .eq(0)
+        .contains("staleId-2")
+        .should("exist");
+    });
+  });
 });


### PR DESCRIPTION
Fix the sorting for time.

Closes DCOS-46214

## Testing
1. Go to services tab.
2. Add a few services that can't start (for example very high cpu or memory requirements) few minutes within each other.
3. Click the "active deployments" link in the top right corner of the Services tab.
4. Verify that sorting by start time works correctly.
5. Verify that the added tests make sense.

## Trade-offs
The caret is reversed for this column because we are sorting by time it was created but we are showing time passed. I felt like fixing this is out of scope here.

## Dependencies
None.

## Screenshots
### Before
![Peek 2019-06-14 14-19](https://user-images.githubusercontent.com/40791275/59513363-61145480-8ec3-11e9-9800-b8648317097b.gif)

### After
![Peek 2019-06-14 16-00](https://user-images.githubusercontent.com/40791275/59513370-640f4500-8ec3-11e9-9194-155e3d773167.gif)
