### PR TITLE
DCOS-55175 - fix: ensure getStatus exists before calling

### DIFF
--- a/plugins/services/src/js/components/DeploymentsModal.js
+++ b/plugins/services/src/js/components/DeploymentsModal.js
@@ -437,7 +437,7 @@ class DeploymentsModal extends mixin(StoreMixin) {
       {});
     }
 
-    let statusText = !item.isStale ? item.getStatus() : null;
+    let statusText = !item.isStale && item.getStatus ? item.getStatus() : null;
     const itemId = item.isStale ? item.serviceID : item.id;
 
     if (currentActions[itemId] != null) {

--- a/plugins/services/src/js/components/__tests__/DeploymentsModal-test.js
+++ b/plugins/services/src/js/components/__tests__/DeploymentsModal-test.js
@@ -1,3 +1,4 @@
+import Item from "#SRC/js/structs/Item";
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */
@@ -32,6 +33,28 @@ describe("DeploymentsModal", function() {
         })
       );
       expect(text).toContain("revert the affected service");
+    });
+  });
+
+  describe("#renderStatus", function() {
+    it("Returns N/A for empty Application", function() {
+      const app = new Application({
+        deployment: {}
+      });
+
+      expect(
+        DeploymentsModal.WrappedComponent.prototype.renderStatus(null, app, {})
+      ).toEqual("N/A");
+    });
+
+    it("Returns null for Item without getStatus function", function() {
+      const item = new Item({
+        deployment: {}
+      });
+
+      expect(
+        DeploymentsModal.WrappedComponent.prototype.renderStatus(null, item, {})
+      ).toEqual(null);
     });
   });
 });


### PR DESCRIPTION
We have seen errors in Sentry where the item being rendered into the
deployments table does not have a getStatus function. This doesn't make
a lot of sense since the item _should_ be an Application, Service or
ServiceTree. And all of those structs have a getStatus function. But
adding a guard against an unhandled exception here regardless.

- Closes DCOS-55175

## Testing

I added unit tests for this case as I was never able to reproduce the actual event from Sentry.

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
