### PR TITLE
DCOS-49826: TypeError: Cannot read property 'includes' of null

### DIFF
--- a/src/js/stores/MetronomeStore.js
+++ b/src/js/stores/MetronomeStore.js
@@ -193,7 +193,7 @@ class MetronomeStore extends EventEmitter {
 
   removeOldJobs(jobs) {
     this.data.jobMap.forEach((job, id) => {
-      if (!jobs.includes(id)) {
+      if (jobs && !jobs.includes(id)) {
         this.data.jobMap.delete(id);
       }
     });


### PR DESCRIPTION
Check if a property is null before
using the include method.

Closes DCOS-49826

## Testing
Verify that the added check makes sense given the sentry error.

## Trade-offs
Sentry bug has disappeared, so we can't really know the scenario in which this happened.

## Dependencies
None.

## Screenshots
None.
