### PR TITLE
DCOS_OSS-1766: Service config page mislabels host ports in dcos-ui

### DIFF
--- a/plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js
@@ -120,9 +120,7 @@ class ServiceNetworkingConfigSection extends ServiceConfigBaseSectionDisplay {
                 prop: keys.port,
                 className: getColumnClassNameFn(),
                 render(prop, row) {
-                  return appDefinition.requirePorts
-                    ? getDisplayValue(row[prop])
-                    : "Auto Assigned";
+                  return getDisplayValue(row[prop]) || "Auto Assigned";
                 },
                 sortable: true
               },

--- a/tests/pages/services/ServiceReviewScreen-cy.js
+++ b/tests/pages/services/ServiceReviewScreen-cy.js
@@ -1498,7 +1498,7 @@ describe("Services", function() {
         .children("table")
         .getTableColumn("Host Port")
         .contents()
-        .should("deep.equal", ["Auto Assigned"]);
+        .should("deep.equal", ["—"]);
 
       cy.root()
         .configurationSection("Service Endpoints")
@@ -1695,7 +1695,7 @@ describe("Services", function() {
         .children("table")
         .getTableColumn("Host Port")
         .contents()
-        .should("deep.equal", ["Auto Assigned", "Auto Assigned"]);
+        .should("deep.equal", ["—", "4200"]);
 
       cy.root()
         .configurationSection("Service Endpoints")


### PR DESCRIPTION
Show host port for services when it is configured.

Closes https://jira.mesosphere.com/browse/DCOS_OSS-1766

## Testing
1. Start a service that has endpoints with manual host port.
Example JSON (from jira):
```
{
  "id": "/statsd-server",
  "container": {
    "portMappings": [
      {
        "containerPort": 80,
        "hostPort": 0,
        "labels": {
          "VIP_0": "/statsd-server:80"
        },
        "protocol": "tcp",
        "name": "nginx"
      },
      {
        "containerPort": 8125,
        "hostPort": 8125,
        "protocol": "udp",
        "name": "statsd"
      }
    ],
    "type": "MESOS",
    "docker": {
      "image": "hopsoft/graphite-statsd",
      "forcePullImage": false
    }
  },
  "cpus": 1,
  "instances": 1,
  "mem": 1024,
  "gpus": 0,
  "networks": [
    {
      "mode": "container/bridge"
    }
  ],
  "healthChecks": [
    {
      "portIndex": 0,
      "protocol": "MESOS_HTTP"
    }
  ]
}
```
2. In the review screen, verify that a manual host port is shown only when it should be (second row in our example).
3. Start the service, open it's configuration tab.
4. Verify that a manual host port is shown only when it should be (second row in our example).
5. Verify that the updated tests make sense.

## Trade-offs
None.

## Dependencies
None.

## Screenshots
### Before
![Screenshot from 2019-06-14 17-08-10](https://user-images.githubusercontent.com/40791275/59515094-01b84380-8ec7-11e9-9cf2-50a280a6fe95.png)

### After
![Screenshot from 2019-06-14 17-03-25](https://user-images.githubusercontent.com/40791275/59515110-054bca80-8ec7-11e9-9c60-6a967c9ccfb4.png)
