### PR TITLE
DCOS-49181: Version column in service table shows misleading information

### DIFF
--- a/plugins/services/src/js/columns/ServicesTableVersionColumn.tsx
+++ b/plugins/services/src/js/columns/ServicesTableVersionColumn.tsx
@@ -12,21 +12,13 @@ import * as Version from "../utils/Version";
 import TableColumnResizeStore from "#SRC/js/stores/TableColumnResizeStore";
 import { columnWidthsStorageKey } from "../containers/services/ServicesTable";
 
-const ServiceVersion = React.memo(
-  ({
-    rawVersion,
-    displayVersion
-  }: {
-    rawVersion: string;
-    displayVersion: string;
-  }) => (
-    <TextCell>
-      <Tooltip content={rawVersion} wrapText={true}>
-        {displayVersion}
-      </Tooltip>
-    </TextCell>
-  )
-);
+const ServiceVersion = React.memo(({ rawVersion }: { rawVersion: string }) => (
+  <TextCell>
+    <Tooltip content={rawVersion} wrapText={true}>
+      {rawVersion}
+    </Tooltip>
+  </TextCell>
+));
 
 export function versionRenderer(
   service: Service | Pod | ServiceTree
@@ -35,13 +27,9 @@ export function versionRenderer(
     return null;
   }
 
-  const rawVersion = Version.fromService(service);
-  const displayVersion =
-    service instanceof Framework ? Version.toDisplayVersion(rawVersion) : "";
-
-  return (
-    <ServiceVersion rawVersion={rawVersion} displayVersion={displayVersion} />
-  );
+  const rawVersion =
+    service instanceof Framework ? Version.fromService(service) : "";
+  return <ServiceVersion rawVersion={rawVersion} />;
 }
 
 export function versionWidth(_: WidthArgs) {

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -62,7 +62,7 @@ const RESTART = ServiceActionItem.RESTART;
 const RESUME = ServiceActionItem.RESUME;
 const SCALE = ServiceActionItem.SCALE;
 const STOP = ServiceActionItem.STOP;
-const RESET_DELAYED = ServiceActionItem.RESET_DELAYED
+const RESET_DELAYED = ServiceActionItem.RESET_DELAYED;
 
 const METHODS_TO_BIND = [
   "handleServiceAction",
@@ -76,10 +76,7 @@ const serviceToVersion = serviceTreeNode => {
     return "";
   }
 
-  return pipe(
-    Version.fromService,
-    Version.toDisplayVersion
-  )(serviceTreeNode);
+  return pipe(Version.fromService)(serviceTreeNode);
 };
 
 function sortForColumn(name) {

--- a/plugins/services/src/js/containers/services/__tests__/ServicesTable-test.js
+++ b/plugins/services/src/js/containers/services/__tests__/ServicesTable-test.js
@@ -63,7 +63,7 @@ describe("ServicesTable", () => {
       const highSemver = framework("2.3.0-3.0.16");
       const lowSemver = framework("2.3.0-1.1.0");
       const nonSemver = framework("not-semver-beta");
-      const no = new Framework();
+      const no = framework("");
 
       const data = [highSemver, lowSemver, nonSemver, no];
 

--- a/plugins/services/src/js/utils/Version.ts
+++ b/plugins/services/src/js/utils/Version.ts
@@ -37,7 +37,4 @@ function compare(a: Version, b: Version) {
 
 const fromService = (service: Service | Pod) => service.getVersion();
 
-const toDisplayVersion = (v: Version) =>
-  FrameworkUtil.extractBaseTechVersion(v);
-
-export { compare, fromService, toDisplayVersion };
+export { compare, fromService };

--- a/plugins/services/src/js/utils/__tests__/Version-test.ts
+++ b/plugins/services/src/js/utils/__tests__/Version-test.ts
@@ -20,11 +20,4 @@ describe("Version", () => {
       ).toEqual("2018-09-13T21:42:41.611Z");
     });
   });
-
-  describe("#toDisplayVersion", () => {
-    const version = Version.fromService(
-      new Framework({ labels: { DCOS_PACKAGE_VERSION: "2.3.0-1.1.0" } })
-    );
-    expect(Version.toDisplayVersion(version)).toEqual("1.1.0");
-  });
 });

--- a/tests/_fixtures/marathon-1-task/groups-sdk-services.json
+++ b/tests/_fixtures/marathon-1-task/groups-sdk-services.json
@@ -38,7 +38,8 @@
           "labels": {
             "DCOS_COMMONS_API_VERSION": "v1",
             "DCOS_PACKAGE_NAME": "test",
-            "DCOS_PACKAGE_FRAMEWORK_NAME": "/services/sdk-sleep"
+            "DCOS_PACKAGE_FRAMEWORK_NAME": "/services/sdk-sleep",
+            "DCOS_PACKAGE_VERSION": "1.0.0-2.0.0"
           },
           "acceptedResourceRoles": null,
           "version": "2015-08-28T01:26:14.620Z",

--- a/tests/pages/services/ServiceTable-cy.js
+++ b/tests/pages/services/ServiceTable-cy.js
@@ -398,6 +398,14 @@ describe("Service Table", function() {
         .contains("Open Service")
         .should("exist");
     });
+
+    it("shows the full version for a framework", function() {
+      cy.get(".ReactVirtualized__Grid__innerScrollContainer")
+        .last() // Bottom right part of the table.
+        .children()
+        .eq(1) // Version column for the first row.
+        .contains("1.0.0-2.0.0");
+    });
   });
 
   context("SDK Groups", function() {


### PR DESCRIPTION
Show full version for frameworks.

Closes https://jira.mesosphere.com/browse/DCOS-49181

## Testing
1. Go to the services tab.
2. Start some services.
3. Go to catalog.
4. Start some frameworks.
5. Go to services table.
6. Verify that for services we show no version and for frameworks we show the full version (when hovering the cell, the tooltip should show the same version).
7. Verify that the added test makes sense.

## Trade-offs
None.

## Dependencies
None.

## Screenshots
### Before
![Screenshot from 2019-06-18 14-37-02](https://user-images.githubusercontent.com/40791275/59679115-b065c800-91d6-11e9-89ca-a6665428f2de.png)

### After
![Screenshot from 2019-06-18 13-16-47](https://user-images.githubusercontent.com/40791275/59679123-b491e580-91d6-11e9-864d-f8a542ef0142.png)
