### PR TITLE
DCOS-45226: fix(jobsform): fix jobs form to preserve docker params

### DIFF
--- a/src/js/utils/JobUtil.js
+++ b/src/js/utils/JobUtil.js
@@ -46,7 +46,7 @@ const JobUtil = {
         id: null
       },
       labels = {},
-      docker,
+      docker = {},
       docker_parameters,
       schedule
     } = formModel;
@@ -72,16 +72,22 @@ const JobUtil = {
       cmd: general.cmd,
       cpus: general.cpus,
       mem: general.mem,
-      disk: general.disk
+      disk: general.disk,
+      docker
     });
 
-    if (docker && docker.image) {
-      Object.assign(spec.run, { docker });
-      if (docker_parameters != null && docker_parameters.items != null) {
-        spec.run.docker.parameters = docker_parameters.items;
-      } else {
-        spec.run.docker.parameters = [];
-      }
+    if (docker_parameters != null && docker_parameters.items != null) {
+      spec.run.docker.parameters = docker_parameters.items;
+    } else {
+      spec.run.docker.parameters = [];
+    }
+
+    if (
+      spec.run.docker &&
+      !spec.run.docker.image &&
+      spec.run.docker.parameters.length === 0
+    ) {
+      delete spec.run.docker;
     }
 
     // default values for id and policy

--- a/src/js/utils/__tests__/JobUtil-test.js
+++ b/src/js/utils/__tests__/JobUtil-test.js
@@ -50,6 +50,31 @@ describe("JobUtil", function() {
       ]);
     });
 
+    it("adds docker parameters without docker image", function() {
+      const job = JobUtil.createJobFromFormModel({
+        general: { id: "test" },
+        docker_parameters: {
+          items: [
+            {
+              key: "env",
+              value: "var"
+            }
+          ]
+        }
+      });
+
+      expect(job.toJSON().run).toEqual({
+        docker: {
+          parameters: [
+            {
+              key: "env",
+              value: "var"
+            }
+          ]
+        }
+      });
+    });
+
     it("job schedule maintains id and policy", function() {
       const job = JobUtil.createJobFromFormModel({
         general: { id: "test", cmd: "sleep 1000;" },


### PR DESCRIPTION
Docker params are now preserved although no docker image has been provided.

CLOSES DCOS-39298

## Testing


1. Add new jobs and enter docker parameters. Open edit page of the job. The docker parameter fields are blank.
2. Open add job or edit job page. Enter data in the docker parameters fields. Switch to json mode. The entered parameter are not visible. Switch back to forms view. The docker parameters fields are blank.
