### PR TITLE
DCOS-48718: i18n exhibition error for task list of UI in Chinese

### DIFF
--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -697,7 +697,7 @@
   "Sets the dcos-gen-resolvconf.service to be run once a minute.": "将 dcos-gen-resolvconf.service 设置为每 运行一次。",
   "Sets the dcos-signal.service interval at once an hour.": "将 dcos-signal.service 间隔设置为每小时一次。",
   "Settings": "设置",
-  "Showing {currentLength} of {totalLength} {name}": "显示 {totalLength} {name} 的 {currentLength} ",
+  "Showing {currentLength} of {totalLength} {name}": "显示{totalLength}个{name}中的{currentLength}个",
   "Sign Out": "退出",
   "Single Container": "单个容器",
   "Size": "大小",


### PR DESCRIPTION
Update Chinese message catalog
to include a more accurate translation.

Closes https://jira.mesosphere.com/browse/DCOS-48718

## Testing
1. Start a service.
2. Change it once so that we have more than one task.
3. Switch to Chinese.
4. Open the service and verify that the text above the filter bar looks something like `显示2个任务s中的1个`.
## Trade-offs
I consider removing the pluralization "s" out of scope here as this is a ticket about the translation.

## Dependencies
None.

## Screenshots
### Before
![Screenshot from 2019-06-18 11-12-36](https://user-images.githubusercontent.com/40791275/59664573-feb89e00-91b9-11e9-8d37-ed571bccc2e7.png)

### After
![Screenshot from 2019-06-18 11-09-38](https://user-images.githubusercontent.com/40791275/59664587-04ae7f00-91ba-11e9-8d57-9613ecd61816.png)
