### PR TITLE
DCOS-48291: Missing history object results in exception

### DIFF
--- a/plugins/services/src/js/components/modals/EditServiceModal.js
+++ b/plugins/services/src/js/components/modals/EditServiceModal.js
@@ -20,7 +20,9 @@ class EditServiceModal extends Component {
 
     // Service not found
     if (!service) {
-      hashHistory.push("/services/404");
+      if (hashHistory && hashHistory.push) {
+        hashHistory.push("/services/404");
+      }
 
       return null;
     }


### PR DESCRIPTION
Check for history object before updating it.

Closes https://jira.mesosphere.com/browse/DCOS-48291

## Testing
Check out the sentry issue and verify that the suggested fix makes sense.

## Trade-offs
None.

## Dependencies
None.

## Screenshots
None.
