### PR TITLE
DCOS-50792: TypeError: Cannot read property 'jsonValue' of null

### DIFF
--- a/src/js/components/JSONEditor.js
+++ b/src/js/components/JSONEditor.js
@@ -226,7 +226,12 @@ class JSONEditor extends React.Component {
     const lastError = this.jsonError;
 
     // Calculate what the next state is going to be
-    const { jsonValue, jsonMeta, jsonError } = this.getNewJsonState(jsonText);
+    const getNewJsonState = this.getNewJsonState(jsonText);
+    if (getNewJsonState === null) {
+      return; // No change.
+    }
+
+    const { jsonValue, jsonMeta, jsonError } = getNewJsonState;
 
     // Update the `isTyping` flag
     this.isTyping = true;

--- a/src/js/components/__tests__/JSONEditor-test.js
+++ b/src/js/components/__tests__/JSONEditor-test.js
@@ -170,6 +170,17 @@ describe("JSONEditor", function() {
 
       expect(onChangeHandler).toBeCalledWith(JSON.parse(validJSONText));
     });
+
+    it("does not crash when getNewJsonState is null", function() {
+      const instance = ReactDOM.render(
+        <JSONEditor value={123} />,
+        thisContainer
+      );
+
+      instance.handleChange("123");
+
+      expect(instance.jsonText).toEqual("123"); // No change.
+    });
   });
 
   describe("#updateLocalJsonState", function() {


### PR DESCRIPTION
Don't crash the UI if getNewJsonState
inside handleChange is null

Closes https://jira.mesosphere.com/browse/DCOS-50792

## Testing
1. In `/src/js/components/JSONEditor.js` in `getNewJsonState` change line 313 from `if (this.jsonText === jsonText) {` to `if (this.jsonText !== jsonText) {`.
2. Open the JSON editor in the jobs form.
3. Change something in the editor.
4. Verify that no console error is shown.
5. Verify that the added test makes sense.

## Trade-offs
None.

## Dependencies
None.

## Screenshots
### Before
![Screenshot from 2019-06-25 16-29-12](https://user-images.githubusercontent.com/40791275/60102447-63e63380-9766-11e9-9877-a7e039783c00.png)
