### PR TITLE
DCOS-21186: Service status panel on dashboard should sort by severity

### DIFF
--- a/src/js/pages/DashboardPage.js
+++ b/src/js/pages/DashboardPage.js
@@ -16,7 +16,6 @@ import Loader from "../components/Loader";
 import BreadcrumbTextContent from "../components/BreadcrumbTextContent";
 import ComponentList from "../components/ComponentList";
 import Config from "../config/Config";
-import HealthSorting from "../../../plugins/services/src/js/constants/HealthSorting";
 import InternalStorageMixin from "../mixins/InternalStorageMixin";
 import MesosSummaryStore from "../stores/MesosSummaryStore";
 import Page from "../components/Page";
@@ -154,11 +153,12 @@ var DashboardPage = createReactClass({
   getServicesList() {
     const services = this.state.dcosServices;
 
-    const sortedServices = services.sort(function(service, other) {
-      const health = service.getHealth();
-      const otherHealth = other.getHealth();
+    const sortedServices = services.sort(function(firstService, secondService) {
+      const firstStatus = firstService.getServiceStatus();
+      const secondStatus = secondService.getServiceStatus();
 
-      return HealthSorting[health.key] - HealthSorting[otherHealth.key];
+      // We invert this, since we want to show the highest priorities last.
+      return secondStatus.priority - firstStatus.priority;
     });
 
     return sortedServices.slice(0, this.props.servicesListLength);


### PR DESCRIPTION
Sort services by severity in the dashboard tab.

Closes https://jira.mesosphere.com/browse/DCOS-21186

## Testing
1. Go to services tab.
2. Start some services, at least one deploying, one running, and one stopped.
Examples:
```
{
  "id": "/running",
  "instances": 1,
  "portDefinitions": [],
  "container": {
    "type": "MESOS",
    "volumes": []
  },
  "cpus": 0.1,
  "mem": 128,
  "requirePorts": false,
  "networks": [],
  "healthChecks": [],
  "fetch": [],
  "constraints": [],
  "cmd": "sleep 1000"
}
```
```
{
  "id": "/delayed",
  "instances": 1,
  "portDefinitions": [],
  "container": {
    "type": "MESOS",
    "volumes": []
  },
  "cpus": 0.1,
  "mem": 12800000000,
  "requirePorts": false,
  "networks": [],
  "healthChecks": [],
  "fetch": [],
  "constraints": [],
  "cmd": "sleep 1000"
}
```
```
{
  "id": "/stopped",
  "instances": 0,
  "portDefinitions": [],
  "container": {
    "type": "MESOS",
    "volumes": []
  },
  "cpus": 0.1,
  "mem": 128,
  "requirePorts": false,
  "networks": [],
  "healthChecks": [],
  "fetch": [],
  "constraints": [],
  "cmd": "sleep 1000"
}
```
3. Open the dashboard and verify that the delayed service(s) are on top, stopped service(s) are next and running service(s) are last.
4. Verify that the added test makes sense.

## Trade-offs
I tried adding a system test https://gist.github.com/GeorgiSTodorov/89e4f3bf378d4514beed2931cb7361b9 , but it would keep failing for a weird reason.
![Screenshot from 2019-06-26 14-29-47](https://user-images.githubusercontent.com/40791275/60177317-49bd5b80-9821-11e9-9583-c83f52af18b2.png)


## Dependencies
None.

## Screenshots
### Before
![Снимка от 2019-06-20 13-57-38](https://user-images.githubusercontent.com/40791275/59844371-69590d80-9363-11e9-8b61-00ec083eb06f.png)

### After
![Screenshot from 2019-06-28 15-44-48](https://user-images.githubusercontent.com/40791275/60343166-0d723280-99bc-11e9-9322-2bad0e9e7c8e.png)



