### PR TITLE
fix: permission builder exception

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4255,6 +4255,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
+      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -9981,7 +9982,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -10002,12 +10004,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10022,17 +10026,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -10149,7 +10156,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -10161,6 +10169,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -10175,6 +10184,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -10182,12 +10192,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -10206,6 +10218,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -10286,7 +10299,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -10298,6 +10312,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -10383,7 +10398,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -10419,6 +10435,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -10438,6 +10455,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -10481,12 +10499,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -11447,7 +11467,8 @@
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "hoist-non-react-statics": {
       "version": "2.5.5",
@@ -23806,9 +23827,9 @@
       }
     },
     "reactjs-components": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/reactjs-components/-/reactjs-components-5.0.2.tgz",
-      "integrity": "sha512-tEW9W9j2dk/pxBk+Y7HnxZ5L5FEJZDtG5BUmlg/650V0WjNQXcGBOjEzz7kxCt0i2qedXJ3+1C06BTW0pB1pFg==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/reactjs-components/-/reactjs-components-5.0.3.tgz",
+      "integrity": "sha512-B/nHUdz0hSyp3qjZImLaQ2wIE1QFYNZOJVePLy3y8Wj22w1dVoEOIcKkvn/Zcfe5236zDjCMer34lYQ485SUbA==",
       "requires": {
         "classnames": "2.2.6",
         "lodash": "^4.17.5",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "react-redux": "6.0.0",
     "react-router": "3.0.5",
     "react-transition-group": "2.5.0",
-    "reactjs-components": "5.0.2",
+    "reactjs-components": "5.0.3",
     "reactjs-mixin": "0.0.2",
     "recompose": "0.30.0",
     "redux": "3.3.1",


### PR DESCRIPTION
Update `reactjs-components` to resolve issue with permissions builder

- Closes DCOS-48704

## Testing

- Create a user account
- Open the permissions builder for the new user
- Select `Mesos` -> `Master` -> `Quota`
- Select both `read` & `Update`
- Change `Quota` -> `Executor`
- Verify modal doesn't crash

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
