### PR TITLE
DCOS-55177 - fix: ensure getStatus exists before calling

### DIFF
--- a/plugins/services/src/js/components/DeploymentsModal.js
+++ b/plugins/services/src/js/components/DeploymentsModal.js
@@ -490,7 +490,7 @@ class DeploymentsModal extends mixin(StoreMixin) {
       {});
     }
 
-    let statusText = !item.isStale ? item.getStatus() : null;
+    let statusText = !item.isStale && item.getStatus ? item.getStatus() : null;
     const itemId = item.isStale ? item.serviceID : item.id;
 
     if (currentActions[itemId] != null) {
@@ -586,3 +586,4 @@ class DeploymentsModal extends mixin(StoreMixin) {
 }
 
 module.exports = withI18n()(DeploymentsModal);
+module.exports.WrappedComponent = DeploymentsModal;

--- a/plugins/services/src/js/components/__tests__/DeploymentsModal-test.js
+++ b/plugins/services/src/js/components/__tests__/DeploymentsModal-test.js
@@ -1,0 +1,59 @@
+import Item from "#SRC/js/structs/Item";
+/* eslint-disable no-unused-vars */
+const React = require("react");
+/* eslint-enable no-unused-vars */
+
+const Deployment = require("../../structs/Deployment");
+const DeploymentsModal = require("../DeploymentsModal");
+const Application = require("../../structs/Application");
+
+describe("DeploymentsModal", function() {
+  describe("#getRollbackModalText", function() {
+    it("returns a removal message when passed a starting deployment", function() {
+      let text = DeploymentsModal.WrappedComponent.prototype.getRollbackModalText(
+        new Deployment({
+          id: "deployment-id",
+          affectedApps: ["app1"],
+          affectedServices: [new Application({ name: "app1" })],
+          steps: [{ actions: [{ type: "StartApplication" }] }]
+        })
+      ).props.id;
+      text = text.replace(/\s{1,}/g, " ");
+      expect(text).toContain("delete the affected service");
+    });
+
+    it("returns a revert message when passed a non-starting deployment", function() {
+      const text = DeploymentsModal.WrappedComponent.prototype.getRollbackModalText(
+        new Deployment({
+          id: "deployment-id",
+          affectedApps: ["app1"],
+          affectedServices: [new Application({ name: "app1" })],
+          steps: [{ actions: [{ type: "ScaleApplication" }] }]
+        })
+      ).props.id;
+      expect(text).toContain("revert the affected service");
+    });
+  });
+
+  describe("#renderStatus", function() {
+    it("Returns N/A for empty Application", function() {
+      const app = new Application({
+        deployment: {}
+      });
+
+      expect(
+        DeploymentsModal.WrappedComponent.prototype.renderStatus(null, app, {})
+      ).toEqual("N/A");
+    });
+
+    it("Returns null for Item without getStatus function", function() {
+      const item = new Item({
+        deployment: {}
+      });
+
+      expect(
+        DeploymentsModal.WrappedComponent.prototype.renderStatus(null, item, {})
+      ).toEqual(null);
+    });
+  });
+});


### PR DESCRIPTION
We have seen errors in Sentry where the item being rendered into the
deployments table does not have a getStatus function. This doesn't make
a lot of sense since the item _should_ be an Application, Service or
ServiceTree. And all of those structs have a getStatus function. But
adding a guard against an unhandled exception here regardless.

- Closes DCOS-55177

## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
