### PR TITLE
DCOS-55586: make json editor fit v0 spec

### DIFF
--- a/plugins/jobs/src/js/components/JobsForm.tsx
+++ b/plugins/jobs/src/js/components/JobsForm.tsx
@@ -84,11 +84,11 @@ class JobModalForm extends React.Component<JobFormProps> {
 
   getJSONEditorData(jobSpec: JobSpec): JobOutput {
     const jobJSON = jobSpecToOutputParser(jobSpec);
-    if (jobJSON.hasOwnProperty("schedule") && jobJSON.schedule === undefined) {
+    if (jobJSON.hasOwnProperty("schedule") && jobJSON.schedules === undefined) {
       // jobSpecToOutputParser returns object with `schedule: undefined` if there is no schedule present,
       // but this triggers an update of the JSONEditor and leads to issues where the state of the JSON in the
       // editor is replaced with old values.
-      delete jobJSON.schedule;
+      delete jobJSON.schedules;
     }
     return jobJSON;
   }

--- a/plugins/jobs/src/js/components/JobsFormModal.tsx
+++ b/plugins/jobs/src/js/components/JobsFormModal.tsx
@@ -29,7 +29,8 @@ import {
   JobSpec,
   JobOutput,
   Action,
-  Container
+  Container,
+  JobAPIOutput
 } from "./form/helpers/JobFormData";
 import { JobResponse } from "src/js/events/MetronomeClient";
 import JobForm from "./JobsForm";
@@ -142,7 +143,7 @@ class JobFormModal extends React.Component<
     const jobSpec = job
       ? this.getJobSpecFromResponse(job)
       : getDefaultJobSpec();
-    const hasSchedule = !!(jobSpec.schedule && jobSpec.schedule.id);
+    const hasSchedule = !!(jobSpec.job.schedules && jobSpec.job.schedules[0]);
     const jobOutput = jobSpecToOutputParser(jobSpec);
     const initialState = {
       jobSpec,
@@ -188,12 +189,11 @@ class JobFormModal extends React.Component<
       jobCopy.labels = Object.entries(jobCopy.labels);
     }
 
-    const { schedules, _itemData, ...jobOnly } = jobCopy;
+    const { _itemData, ...jobOnly } = jobCopy;
     const jobSpec = {
       cmdOnly,
       container,
-      job: jobOnly,
-      schedule: schedules[0]
+      job: jobOnly
     };
     return jobSpec;
   }
@@ -234,16 +234,23 @@ class JobFormModal extends React.Component<
   getSubmitAction(jobOutput: JobOutput) {
     const { isEdit } = this.props;
     const { hasSchedule, scheduleFailure } = this.state;
+    const data: JobAPIOutput = {
+      job: jobOutput
+    };
+    if (jobOutput.schedules) {
+      data.schedule = jobOutput.schedules[0];
+      delete jobOutput.schedules;
+    }
     if (isEdit || scheduleFailure) {
       const editContext = {
-        jobId: jobOutput.job.id,
-        data: jobOutput,
+        jobId: jobOutput.id,
+        data,
         existingSchedule: hasSchedule
       };
       return dataLayer.query(editJobMutation, editContext);
     } else {
       const createContext = {
-        data: jobOutput
+        data
       };
       return dataLayer.query(createJobMutation, createContext);
     }

--- a/plugins/jobs/src/js/components/form/ArgsSection.tsx
+++ b/plugins/jobs/src/js/components/form/ArgsSection.tsx
@@ -48,7 +48,7 @@ class ArgsSection extends React.Component<ArgsSectionProps> {
           </FieldLabel>
         );
       }
-      const argErrors = getFieldError(`job.run.args.${index}`, errors);
+      const argErrors = getFieldError(`run.args.${index}`, errors);
 
       return (
         <FormRow key={index}>

--- a/plugins/jobs/src/js/components/form/GeneralFormSection.tsx
+++ b/plugins/jobs/src/js/components/form/GeneralFormSection.tsx
@@ -52,10 +52,10 @@ class GeneralFormSection extends React.Component<GeneralProps> {
     );
     const gpusDisabled = !formData.cmdOnly && formData.container !== "ucr";
 
-    const cpusError = getFieldError("job.run.cpus", errors);
-    const gpusError = getFieldError("job.run.gpus", errors);
-    const memError = getFieldError("job.run.mem", errors);
-    const diskError = getFieldError("job.run.disk", errors);
+    const cpusError = getFieldError("run.cpus", errors);
+    const gpusError = getFieldError("run.gpus", errors);
+    const memError = getFieldError("run.mem", errors);
+    const diskError = getFieldError("run.disk", errors);
 
     return (
       <FormRow>
@@ -150,9 +150,9 @@ class GeneralFormSection extends React.Component<GeneralProps> {
     const containerImage = formData.containerImage;
 
     const containerImageErrors =
-      getFieldError("job.run.docker.image", errors) ||
-      getFieldError("job.run.ucr.image.id", errors);
-    const cmdErrors = getFieldError("job.run.cmd", errors);
+      getFieldError("run.docker.image", errors) ||
+      getFieldError("run.ucr.image.id", errors);
+    const cmdErrors = getFieldError("run.cmd", errors);
 
     return (
       <div className="form-section">
@@ -274,7 +274,7 @@ class GeneralFormSection extends React.Component<GeneralProps> {
       </Trans>
     );
     const descTooltipContent = <Trans>A description of this job.</Trans>;
-    const idError = getFieldError("job.id", errors);
+    const idError = getFieldError("id", errors);
 
     return (
       <div className="form-section">

--- a/plugins/jobs/src/js/components/form/ParametersSection.tsx
+++ b/plugins/jobs/src/js/components/form/ParametersSection.tsx
@@ -62,15 +62,15 @@ class ParametersSection extends React.Component<
         );
       }
       const keyErrors = getFieldError(
-        `job.run.docker.parameters.${index}.key`,
+        `run.docker.parameters.${index}.key`,
         errors
       );
       const valueErrors = getFieldError(
-        `job.run.docker.parameters.${index}.value`,
+        `run.docker.parameters.${index}.value`,
         errors
       );
       const generalParamError = getFieldError(
-        `job.run.docker.parameters.${index}`,
+        `run.docker.parameters.${index}`,
         errors
       );
 

--- a/plugins/jobs/src/js/components/form/RunConfigFormSection.tsx
+++ b/plugins/jobs/src/js/components/form/RunConfigFormSection.tsx
@@ -381,13 +381,13 @@ class RunConfigFormSection extends React.Component<RunConfigSectionProps> {
               <FormGroup
                 className="column-6"
                 showError={Boolean(
-                  showErrors && getFieldError(`job.labels.${i}`, errors)
+                  showErrors && getFieldError(`labels.${i}`, errors)
                 )}
               >
                 <FieldAutofocus>
                   <FieldInput name={`key.${i}.labels`} value={key} />
                   <FieldError>
-                    {getFieldError(`job.labels.${i}`, errors)}
+                    {getFieldError(`labels.${i}`, errors)}
                   </FieldError>
                 </FieldAutofocus>
                 <span className="emphasis form-colon">:</span>

--- a/plugins/jobs/src/js/components/form/ScheduleFormSection.tsx
+++ b/plugins/jobs/src/js/components/form/ScheduleFormSection.tsx
@@ -36,11 +36,11 @@ class ScheduleFormSection extends React.Component<ScheduleSectionProps> {
         lowercase letters (`a-z`). The id may not begin or end with a dash.
       </Trans>
     );
-    const idErrors = getFieldError("schedule.id", errors);
-    const cronErrors = getFieldError("schedule.cron", errors);
-    const timezoneErrors = getFieldError("schedule.timezone", errors);
+    const idErrors = getFieldError("schedules.0.id", errors);
+    const cronErrors = getFieldError("schedules.0.cron", errors);
+    const timezoneErrors = getFieldError("schedules.0.timezone", errors);
     const deadlineErrors = getFieldError(
-      "schedule.startingDeadlineSeconds",
+      "schedules.0.startingDeadlineSeconds",
       errors
     );
 
@@ -83,7 +83,7 @@ class ScheduleFormSection extends React.Component<ScheduleSectionProps> {
               </FormGroupHeading>
             </FieldLabel>
             <FieldInput
-              name="schedule.id"
+              name="id.schedules"
               type="text"
               value={formData.scheduleId}
             />
@@ -103,7 +103,7 @@ class ScheduleFormSection extends React.Component<ScheduleSectionProps> {
               </FormGroupHeading>
             </FieldLabel>
             <FieldInput
-              name="schedule.cron"
+              name="cron.schedules"
               type="text"
               placeholder="* * * * *"
               value={formData.cronSchedule}
@@ -134,7 +134,7 @@ class ScheduleFormSection extends React.Component<ScheduleSectionProps> {
               </FormGroupHeading>
             </FieldLabel>
             <FieldInput
-              name="schedule.timezone"
+              name="timezone.schedules"
               type="text"
               value={formData.timezone}
               placeholder={JobDataPlaceholders.timezone}
@@ -158,7 +158,7 @@ class ScheduleFormSection extends React.Component<ScheduleSectionProps> {
               </FormGroupHeading>
             </FieldLabel>
             <FieldInput
-              name="schedule.startingDeadlineSeconds"
+              name="startingDeadlineSeconds.schedules"
               type="number"
               value={formData.startingDeadline}
               placeholder={JobDataPlaceholders.startingDeadlineSeconds}

--- a/plugins/jobs/src/js/components/form/helpers/JobFormData.ts
+++ b/plugins/jobs/src/js/components/form/helpers/JobFormData.ts
@@ -6,10 +6,20 @@ export interface JobNoLabels {
 
 export interface JobFormData extends JobNoLabels {
   labels?: ArrayLabels;
+  schedules?: JobSchedule[];
 }
 
 export interface JobOutputData extends JobNoLabels {
   labels?: JobLabels;
+}
+
+export interface JobOutput extends JobOutputData {
+  schedules?: JobSchedule[];
+}
+
+export interface JobAPIOutput {
+  job: JobOutputData;
+  schedule?: JobSchedule;
 }
 
 export enum ConcurrentPolicy {
@@ -35,7 +45,6 @@ export interface JobSpec {
   cmdOnly: boolean;
   container?: Container | null;
   job: JobFormData;
-  schedule?: JobSchedule;
 }
 
 export interface FormOutput {
@@ -66,11 +75,6 @@ export interface FormOutput {
   retryTime?: number;
   labels?: ArrayLabels;
   artifacts?: JobArtifact[];
-}
-
-export interface JobOutput {
-  job: JobOutputData;
-  schedule?: JobSchedule;
 }
 
 // Labels used internally to track form state

--- a/plugins/jobs/src/js/components/form/helpers/MetronomeJobValidators.ts
+++ b/plugins/jobs/src/js/components/form/helpers/MetronomeJobValidators.ts
@@ -62,60 +62,60 @@ const isUniqIn = <T>(list: T[]) =>
 
 export const MetronomeSpecValidators: MetronomeValidators = {
   validate(formData: JobOutput): FormError[] {
-    const { run } = formData.job;
+    const { run } = formData;
     const parameters = (run.docker && run.docker.parameters) || [];
 
     // prettier-ignore
     return pipe(
       // IS BOOLEAN
 
-      isBoolean(_ => "job.run.docker.forcePullImage", [run.docker && run.docker.forcePullImage]),
-      isBoolean(_ => "job.run.docker.privileged", [run.docker && run.docker.privileged]),
-      isBoolean(_ => "job.run.ucr.privileged", [run.ucr && run.ucr.privileged]),
-      isBoolean(_ => "job.run.ucr.image.forcePull", [run.ucr && run.ucr.image&& run.ucr.image.forcePull]),
+      isBoolean(_ => "run.docker.forcePullImage", [run.docker && run.docker.forcePullImage]),
+      isBoolean(_ => "run.docker.privileged", [run.docker && run.docker.privileged]),
+      isBoolean(_ => "run.ucr.privileged", [run.ucr && run.ucr.privileged]),
+      isBoolean(_ => "run.ucr.image.forcePull", [run.ucr && run.ucr.image&& run.ucr.image.forcePull]),
 
       // IS NUMBER
 
-      isNumber(_ => "job.run.cpus", [run.cpus]),
-      isNumber(_ => "job.run.disk", [run.disk]),
-      isNumber(_ => "job.run.gpus", [run.gpus]),
-      isNumber(_ => "job.run.maxLaunchDelay", [run.maxLaunchDelay]),
-      isNumber(_ => "job.run.mem", [run.mem]),
-      isNumber(_ => "job.run.restart.activeDeadlineSeconds", [run.restart && run.restart.activeDeadlineSeconds]),
-      isNumber(_ => "job.run.taskKillGracePeriodSeconds", [run.taskKillGracePeriodSeconds]),
+      isNumber(_ => "run.cpus", [run.cpus]),
+      isNumber(_ => "run.disk", [run.disk]),
+      isNumber(_ => "run.gpus", [run.gpus]),
+      isNumber(_ => "run.maxLaunchDelay", [run.maxLaunchDelay]),
+      isNumber(_ => "run.mem", [run.mem]),
+      isNumber(_ => "run.restart.activeDeadlineSeconds", [run.restart && run.restart.activeDeadlineSeconds]),
+      isNumber(_ => "run.taskKillGracePeriodSeconds", [run.taskKillGracePeriodSeconds]),
 
       // IS OBJECT
 
-      isObject(_ => "job.labels", [formData.job.labels]),
-      isObject(_ => "job.run.docker", [run.docker]),
-      isObject(_ => "job.run.ucr", [run.ucr]),
-      isObject(_ => "job.run.ucr.image", [run.ucr && run.ucr.image]),
+      isObject(_ => "labels", [formData.labels]),
+      isObject(_ => "run.docker", [run.docker]),
+      isObject(_ => "run.ucr", [run.ucr]),
+      isObject(_ => "run.ucr.image", [run.ucr && run.ucr.image]),
 
       // IS PRESENT
 
-      isPresent(_ => "job.id", [formData.job.id]),
-      isPresent(_ => "job.run.cpus", [run.cpus]),
-      isPresent(_ => "job.run.disk", [run.disk]),
-      isPresent(_ => "job.run.mem", [run.mem]),
-      isPresent(i => `job.labels.${i}.key`, Object.keys(formData.job.labels || [])),
-      isPresent(i => `job.run.artifacts.${i}.uri`, (run.artifacts || []).map(_ => _.uri)),
-      isPresent(i => `job.run.docker.parameters.${i}.key`, parameters.map(_ => _.key)),
-      isPresent(i => `job.run.docker.parameters.${i}.value`, parameters.map(_ => _.value)),
+      isPresent(_ => "id", [formData.id]),
+      isPresent(_ => "run.cpus", [run.cpus]),
+      isPresent(_ => "run.disk", [run.disk]),
+      isPresent(_ => "run.mem", [run.mem]),
+      isPresent(i => `labels.${i}.key`, Object.keys(formData.labels || [])),
+      isPresent(i => `run.artifacts.${i}.uri`, (run.artifacts || []).map(_ => _.uri)),
+      isPresent(i => `run.docker.parameters.${i}.key`, parameters.map(_ => _.key)),
+      isPresent(i => `run.docker.parameters.${i}.value`, parameters.map(_ => _.value)),
 
       // IS STRING
 
-      isString(_ => "job.id", [formData.job.id]),
-      isString(_ => "job.run.cmd", [run.cmd]),
-      isString(_ => "job.run.docker.image", [run.docker && run.docker.image]),
-      isString(_ => "job.run.restart.policy", [run.restart && run.restart.policy]),
-      isString(_ => "job.run.ucr.image.id", [run.ucr && run.ucr.image && run.ucr.image.id]),
-      isString(_ => "job.run.user", [run.user]),
-      isString(i => `job.labels.${i}.key`, Object.keys(formData.job.labels || [])),
-      isString(i => `job.labels.${i}.value`, Object.values(formData.job.labels || [])),
-      isString(i => `job.run.args.${i}`, run.args || []),
-      isString(i => `job.run.artifacts.${i}.uri`, (run.artifacts || []).map(_ => _.uri)),
-      isString(i => `job.run.docker.parameters.${i}.key`, parameters.map(_ => _.key)),
-      isString(i => `job.run.docker.parameters.${i}.value`, parameters.map(_ => _.value))
+      isString(_ => "id", [formData.id]),
+      isString(_ => "run.cmd", [run.cmd]),
+      isString(_ => "run.docker.image", [run.docker && run.docker.image]),
+      isString(_ => "run.restart.policy", [run.restart && run.restart.policy]),
+      isString(_ => "run.ucr.image.id", [run.ucr && run.ucr.image && run.ucr.image.id]),
+      isString(_ => "run.user", [run.user]),
+      isString(i => `labels.${i}.key`, Object.keys(formData.labels || [])),
+      isString(i => `labels.${i}.value`, Object.values(formData.labels || [])),
+      isString(i => `run.args.${i}`, run.args || []),
+      isString(i => `run.artifacts.${i}.uri`, (run.artifacts || []).map(_ => _.uri)),
+      isString(i => `run.docker.parameters.${i}.key`, parameters.map(_ => _.key)),
+      isString(i => `run.docker.parameters.${i}.value`, parameters.map(_ => _.value))
 
       // pipe only infers 10 steps, so we need a cast here
     )([]) as FormError[];
@@ -125,7 +125,7 @@ export const MetronomeSpecValidators: MetronomeValidators = {
    * Ensure ID contains only allowed characters.
    */
   jobIdIsValid(formData: JobOutput): FormError[] {
-    const jobId = findNestedPropertyInObject(formData, "job.id");
+    const jobId = findNestedPropertyInObject(formData, "id");
     const jobIdRegex = /^([a-z0-9]([a-z0-9-]*[a-z0-9]+)*)([.][a-z0-9]([a-z0-9-]*[a-z0-9]+)*)*$/;
     const message = i18nMark(
       "ID must be at least 1 character and may only contain digits (`0-9`), dashes (`-`), and lowercase letters (`a-z`). The ID may not begin or end with a dash."
@@ -133,17 +133,14 @@ export const MetronomeSpecValidators: MetronomeValidators = {
     if (jobId == undefined) {
       return [];
     }
-    return jobId && jobIdRegex.test(jobId)
-      ? []
-      : [{ path: ["job", "id"], message }];
+    return jobId && jobIdRegex.test(jobId) ? [] : [{ path: ["id"], message }];
   },
 
   /**
    * Ensure that the user has provided either one of `cmd` or `args`, or a container image field.
    * Ensure that the user has not provided both `cmd` and `args`.
    */
-  containsCmdArgsOrContainer(formData: JobOutput): FormError[] {
-    const { job } = formData;
+  containsCmdArgsOrContainer(job: JobOutput): FormError[] {
     const hasCmd = findNestedPropertyInObject(job, "run.cmd");
     const hasArgs =
       findNestedPropertyInObject(job, "run.args") &&
@@ -157,11 +154,11 @@ export const MetronomeSpecValidators: MetronomeValidators = {
 
       return [
         {
-          path: ["job", "run", "cmd"],
+          path: ["run", "cmd"],
           message: notBothMessage
         },
         {
-          path: ["job", "run", "args"],
+          path: ["run", "args"],
           message: notBothMessage
         }
       ];
@@ -192,14 +189,14 @@ export const MetronomeSpecValidators: MetronomeValidators = {
     );
 
     const containerImageErrorPath = job.run.ucr
-      ? ["job", "run", "ucr", "image", "id"]
+      ? ["run", "ucr", "image", "id"]
       : job.run.docker
-      ? ["job", "run", "docker", "image"]
+      ? ["run", "docker", "image"]
       : [];
 
     return [
-      { path: ["job", "run", "cmd"], message },
-      { path: ["job", "run", "args"], message },
+      { path: ["run", "cmd"], message },
+      { path: ["run", "args"], message },
       { path: containerImageErrorPath, message }
     ];
   },
@@ -208,11 +205,11 @@ export const MetronomeSpecValidators: MetronomeValidators = {
    * Ensure there is a container image if a container is specified
    */
   mustContainImageOnDockerOrUCR(formData: JobOutput) {
-    const docker = findNestedPropertyInObject(formData, "job.run.docker");
+    const docker = findNestedPropertyInObject(formData, "run.docker");
     if (docker && !docker.image) {
       return [
         {
-          path: ["job", "run", "docker", "image"],
+          path: ["run", "docker", "image"],
           message: i18nMark(
             "Must be specified when using the Docker Engine runtime."
           )
@@ -220,11 +217,11 @@ export const MetronomeSpecValidators: MetronomeValidators = {
       ];
     }
 
-    const ucr = findNestedPropertyInObject(formData, "job.run.ucr");
+    const ucr = findNestedPropertyInObject(formData, "run.ucr");
     if (ucr && (!ucr.image || !ucr.image.id)) {
       return [
         {
-          path: ["job", "run", "ucr", "image", "id"],
+          path: ["run", "ucr", "image", "id"],
           message: i18nMark("Must be specified when using UCR.")
         }
       ];
@@ -237,12 +234,12 @@ export const MetronomeSpecValidators: MetronomeValidators = {
    * Ensure GPUs are used only with UCR
    */
   gpusOnlyWithUCR(formData: JobOutput) {
-    const gpus = findNestedPropertyInObject(formData, "job.run.gpus");
-    const docker = findNestedPropertyInObject(formData, "job.run.docker");
+    const gpus = findNestedPropertyInObject(formData, "run.gpus");
+    const docker = findNestedPropertyInObject(formData, "run.docker");
     if ((gpus || gpus === 0) && docker) {
       return [
         {
-          path: ["job", "run", "gpus"],
+          path: ["run", "gpus"],
           message: i18nMark("GPUs are only available with UCR.")
         }
       ];
@@ -252,16 +249,16 @@ export const MetronomeSpecValidators: MetronomeValidators = {
   },
 
   oneOfUcrOrDocker(formData: JobOutput) {
-    const docker = findNestedPropertyInObject(formData, "job.run.docker");
-    const ucr = findNestedPropertyInObject(formData, "job.run.ucr");
+    const docker = findNestedPropertyInObject(formData, "run.docker");
+    const ucr = findNestedPropertyInObject(formData, "run.ucr");
     if (docker && ucr) {
       return [
         {
-          path: ["job", "run", "docker"],
+          path: ["run", "docker"],
           message: i18nMark("Only one of UCR or Docker is allowed.")
         },
         {
-          path: ["job", "run", "ucr"],
+          path: ["run", "ucr"],
           message: i18nMark("Only one of UCR or Docker is allowed.")
         }
       ];
@@ -270,21 +267,21 @@ export const MetronomeSpecValidators: MetronomeValidators = {
   },
 
   checkTypesOfUcrProps(formData: JobOutput) {
-    const ucr = findNestedPropertyInObject(formData, "job.run.ucr");
+    const ucr = findNestedPropertyInObject(formData, "run.ucr");
     const errors: FormError[] = [];
 
     if (ucr == undefined) {
       return errors;
     }
 
-    const kind = findNestedPropertyInObject(formData, "job.run.ucr.image.kind");
+    const kind = findNestedPropertyInObject(formData, "run.ucr.image.kind");
 
     if (
       kind != undefined &&
       (kind !== UcrImageKind.Docker && kind !== UcrImageKind.Appc)
     ) {
       errors.push({
-        path: ["job", "run", "ucr", "image", "kind"],
+        path: ["run", "ucr", "image", "kind"],
         message: i18nMark("Image kind must be one of `docker` or `appc`.")
       });
     }
@@ -292,28 +289,28 @@ export const MetronomeSpecValidators: MetronomeValidators = {
   },
 
   valuesAreWithinRange(formData: JobOutput) {
-    const cpus = findNestedPropertyInObject(formData, "job.run.cpus");
-    const mem = findNestedPropertyInObject(formData, "job.run.mem");
-    const disk = findNestedPropertyInObject(formData, "job.run.disk");
+    const cpus = findNestedPropertyInObject(formData, "run.cpus");
+    const mem = findNestedPropertyInObject(formData, "run.mem");
+    const disk = findNestedPropertyInObject(formData, "run.disk");
     const errors = [];
 
     if (cpus != undefined && typeof cpus === "number" && cpus < 0.01) {
       errors.push({
-        path: ["job", "run", "cpus"],
+        path: ["run", "cpus"],
         message: i18nMark("Minimum value is 0.01.")
       });
     }
 
     if (mem != undefined && typeof mem === "number" && mem < 32) {
       errors.push({
-        path: ["job", "run", "mem"],
+        path: ["run", "mem"],
         message: i18nMark("Minimum value is 32.")
       });
     }
 
     if (disk != undefined && typeof disk === "number" && disk < 0) {
       errors.push({
-        path: ["job", "run", "disk"],
+        path: ["run", "disk"],
         message: i18nMark("Minimum value is 0.")
       });
     }
@@ -322,11 +319,11 @@ export const MetronomeSpecValidators: MetronomeValidators = {
   },
 
   gpusWithinRange(formData: JobOutput) {
-    const gpus = findNestedPropertyInObject(formData, "job.run.gpus");
+    const gpus = findNestedPropertyInObject(formData, "run.gpus");
     if (gpus && typeof gpus === "number" && gpus < 0) {
       return [
         {
-          path: ["job", "run", "gpus"],
+          path: ["run", "gpus"],
           message: i18nMark("Minimum value is 0.")
         }
       ];
@@ -335,13 +332,13 @@ export const MetronomeSpecValidators: MetronomeValidators = {
   },
 
   noEmptyArgs(formData: JobOutput) {
-    const args = formData.job.run.args;
+    const args = formData.run.args;
     const errors: FormError[] = [];
     if (args && Array.isArray(args)) {
       args.forEach((arg, index) => {
         if (arg === "" || arg == undefined) {
           errors.push({
-            path: ["job", "run", "args", `${index}`],
+            path: ["run", "args", `${index}`],
             message: i18nMark("Arg cannot be empty.")
           });
         }
@@ -351,13 +348,13 @@ export const MetronomeSpecValidators: MetronomeValidators = {
   },
 
   argsUsedOnlyWithDocker(formData: JobOutput) {
-    const args = formData.job.run.args;
-    const docker = formData.job.run.docker;
+    const args = formData.run.args;
+    const docker = formData.run.docker;
 
     if (args && !docker) {
       return [
         {
-          path: ["job", "run", "args"],
+          path: ["run", "args"],
           message: i18nMark("Args can only be used with Docker.")
         }
       ];
@@ -366,7 +363,7 @@ export const MetronomeSpecValidators: MetronomeValidators = {
   },
 
   noDuplicateArgs(formData: JobOutput) {
-    const args = formData.job.run && formData.job.run.args;
+    const args = formData.run && formData.run.args;
     const errors: FormError[] = [];
     const map: { [key: string]: number } = {};
     const dupIndex: number[] = [];
@@ -385,7 +382,7 @@ export const MetronomeSpecValidators: MetronomeValidators = {
 
       dupIndex.forEach(errorIndex => {
         errors.push({
-          path: ["job", "run", "args", `${errorIndex}`],
+          path: ["run", "args", `${errorIndex}`],
           message: i18nMark("No duplicate args.")
         });
       });
@@ -394,7 +391,7 @@ export const MetronomeSpecValidators: MetronomeValidators = {
   },
 
   noDuplicateParams(formData: JobOutput) {
-    const docker = formData.job.run && formData.job.run.docker;
+    const docker = formData.run && formData.run.docker;
     const errors: FormError[] = [];
     const map: { [key: string]: number } = {};
     const dupIndex: number[] = [];
@@ -414,7 +411,7 @@ export const MetronomeSpecValidators: MetronomeValidators = {
 
       dupIndex.forEach(errorIndex => {
         errors.push({
-          path: ["job", "run", "docker", "parameters", `${errorIndex}`],
+          path: ["run", "docker", "parameters", `${errorIndex}`],
           message: i18nMark("No duplicate parameters.")
         });
       });
@@ -423,11 +420,16 @@ export const MetronomeSpecValidators: MetronomeValidators = {
   },
 
   scheduleHasId(formData: JobOutput) {
-    const { schedule } = formData;
-    if (schedule && !schedule.id) {
+    const { schedules } = formData;
+    if (
+      schedules &&
+      Array.isArray(schedules) &&
+      schedules.length &&
+      !schedules[0].id
+    ) {
       return [
         {
-          path: ["schedule", "id"],
+          path: ["schedules", "0", "id"],
           message: i18nMark("ID is required.")
         }
       ];
@@ -436,11 +438,16 @@ export const MetronomeSpecValidators: MetronomeValidators = {
   },
 
   scheduleHasCron(formData: JobOutput) {
-    const { schedule } = formData;
-    if (schedule && !schedule.cron) {
+    const { schedules } = formData;
+    if (
+      schedules &&
+      Array.isArray(schedules) &&
+      schedules.length &&
+      !schedules[0].cron
+    ) {
       return [
         {
-          path: ["schedule", "cron"],
+          path: ["schedules", "0", "cron"],
           message: i18nMark("CRON schedule is required.")
         }
       ];
@@ -449,40 +456,46 @@ export const MetronomeSpecValidators: MetronomeValidators = {
   },
 
   scheduleIdIsValid(formData: JobOutput) {
-    const { schedule } = formData;
+    const { schedules } = formData;
     const idRegex = /^([a-z0-9][a-z0-9\\-]*[a-z0-9]+)$/;
     const message = i18nMark(
       "ID must be at least 2 characters and may only contain digits (`0-9`), dashes (`-`), and lowercase letters (`a-z`). The ID may not begin or end with a dash."
     );
-    if (!schedule) {
+    if (!schedules || !Array.isArray(schedules) || !schedules.length) {
       return [];
     }
+    const schedule = schedules[0];
     if (schedule.id && typeof schedule.id !== "string") {
       return [
         {
-          path: ["schedule", "id"],
+          path: ["schedules", "0", "id"],
           message: i18nMark("Schedule ID must be a string.")
         }
       ];
     }
     return schedule && schedule.id && idRegex.test(schedule.id)
       ? []
-      : [{ path: ["schedule", "id"], message }];
+      : [{ path: ["schedules", "0", "id"], message }];
   },
 
   scheduleStartingDeadlineIsValid(formData: JobOutput) {
-    const { schedule } = formData;
+    const { schedules } = formData;
     const errors = [];
-    if (schedule && schedule.startingDeadlineSeconds != undefined) {
-      if (typeof schedule.startingDeadlineSeconds !== "number") {
+    if (
+      schedules &&
+      Array.isArray(schedules) &&
+      schedules.length &&
+      schedules[0].startingDeadlineSeconds != undefined
+    ) {
+      if (typeof schedules[0].startingDeadlineSeconds !== "number") {
         errors.push({
-          path: ["schedule", "startingDeadlineSeconds"],
+          path: ["schedules", "0", "startingDeadlineSeconds"],
           message: i18nMark("Starting deadline must be a number.")
         });
       }
-      if (schedule.startingDeadlineSeconds < 1) {
+      if (schedules[0].startingDeadlineSeconds < 1) {
         errors.push({
-          path: ["schedule", "startingDeadlineSeconds"],
+          path: ["schedules", "0", "startingDeadlineSeconds"],
           message: i18nMark("Minimum value is 1.")
         });
       }
@@ -496,7 +509,7 @@ export function validateFormLabels(jobSpec: JobSpec): FormError[] {
   const message = i18nMark("Cannot have multiple labels with the same key.");
 
   return pipe(
-    allUniq(_ => "job.labels", [labels], message),
-    isUniqIn(labels)(i => `job.labels.${i}`, labels, message)
+    allUniq(_ => "labels", [labels], message),
+    isUniqIn(labels)(i => `labels.${i}`, labels, message)
   )([]);
 }

--- a/plugins/jobs/src/js/components/form/helpers/__tests__/JobParsers-test.ts
+++ b/plugins/jobs/src/js/components/form/helpers/__tests__/JobParsers-test.ts
@@ -20,9 +20,9 @@ describe("JobParsers", () => {
       };
 
       const parsed = jobSpecToOutputParser(input as JobSpec);
-      expect(parsed.job.run.docker).toBe(undefined);
-      expect(parsed.job.run.ucr).toBe(undefined);
-      expect(parsed.job.run.gpus).toBe(0);
+      expect(parsed.run.docker).toBe(undefined);
+      expect(parsed.run.ucr).toBe(undefined);
+      expect(parsed.run.gpus).toBe(0);
     });
 
     it("returns object with only container property indicated by `container` if cmdOnly false", () => {
@@ -38,8 +38,8 @@ describe("JobParsers", () => {
       };
 
       const parsed = jobSpecToOutputParser(input as JobSpec);
-      expect(parsed.job.run.docker).toEqual({});
-      expect(parsed.job.run.ucr).toBe(undefined);
+      expect(parsed.run.docker).toEqual({});
+      expect(parsed.run.ucr).toBe(undefined);
     });
 
     it("returns object with only docker and no gpus if `container` is docker and cmdOnly is false", () => {
@@ -56,9 +56,9 @@ describe("JobParsers", () => {
       };
 
       const parsed = jobSpecToOutputParser(input as JobSpec);
-      expect(parsed.job.run.docker).toEqual({});
-      expect(parsed.job.run.ucr).toBe(undefined);
-      expect(parsed.job.run.gpus).toBe(undefined);
+      expect(parsed.run.docker).toEqual({});
+      expect(parsed.run.ucr).toBe(undefined);
+      expect(parsed.run.gpus).toBe(undefined);
     });
   });
 

--- a/plugins/jobs/src/js/components/form/helpers/__tests__/MetronomeJobValidators-test.ts
+++ b/plugins/jobs/src/js/components/form/helpers/__tests__/MetronomeJobValidators-test.ts
@@ -6,30 +6,30 @@ import { JobOutput } from "../JobFormData";
 
 const JOBID_ERRORS = [
   {
-    path: ["job", "id"],
+    path: ["id"],
     message:
       "ID must be at least 1 character and may only contain digits (`0-9`), dashes (`-`), and lowercase letters (`a-z`). The ID may not begin or end with a dash."
   }
 ];
 const CMDARGSERROR = [
   {
-    path: ["job", "run", "cmd"],
+    path: ["run", "cmd"],
     message: "Please specify only one of `cmd` or `args`."
   },
   {
-    path: ["job", "run", "args"],
+    path: ["run", "args"],
     message: "Please specify only one of `cmd` or `args`."
   }
 ];
 
 const CMDARGSCONTAINERERROR = [
   {
-    path: ["job", "run", "cmd"],
+    path: ["run", "cmd"],
     message:
       "You must specify a command, an argument or a container with an image."
   },
   {
-    path: ["job", "run", "args"],
+    path: ["run", "args"],
     message:
       "You must specify a command, an argument or a container with an image."
   },
@@ -42,88 +42,88 @@ const CMDARGSCONTAINERERROR = [
 
 const MUSTCONTAINIMAGEFORDOCKER = [
   {
-    path: ["job", "run", "docker", "image"],
+    path: ["run", "docker", "image"],
     message: "Must be specified when using the Docker Engine runtime."
   }
 ];
 
 const MUSTCONTAINIMAGEFORUCR = [
   {
-    path: ["job", "run", "ucr", "image", "id"],
+    path: ["run", "ucr", "image", "id"],
     message: "Must be specified when using UCR."
   }
 ];
 
 const GPUSERROR = [
   {
-    path: ["job", "run", "gpus"],
+    path: ["run", "gpus"],
     message: "GPUs are only available with UCR."
   }
 ];
 
 const CPURANGEERROR = [
   {
-    path: ["job", "run", "cpus"],
+    path: ["run", "cpus"],
     message: "Minimum value is 0.01."
   }
 ];
 
 const MEMRANGEERROR = [
   {
-    path: ["job", "run", "mem"],
+    path: ["run", "mem"],
     message: "Minimum value is 32."
   }
 ];
 
 const DISKRANGEERROR = [
   {
-    path: ["job", "run", "disk"],
+    path: ["run", "disk"],
     message: "Minimum value is 0."
   }
 ];
 
 const GPURANGEERROR = [
   {
-    path: ["job", "run", "gpus"],
+    path: ["run", "gpus"],
     message: "Minimum value is 0."
   }
 ];
 
 const EMPTYARGGERROR = [
   {
-    path: ["job", "run", "args", "0"],
+    path: ["run", "args", "0"],
     message: "Arg cannot be empty."
   }
 ];
 
 const ARGSWITHOUTDOCKERERROR = [
   {
-    path: ["job", "run", "args"],
+    path: ["run", "args"],
     message: "Args can only be used with Docker."
   }
 ];
 
 const UCRANDDOCKERERROR = [
   {
-    path: ["job", "run", "docker"],
+    path: ["run", "docker"],
     message: "Only one of UCR or Docker is allowed."
   },
   {
-    path: ["job", "run", "ucr"],
+    path: ["run", "ucr"],
     message: "Only one of UCR or Docker is allowed."
   }
 ];
 
 const SCHEDULEIDERROR = [
   {
-    path: ["schedule", "id"],
+    path: ["schedules", "0", "id"],
     message: "ID is required."
   }
 ];
 
 const SCHEDULEIDREGEXERROR = [
   {
-    path: ["schedule", "id"],
+    path: ["schedules", "0", "id"],
     message:
       "ID must be at least 2 characters and may only contain digits (`0-9`), dashes (`-`), and lowercase letters (`a-z`). The ID may not begin or end with a dash."
   }
@@ -131,33 +131,31 @@ const SCHEDULEIDREGEXERROR = [
 
 const CRONERROR = [
   {
-    path: ["schedule", "cron"],
+    path: ["schedules", "0", "cron"],
     message: "CRON schedule is required."
   }
 ];
 
 const STARTINGDEADLINETYPEERROR = [
   {
-    path: ["schedule", "startingDeadlineSeconds"],
+    path: ["schedules", "0", "startingDeadlineSeconds"],
     message: "Starting deadline must be a number."
   }
 ];
 
 const STARTINGDEADLINEVALUEERROR = [
   {
-    path: ["schedule", "startingDeadlineSeconds"],
+    path: ["schedules", "0", "startingDeadlineSeconds"],
     message: "Minimum value is 1."
   }
 ];
 
 const validJobSpec = (): JobOutput => ({
-  job: {
-    id: "id",
-    run: {
-      cpus: 1,
-      mem: 128,
-      disk: 32
-    }
+  id: "id",
+  run: {
+    cpus: 1,
+    mem: 128,
+    disk: 32
   }
 });
 
@@ -165,17 +163,17 @@ describe("MetronomeSpecValidators", () => {
   describe("#jobIdIsValid", () => {
     it("returns error if id is not a string", () => {
       const spec: any = validJobSpec();
-      spec.job.id = 123;
+      spec.id = 123;
 
       expect(MetronomeSpecValidators.validate(spec)).toContainEqual({
-        path: ["job", "id"],
+        path: ["id"],
         message: "Must be a string."
       });
     });
 
     it("returns error if id contains special characters", () => {
       const spec: any = validJobSpec();
-      spec.job.id = "test$";
+      spec.id = "test$";
 
       expect(MetronomeSpecValidators.jobIdIsValid(spec as JobOutput)).toEqual(
         JOBID_ERRORS
@@ -184,9 +182,7 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if id contains uppercase letters", () => {
       const spec = {
-        job: {
-          id: "Test"
-        }
+        id: "Test"
       };
       expect(MetronomeSpecValidators.jobIdIsValid(spec as JobOutput)).toEqual(
         JOBID_ERRORS
@@ -195,9 +191,7 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if id starts with a dash", () => {
       const spec = {
-        job: {
-          id: "-test"
-        }
+        id: "-test"
       };
       expect(MetronomeSpecValidators.jobIdIsValid(spec as JobOutput)).toEqual(
         JOBID_ERRORS
@@ -206,9 +200,7 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if id ends with a dash", () => {
       const spec = {
-        job: {
-          id: "test-"
-        }
+        id: "test-"
       };
       expect(MetronomeSpecValidators.jobIdIsValid(spec as JobOutput)).toEqual(
         JOBID_ERRORS
@@ -217,9 +209,7 @@ describe("MetronomeSpecValidators", () => {
 
     it("does not return error for id with lowercase letters and dashes", () => {
       const spec = {
-        job: {
-          id: "test-1"
-        }
+        id: "test-1"
       };
       expect(MetronomeSpecValidators.jobIdIsValid(spec as JobOutput)).toEqual(
         []
@@ -230,10 +220,8 @@ describe("MetronomeSpecValidators", () => {
   describe("#containsCmdArgsOrContainer", () => {
     it("returns no errors if `cmd` defined", () => {
       const spec = {
-        job: {
-          run: {
-            cmd: "sleep 100"
-          }
+        run: {
+          cmd: "sleep 100"
         }
       };
       expect(
@@ -243,10 +231,8 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns no errors if `args` defined", () => {
       const spec = {
-        job: {
-          run: {
-            args: ["sleep 100"]
-          }
+        run: {
+          args: ["sleep 100"]
         }
       };
       expect(
@@ -256,11 +242,9 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns no errors if `run.docker.image` defined", () => {
       const spec = {
-        job: {
-          run: {
-            docker: {
-              image: "foo"
-            }
+        run: {
+          docker: {
+            image: "foo"
           }
         }
       };
@@ -271,12 +255,10 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns no errors if `run.ucr.image.id` defined", () => {
       const spec = {
-        job: {
-          run: {
-            ucr: {
-              image: {
-                id: "foo"
-              }
+        run: {
+          ucr: {
+            image: {
+              id: "foo"
             }
           }
         }
@@ -288,11 +270,9 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if both `args` and `cmd` are defined", () => {
       const spec = {
-        job: {
-          run: {
-            args: ["sleep 100"],
-            cmd: "sleep 100"
-          }
+        run: {
+          args: ["sleep 100"],
+          cmd: "sleep 100"
         }
       };
       expect(
@@ -301,7 +281,7 @@ describe("MetronomeSpecValidators", () => {
     });
 
     it("returns all errors if neither is defined", () => {
-      const spec = { job: { run: {} } };
+      const spec = { run: {} };
       expect(
         MetronomeSpecValidators.containsCmdArgsOrContainer(spec as JobOutput)
       ).toEqual(CMDARGSCONTAINERERROR);
@@ -311,10 +291,8 @@ describe("MetronomeSpecValidators", () => {
   describe("#mustContainImageOnDockerOrUCR", () => {
     it("returns error if runtime is docker but image is missing", () => {
       const spec = {
-        job: {
-          run: {
-            docker: {}
-          }
+        run: {
+          docker: {}
         }
       };
       expect(
@@ -324,26 +302,26 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns an error if docker is present but is not an object", () => {
       const spec: any = validJobSpec();
-      spec.job.run.docker = "not an object";
+      spec.run.docker = "not an object";
       expect(MetronomeSpecValidators.validate(spec)).toContainEqual({
         message: "Must be an object.",
-        path: ["job", "run", "docker"]
+        path: ["run", "docker"]
       });
     });
 
     it("returns an error if ucr is present but is not an object", () => {
       const spec: any = validJobSpec();
-      spec.job.run.ucr = "not an object";
+      spec.run.ucr = "not an object";
 
       expect(MetronomeSpecValidators.validate(spec)).toContainEqual({
         message: "Must be an object.",
-        path: ["job", "run", "ucr"]
+        path: ["run", "ucr"]
       });
     });
 
     it("does not return error if runtime docker and image is specified", () => {
       const spec: any = validJobSpec();
-      spec.job.run.docker = { image: "foo" };
+      spec.run.docker = { image: "foo" };
       expect(
         MetronomeSpecValidators.mustContainImageOnDockerOrUCR(spec)
       ).toEqual([]);
@@ -351,7 +329,7 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if runtime is ucr but image is missing", () => {
       const spec: any = validJobSpec();
-      spec.job.run.ucr = {};
+      spec.run.ucr = {};
 
       expect(
         MetronomeSpecValidators.mustContainImageOnDockerOrUCR(spec as JobOutput)
@@ -360,7 +338,7 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if runtime is ucr but image.id is missing", () => {
       const spec: any = validJobSpec();
-      spec.job.run.ucr = { image: {} };
+      spec.run.ucr = { image: {} };
 
       expect(
         MetronomeSpecValidators.mustContainImageOnDockerOrUCR(spec as JobOutput)
@@ -369,7 +347,7 @@ describe("MetronomeSpecValidators", () => {
 
     it("does not return error if runtime is ucr and image.id is specified", () => {
       const spec: any = validJobSpec();
-      spec.job.run.ucr = { image: { id: "foo" } };
+      spec.run.ucr = { image: { id: "foo" } };
 
       expect(
         MetronomeSpecValidators.mustContainImageOnDockerOrUCR(spec as JobOutput)
@@ -380,13 +358,11 @@ describe("MetronomeSpecValidators", () => {
   describe("#gpusOnlyWithUCR", () => {
     it("returns no errors when gpus are used with ucr", () => {
       const spec = {
-        job: {
-          run: {
-            gpus: 0,
-            ucr: {
-              image: {
-                id: "foo"
-              }
+        run: {
+          gpus: 0,
+          ucr: {
+            image: {
+              id: "foo"
             }
           }
         }
@@ -398,12 +374,10 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error when gpus are used with docker", () => {
       const spec = {
-        job: {
-          run: {
-            gpus: 0,
-            docker: {
-              image: "foo"
-            }
+        run: {
+          gpus: 0,
+          docker: {
+            image: "foo"
           }
         }
       };
@@ -414,10 +388,8 @@ describe("MetronomeSpecValidators", () => {
 
     it("does not return error when gpus are used without explicit container", () => {
       const spec = {
-        job: {
-          run: {
-            gpus: 0
-          }
+        run: {
+          gpus: 0
         }
       };
       expect(
@@ -434,44 +406,44 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if id is not specified", () => {
       const spec = validJobSpec();
-      delete spec.job.id;
+      delete spec.id;
       expect(MetronomeSpecValidators.validate(spec as JobOutput)).toEqual([
-        { message: "Must be present.", path: ["job", "id"] }
+        { message: "Must be present.", path: ["id"] }
       ]);
     });
 
     it("returns error if cpus is not specified", () => {
       const spec = validJobSpec();
-      delete spec.job.run.cpus;
+      delete spec.run.cpus;
       expect(MetronomeSpecValidators.validate(spec as JobOutput)).toEqual([
-        { message: "Must be present.", path: ["job", "run", "cpus"] }
+        { message: "Must be present.", path: ["run", "cpus"] }
       ]);
     });
 
     it("returns error if mem is not specified", () => {
       const spec = validJobSpec();
-      delete spec.job.run.mem;
+      delete spec.run.mem;
       expect(MetronomeSpecValidators.validate(spec as JobOutput)).toEqual([
-        { message: "Must be present.", path: ["job", "run", "mem"] }
+        { message: "Must be present.", path: ["run", "mem"] }
       ]);
     });
 
     it("returns error if disk is not specified", () => {
       const spec = validJobSpec();
-      delete spec.job.run.disk;
+      delete spec.run.disk;
       expect(MetronomeSpecValidators.validate(spec as JobOutput)).toEqual([
-        { message: "Must be present.", path: ["job", "run", "disk"] }
+        { message: "Must be present.", path: ["run", "disk"] }
       ]);
     });
 
     it("returns all errors if no base required fields are specified", () => {
-      const spec = { job: { run: {} } };
+      const spec = { run: {} };
 
       expect(MetronomeSpecValidators.validate(spec as any)).toEqual([
-        { message: "Must be present.", path: ["job", "id"] },
-        { message: "Must be present.", path: ["job", "run", "cpus"] },
-        { message: "Must be present.", path: ["job", "run", "disk"] },
-        { message: "Must be present.", path: ["job", "run", "mem"] }
+        { message: "Must be present.", path: ["id"] },
+        { message: "Must be present.", path: ["run", "cpus"] },
+        { message: "Must be present.", path: ["run", "disk"] },
+        { message: "Must be present.", path: ["run", "mem"] }
       ]);
     });
   });
@@ -479,13 +451,11 @@ describe("MetronomeSpecValidators", () => {
   describe("#valuesAreWithinRange", () => {
     it("does not return error if values are all within acceptable range", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            cpus: 1,
-            mem: 32,
-            disk: 0
-          }
+        id: "id",
+        run: {
+          cpus: 1,
+          mem: 32,
+          disk: 0
         }
       };
       expect(MetronomeSpecValidators.valuesAreWithinRange(spec)).toEqual([]);
@@ -493,10 +463,8 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if cpus is not within range", () => {
       const spec = {
-        job: {
-          run: {
-            cpus: 0
-          }
+        run: {
+          cpus: 0
         }
       };
       expect(
@@ -506,10 +474,8 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if mem is not within range", () => {
       const spec = {
-        job: {
-          run: {
-            mem: 0
-          }
+        run: {
+          mem: 0
         }
       };
       expect(
@@ -519,10 +485,8 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if disk is not within range", () => {
       const spec = {
-        job: {
-          run: {
-            disk: -1
-          }
+        run: {
+          disk: -1
         }
       };
       expect(
@@ -532,12 +496,10 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns all errors if no base required fields are specified", () => {
       const spec = {
-        job: {
-          run: {
-            disk: -1,
-            cpus: 0,
-            mem: 0
-          }
+        run: {
+          disk: -1,
+          cpus: 0,
+          mem: 0
         }
       };
       expect(
@@ -549,11 +511,9 @@ describe("MetronomeSpecValidators", () => {
   describe("#gpusWithinRange", () => {
     it("does not return error if gpus >= 0", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            gpus: 0
-          }
+        id: "id",
+        run: {
+          gpus: 0
         }
       };
       expect(
@@ -563,10 +523,8 @@ describe("MetronomeSpecValidators", () => {
 
     it("does not return error if gpus not present", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {}
-        }
+        id: "id",
+        run: {}
       };
       expect(
         MetronomeSpecValidators.gpusWithinRange(spec as JobOutput)
@@ -575,10 +533,8 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if gpus < 0", () => {
       const spec = {
-        job: {
-          run: {
-            gpus: -1
-          }
+        run: {
+          gpus: -1
         }
       };
       expect(
@@ -590,7 +546,7 @@ describe("MetronomeSpecValidators", () => {
   describe("#parametersHaveStringKeyAndValue", () => {
     it("does not return error if parameters have both key and value", () => {
       const spec = validJobSpec();
-      spec.job.run.docker = {
+      spec.run.docker = {
         image: "",
         parameters: [{ key: "key", value: "value" }]
       };
@@ -599,41 +555,37 @@ describe("MetronomeSpecValidators", () => {
 
     it("does not return error if there are no parameters", () => {
       const spec = validJobSpec();
-      spec.job.run.docker = undefined;
+      spec.run.docker = undefined;
       expect(MetronomeSpecValidators.validate(spec)).toEqual([]);
     });
 
     it("does not return error if parameters are an empty array", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            docker: {
-              parameters: []
-            }
+        id: "id",
+        run: {
+          docker: {
+            parameters: []
           }
         }
       };
 
       expect(MetronomeSpecValidators.validate(spec as any)).not.toContainEqual({
         message: "Must be present.",
-        path: ["job", "run", "docker", "parameters", "0", "value"]
+        path: ["run", "docker", "parameters", "0", "value"]
       });
     });
 
     it("returns error if a parameters has an empty key", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            docker: {
-              parameters: [
-                {
-                  key: "",
-                  value: "value"
-                }
-              ]
-            }
+        id: "id",
+        run: {
+          docker: {
+            parameters: [
+              {
+                key: "",
+                value: "value"
+              }
+            ]
           }
         }
       };
@@ -641,23 +593,21 @@ describe("MetronomeSpecValidators", () => {
         MetronomeSpecValidators.validate(spec as JobOutput)
       ).toContainEqual({
         message: "Must be present.",
-        path: ["job", "run", "docker", "parameters", "0", "key"]
+        path: ["run", "docker", "parameters", "0", "key"]
       });
     });
 
     it("returns error if a parameters has an empty value", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            docker: {
-              parameters: [
-                {
-                  key: "key",
-                  value: ""
-                }
-              ]
-            }
+        id: "id",
+        run: {
+          docker: {
+            parameters: [
+              {
+                key: "key",
+                value: ""
+              }
+            ]
           }
         }
       };
@@ -666,7 +616,7 @@ describe("MetronomeSpecValidators", () => {
         MetronomeSpecValidators.validate(spec as JobOutput)
       ).toContainEqual({
         message: "Must be present.",
-        path: ["job", "run", "docker", "parameters", "0", "value"]
+        path: ["run", "docker", "parameters", "0", "value"]
       });
     });
   });
@@ -674,11 +624,9 @@ describe("MetronomeSpecValidators", () => {
   describe("#noEmptyArgs", () => {
     it("does not return error if no args are empty", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            args: ["arg"]
-          }
+        id: "id",
+        run: {
+          args: ["arg"]
         }
       };
       expect(MetronomeSpecValidators.noEmptyArgs(spec as JobOutput)).toEqual(
@@ -688,10 +636,8 @@ describe("MetronomeSpecValidators", () => {
 
     it("does not return error if there are no args", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {}
-        }
+        id: "id",
+        run: {}
       };
       expect(MetronomeSpecValidators.noEmptyArgs(spec as JobOutput)).toEqual(
         []
@@ -700,11 +646,9 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if an arg is an empty string", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            args: [""]
-          }
+        id: "id",
+        run: {
+          args: [""]
         }
       };
       expect(MetronomeSpecValidators.noEmptyArgs(spec as JobOutput)).toEqual(
@@ -716,12 +660,10 @@ describe("MetronomeSpecValidators", () => {
   describe("#argsUsedOnlyWithDocker", () => {
     it("does not return error if args are used with docker", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            args: [],
-            docker: {}
-          }
+        id: "id",
+        run: {
+          args: [],
+          docker: {}
         }
       };
       expect(
@@ -731,10 +673,8 @@ describe("MetronomeSpecValidators", () => {
 
     it("does not return error if there are no args", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {}
-        }
+        id: "id",
+        run: {}
       };
       expect(
         MetronomeSpecValidators.argsUsedOnlyWithDocker(spec as JobOutput)
@@ -743,11 +683,9 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if args are used without docker", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            args: ["arg"]
-          }
+        id: "id",
+        run: {
+          args: ["arg"]
         }
       };
       expect(
@@ -759,11 +697,9 @@ describe("MetronomeSpecValidators", () => {
   describe("#oneOfUcrOrDocker", () => {
     it("does not return error if neither docker or ucr are present", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            cmd: "cmd"
-          }
+        id: "id",
+        run: {
+          cmd: "cmd"
         }
       };
       expect(
@@ -773,11 +709,9 @@ describe("MetronomeSpecValidators", () => {
 
     it("does not return error if only ucr is present", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            ucr: {}
-          }
+        id: "id",
+        run: {
+          ucr: {}
         }
       };
       expect(
@@ -787,11 +721,9 @@ describe("MetronomeSpecValidators", () => {
 
     it("does not return error if only docker is present", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            docker: {}
-          }
+        id: "id",
+        run: {
+          docker: {}
         }
       };
       expect(
@@ -801,12 +733,10 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if both ucr and docker are present", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            docker: {},
-            ucr: {}
-          }
+        id: "id",
+        run: {
+          docker: {},
+          ucr: {}
         }
       };
       expect(
@@ -818,11 +748,9 @@ describe("MetronomeSpecValidators", () => {
   describe("#noDuplicateParams", () => {
     it("does not return error if there are no params", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            docker: {}
-          }
+        id: "id",
+        run: {
+          docker: {}
         }
       };
       expect(
@@ -832,12 +760,10 @@ describe("MetronomeSpecValidators", () => {
 
     it("does not return error if there is one param", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            docker: {
-              parameters: [{ key: "key", value: "value" }]
-            }
+        id: "id",
+        run: {
+          docker: {
+            parameters: [{ key: "key", value: "value" }]
           }
         }
       };
@@ -848,15 +774,13 @@ describe("MetronomeSpecValidators", () => {
 
     it("does not return error if there are no duplicate params", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            docker: {
-              parameters: [
-                { key: "key", value: "value" },
-                { key: "key2", value: "value" }
-              ]
-            }
+        id: "id",
+        run: {
+          docker: {
+            parameters: [
+              { key: "key", value: "value" },
+              { key: "key2", value: "value" }
+            ]
           }
         }
       };
@@ -867,25 +791,23 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns an error if there are duplicate params", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            docker: {
-              parameters: [
-                { key: "key", value: "value" },
-                { key: "key", value: "value" }
-              ]
-            }
+        id: "id",
+        run: {
+          docker: {
+            parameters: [
+              { key: "key", value: "value" },
+              { key: "key", value: "value" }
+            ]
           }
         }
       };
       const errors = [
         {
-          path: ["job", "run", "docker", "parameters", "0"],
+          path: ["run", "docker", "parameters", "0"],
           message: "No duplicate parameters."
         },
         {
-          path: ["job", "run", "docker", "parameters", "1"],
+          path: ["run", "docker", "parameters", "1"],
           message: "No duplicate parameters."
         }
       ];
@@ -898,10 +820,8 @@ describe("MetronomeSpecValidators", () => {
   describe("#noDuplicateArgs", () => {
     it("does not return error if there are no args", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {}
-        }
+        id: "id",
+        run: {}
       };
       expect(
         MetronomeSpecValidators.noDuplicateArgs(spec as JobOutput)
@@ -910,11 +830,9 @@ describe("MetronomeSpecValidators", () => {
 
     it("does not return error if there is one param", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            args: ["arg"]
-          }
+        id: "id",
+        run: {
+          args: ["arg"]
         }
       };
       expect(
@@ -924,11 +842,9 @@ describe("MetronomeSpecValidators", () => {
 
     it("does not return error if there are no duplicate params", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            args: ["arg1", "arg2"]
-          }
+        id: "id",
+        run: {
+          args: ["arg1", "arg2"]
         }
       };
       expect(
@@ -938,20 +854,18 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns an error if there are duplicate params", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            args: ["arg", "arg"]
-          }
+        id: "id",
+        run: {
+          args: ["arg", "arg"]
         }
       };
       const errors = [
         {
-          path: ["job", "run", "args", "0"],
+          path: ["run", "args", "0"],
           message: "No duplicate args."
         },
         {
-          path: ["job", "run", "args", "1"],
+          path: ["run", "args", "1"],
           message: "No duplicate args."
         }
       ];
@@ -964,41 +878,41 @@ describe("MetronomeSpecValidators", () => {
   describe("#checkTypesOfJobRunProps", () => {
     it("returns error if cmd is not a string", () => {
       const spec = validJobSpec() as any;
-      spec.job.run.cmd = 123;
+      spec.run.cmd = 123;
 
       expect(MetronomeSpecValidators.validate(spec)).toContainEqual({
         message: "Must be a string.",
-        path: ["job", "run", "cmd"]
+        path: ["run", "cmd"]
       });
     });
 
     it("returns error if cpus is not a number", () => {
       const spec = validJobSpec() as any;
-      spec.job.run.cpus = "123";
+      spec.run.cpus = "123";
 
       expect(MetronomeSpecValidators.validate(spec)).toContainEqual({
         message: "Must be a number.",
-        path: ["job", "run", "cpus"]
+        path: ["run", "cpus"]
       });
     });
 
     it("returns error if disk is not a number", () => {
       const spec = validJobSpec() as any;
-      spec.job.run.disk = "123";
+      spec.run.disk = "123";
 
       expect(MetronomeSpecValidators.validate(spec)).toContainEqual({
         message: "Must be a number.",
-        path: ["job", "run", "disk"]
+        path: ["run", "disk"]
       });
     });
 
     it("returns error if mem is not a number", () => {
       const spec = validJobSpec() as any;
-      spec.job.run.mem = "123";
+      spec.run.mem = "123";
 
       expect(MetronomeSpecValidators.validate(spec)).toContainEqual({
         message: "Must be a number.",
-        path: ["job", "run", "mem"]
+        path: ["run", "mem"]
       });
     });
   });
@@ -1006,31 +920,31 @@ describe("MetronomeSpecValidators", () => {
   describe("#isString", () => {
     it("returns error if image is not a string", () => {
       const spec = validJobSpec() as any;
-      spec.job.run.docker = { image: 123 };
+      spec.run.docker = { image: 123 };
 
       expect(MetronomeSpecValidators.validate(spec)).toContainEqual({
         message: "Must be a string.",
-        path: ["job", "run", "docker", "image"]
+        path: ["run", "docker", "image"]
       });
     });
 
     it("returns error if forcePullImage is not a boolean", () => {
       const spec = validJobSpec() as any;
-      spec.job.run.docker = { forcePullImage: 123 };
+      spec.run.docker = { forcePullImage: 123 };
 
       expect(MetronomeSpecValidators.validate(spec)).toContainEqual({
         message: "Must be a boolean.",
-        path: ["job", "run", "docker", "forcePullImage"]
+        path: ["run", "docker", "forcePullImage"]
       });
     });
 
     it("returns error if privileged is not a boolean", () => {
       const spec = validJobSpec() as any;
-      spec.job.run.docker = { privileged: 123 };
+      spec.run.docker = { privileged: 123 };
 
       expect(MetronomeSpecValidators.validate(spec)).toContainEqual({
         message: "Must be a boolean.",
-        path: ["job", "run", "docker", "privileged"]
+        path: ["run", "docker", "privileged"]
       });
     });
   });
@@ -1038,16 +952,14 @@ describe("MetronomeSpecValidators", () => {
   describe("#checkTypesOfUcrProps", () => {
     it("does not return error if ucr properties have correc type", () => {
       const spec = {
-        job: {
-          run: {
-            ucr: {
-              image: {
-                id: "image",
-                kind: "docker",
-                forcePull: true
-              },
-              privileged: false
-            }
+        run: {
+          ucr: {
+            image: {
+              id: "image",
+              kind: "docker",
+              forcePull: true
+            },
+            privileged: false
           }
         }
       };
@@ -1058,9 +970,7 @@ describe("MetronomeSpecValidators", () => {
 
     it("does not return error if no ucr", () => {
       const spec = {
-        job: {
-          run: {}
-        }
+        run: {}
       };
       expect(MetronomeSpecValidators.checkTypesOfUcrProps(spec as any)).toEqual(
         []
@@ -1069,42 +979,40 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if image is not an object", () => {
       const spec = validJobSpec() as any;
-      spec.job.run.ucr = { image: 123 };
+      spec.run.ucr = { image: 123 };
 
       expect(MetronomeSpecValidators.validate(spec)).toContainEqual({
         message: "Must be an object.",
-        path: ["job", "run", "ucr", "image"]
+        path: ["run", "ucr", "image"]
       });
     });
 
     it("returns error if privileged is not a boolean", () => {
       const spec = validJobSpec() as any;
-      spec.job.run.ucr = { privileged: 123 };
+      spec.run.ucr = { privileged: 123 };
 
       expect(MetronomeSpecValidators.validate(spec)).toContainEqual({
         message: "Must be a boolean.",
-        path: ["job", "run", "ucr", "privileged"]
+        path: ["run", "ucr", "privileged"]
       });
     });
 
     it("returns error if id is not a string", () => {
       const spec = validJobSpec() as any;
-      spec.job.run.ucr = { image: { id: 123 } };
+      spec.run.ucr = { image: { id: 123 } };
 
       expect(MetronomeSpecValidators.validate(spec)).toContainEqual({
         message: "Must be a string.",
-        path: ["job", "run", "ucr", "image", "id"]
+        path: ["run", "ucr", "image", "id"]
       });
     });
 
     it("returns error if kind is not `docker` or `appc`", () => {
       const spec = {
-        job: {
-          run: {
-            ucr: {
-              image: {
-                kind: 123
-              }
+        run: {
+          ucr: {
+            image: {
+              kind: 123
             }
           }
         }
@@ -1112,7 +1020,7 @@ describe("MetronomeSpecValidators", () => {
       expect(MetronomeSpecValidators.checkTypesOfUcrProps(spec as any)).toEqual(
         [
           {
-            path: ["job", "run", "ucr", "image", "kind"],
+            path: ["run", "ucr", "image", "kind"],
             message: "Image kind must be one of `docker` or `appc`."
           }
         ]
@@ -1121,11 +1029,11 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if forcePull is not a boolean", () => {
       const spec = validJobSpec() as any;
-      spec.job.run.ucr = { image: { forcePull: 123 } };
+      spec.run.ucr = { image: { forcePull: 123 } };
 
       expect(MetronomeSpecValidators.validate(spec)).toContainEqual({
         message: "Must be a boolean.",
-        path: ["job", "run", "ucr", "image", "forcePull"]
+        path: ["run", "ucr", "image", "forcePull"]
       });
     });
   });
@@ -1133,11 +1041,9 @@ describe("MetronomeSpecValidators", () => {
   describe("#scheduleHasId", () => {
     it("does not return error if there is no schedule", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            cmd: "cmd"
-          }
+        id: "id",
+        run: {
+          cmd: "cmd"
         }
       };
       expect(MetronomeSpecValidators.scheduleHasId(spec as JobOutput)).toEqual(
@@ -1147,13 +1053,11 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if schedule present without id", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            ucr: {}
-          }
+        id: "id",
+        run: {
+          ucr: {}
         },
-        schedule: {}
+        schedules: [{}]
       };
       expect(MetronomeSpecValidators.scheduleHasId(spec as JobOutput)).toEqual(
         SCHEDULEIDERROR
@@ -1164,11 +1068,9 @@ describe("MetronomeSpecValidators", () => {
   describe("#scheduleIdIsValid", () => {
     it("does not return error if there is no schedule", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            cmd: "cmd"
-          }
+        id: "id",
+        run: {
+          cmd: "cmd"
         }
       };
       expect(
@@ -1178,13 +1080,11 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if schedule id is invalid", () => {
       const spec = {
-        job: {
-          id: "-id",
-          run: {
-            ucr: {}
-          }
+        id: "-id",
+        run: {
+          ucr: {}
         },
-        schedule: {}
+        schedules: [{}]
       };
       expect(
         MetronomeSpecValidators.scheduleIdIsValid(spec as JobOutput)
@@ -1195,11 +1095,9 @@ describe("MetronomeSpecValidators", () => {
   describe("#scheduleHasCron", () => {
     it("does not return error if there is no schedule", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            cmd: "cmd"
-          }
+        id: "id",
+        run: {
+          cmd: "cmd"
         }
       };
       expect(
@@ -1209,13 +1107,11 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if schedule is present without cron", () => {
       const spec = {
-        job: {
-          id: "-id",
-          run: {
-            ucr: {}
-          }
+        id: "-id",
+        run: {
+          ucr: {}
         },
-        schedule: {}
+        schedules: [{}]
       };
       expect(
         MetronomeSpecValidators.scheduleHasCron(spec as JobOutput)
@@ -1226,11 +1122,9 @@ describe("MetronomeSpecValidators", () => {
   describe("#scheduleStartingDeadlineIsValid", () => {
     it("does not return error if there is no schedule", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            cmd: "cmd"
-          }
+        id: "id",
+        run: {
+          cmd: "cmd"
         }
       };
       expect(
@@ -1242,15 +1136,15 @@ describe("MetronomeSpecValidators", () => {
 
     it("does not return error if starting deadline is number > 0", () => {
       const spec = {
-        job: {
-          id: "id",
-          run: {
-            cmd: "cmd"
-          }
+        id: "id",
+        run: {
+          cmd: "cmd"
         },
-        schedule: {
-          startingDeadlineSeconds: 1
-        }
+        schedules: [
+          {
+            startingDeadlineSeconds: 1
+          }
+        ]
       };
       expect(
         MetronomeSpecValidators.scheduleStartingDeadlineIsValid(
@@ -1261,15 +1155,15 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if starting deadline is number less than 1", () => {
       const spec = {
-        job: {
-          id: "-id",
-          run: {
-            ucr: {}
-          }
+        id: "-id",
+        run: {
+          ucr: {}
         },
-        schedule: {
-          startingDeadlineSeconds: 0
-        }
+        schedules: [
+          {
+            startingDeadlineSeconds: 0
+          }
+        ]
       };
       expect(
         MetronomeSpecValidators.scheduleStartingDeadlineIsValid(
@@ -1280,15 +1174,15 @@ describe("MetronomeSpecValidators", () => {
 
     it("returns error if starting deadline is not a number", () => {
       const spec = {
-        job: {
-          id: "-id",
-          run: {
-            ucr: {}
-          }
+        id: "-id",
+        run: {
+          ucr: {}
         },
-        schedule: {
-          startingDeadlineSeconds: "not a number"
-        }
+        schedules: [
+          {
+            startingDeadlineSeconds: "not a number"
+          }
+        ]
       };
       expect(
         MetronomeSpecValidators.scheduleStartingDeadlineIsValid(spec as any)
@@ -1326,15 +1220,15 @@ describe("validateFormLabels", () => {
 
     expect(validateFormLabels(spec as any)).toEqual([
       {
-        path: ["job", "labels"],
+        path: ["labels"],
         message
       },
       {
-        path: ["job", "labels", "0"],
+        path: ["labels", "0"],
         message
       },
       {
-        path: ["job", "labels", "1"],
+        path: ["labels", "1"],
         message
       }
     ]);

--- a/plugins/jobs/src/js/components/form/reducers/JobReducers.ts
+++ b/plugins/jobs/src/js/components/form/reducers/JobReducers.ts
@@ -17,7 +17,11 @@ import {
   grantRuntimePrivilegesReducers,
   containerImageReducers
 } from "./ContainerReducers";
-import { enabledReducers, concurrencyPolicyReducers } from "./ScheduleReducers";
+import {
+  enabledReducers,
+  concurrencyPolicyReducers,
+  schedulesReducers
+} from "./ScheduleReducers";
 
 type DefaultReducerFunction = (
   value: string,
@@ -75,7 +79,8 @@ const combinedReducers: CombinedReducers = {
   labels,
   artifacts,
   activeDeadlineSeconds,
-  restartPolicy
+  restartPolicy,
+  schedules: schedulesReducers
 };
 
 export function jobFormOutputToSpecReducer(

--- a/plugins/jobs/src/js/components/form/reducers/JsonReducers.ts
+++ b/plugins/jobs/src/js/components/form/reducers/JsonReducers.ts
@@ -13,64 +13,55 @@ export const jsonReducers = {
     const valueCopy = deepCopy(value);
 
     if (
-      !valueCopy.job ||
-      Object.prototype.toString.call(valueCopy.job) !== "[object Object]"
+      !valueCopy ||
+      Object.prototype.toString.call(valueCopy) !== "[object Object]"
     ) {
       const newState = {
         job: stateCopy.job,
-        schedule: {
-          ...stateCopy.schedule,
-          ...valueCopy.schedule
-        },
         cmdOnly: stateCopy.cmdOnly,
         container: stateCopy.container
       };
-      if (!Object.keys(newState.schedule).length) {
-        newState.schedule = undefined;
-      }
       return newState;
     }
 
     // Can't check `typeof run === "object"` because that will return true for
     // arrays, null...
     if (
-      !valueCopy.job.run ||
-      Object.prototype.toString.call(valueCopy.job.run) !== "[object Object]"
+      !valueCopy.run ||
+      Object.prototype.toString.call(valueCopy.run) !== "[object Object]"
     ) {
       const newState = {
         cmdOnly: stateCopy.cmdOnly,
         container: stateCopy.container,
         job: {
           ...stateCopy.job,
-          ...valueCopy.job,
+          ...valueCopy,
           run: {
             ...stateCopy.job.run
           }
-        },
-        schedule: valueCopy.schedule
+        }
       };
       return newState;
     }
 
-    valueCopy.job.labels = isObject(valueCopy.job.labels)
-      ? Object.entries(valueCopy.job.labels)
-      : valueCopy.job.labels;
+    valueCopy.labels = isObject(valueCopy.labels)
+      ? Object.entries(valueCopy.labels)
+      : valueCopy.labels;
 
-    const cmdOnly = !(valueCopy.job.run.docker || valueCopy.job.run.ucr);
+    const cmdOnly = !(valueCopy.run.docker || valueCopy.run.ucr);
 
     // Try to assign `container` based first off of whether the new value from JSON contains a `docker` or
     // `ucr` property. If not, check if the previous state had a `container` specified (remember the last container
     // option the user had chosen). Finally, default to "ucr".
-    const container = valueCopy.job.run.docker
+    const container = valueCopy.run.docker
       ? Container.Docker
-      : valueCopy.job.run.ucr
+      : valueCopy.run.ucr
       ? Container.UCR
       : stateCopy.container || Container.UCR;
 
     const newState = {
       ...stateCopy,
-      job: valueCopy.job,
-      schedule: valueCopy.schedule,
+      job: valueCopy,
       cmdOnly,
       container
     };

--- a/plugins/jobs/src/js/components/form/reducers/ScheduleReducers.ts
+++ b/plugins/jobs/src/js/components/form/reducers/ScheduleReducers.ts
@@ -10,13 +10,16 @@ import { schedulePropertiesCanBeDiscarded } from "../helpers/ScheduleUtil";
 export const enabledReducers = {
   [JobFormActionType.Set]: (_: any, state: JobSpec) => {
     const stateCopy = deepCopy(state);
-    if (!stateCopy.schedule) {
-      stateCopy.schedule = {};
+    if (!stateCopy.job.schedules) {
+      stateCopy.job.schedules = [];
     }
-    const prevValue = Boolean(stateCopy.schedule.enabled);
-    stateCopy.schedule.enabled = !prevValue;
-    if (schedulePropertiesCanBeDiscarded(stateCopy.schedule)) {
-      stateCopy.schedule = undefined;
+    if (!stateCopy.job.schedules.length) {
+      stateCopy.job.schedules.push({});
+    }
+    const prevValue = Boolean(stateCopy.job.schedules[0].enabled);
+    stateCopy.job.schedules[0].enabled = !prevValue;
+    if (schedulePropertiesCanBeDiscarded(stateCopy.job.schedules[0])) {
+      stateCopy.job.schedules = undefined;
     }
     return stateCopy;
   }
@@ -25,17 +28,58 @@ export const enabledReducers = {
 export const concurrencyPolicyReducers = {
   [JobFormActionType.Set]: (_: any, state: JobSpec) => {
     const stateCopy = deepCopy(state);
-    if (!stateCopy.schedule) {
-      stateCopy.schedule = {};
+    if (!stateCopy.job.schedules) {
+      stateCopy.job.schedules = [];
     }
-    const prevValue = stateCopy.schedule.concurrencyPolicy;
-    stateCopy.schedule.concurrencyPolicy =
+    if (!stateCopy.job.schedules.length) {
+      stateCopy.job.schedules.push({});
+    }
+    const prevValue = stateCopy.job.schedules[0].concurrencyPolicy;
+    stateCopy.job.schedules[0].concurrencyPolicy =
       !prevValue || prevValue === ConcurrentPolicy.Forbid
-        ? (stateCopy.schedule.concurrencyPolicy = ConcurrentPolicy.Allow)
-        : (stateCopy.schedule.concurrencyPolicy = ConcurrentPolicy.Forbid);
-    if (schedulePropertiesCanBeDiscarded(stateCopy.schedule)) {
-      stateCopy.schedule = undefined;
+        ? (stateCopy.job.schedules[0].concurrencyPolicy =
+            ConcurrentPolicy.Allow)
+        : (stateCopy.job.schedules[0].concurrencyPolicy =
+            ConcurrentPolicy.Forbid);
+    if (schedulePropertiesCanBeDiscarded(stateCopy.job.schedules[0])) {
+      stateCopy.job.schedules = undefined;
     }
     return stateCopy;
+  }
+};
+
+function updateScheduleAt(state: JobSpec, path: string[], value: any) {
+  const stateCopy = deepCopy(state);
+  const assignProp = path[0];
+  if (!assignProp) {
+    throw Error(`can not set a prop without a path`);
+  }
+  if (!stateCopy.job.schedules) {
+    stateCopy.job.schedules = [];
+  }
+
+  if (Array.isArray(stateCopy.job.schedules)) {
+    if (!stateCopy.job.schedules.length) {
+      stateCopy.job.schedules.push({});
+    }
+    stateCopy.job.schedules[0][assignProp] = value;
+  }
+
+  return stateCopy;
+}
+
+export const schedulesReducers = {
+  [JobFormActionType.Set]: (value: string, state: JobSpec, path: string[]) => {
+    return updateScheduleAt(state, path, value);
+  },
+
+  [JobFormActionType.SetNum]: (
+    value: string,
+    state: JobSpec,
+    path: string[]
+  ) => {
+    const numValue = parseFloat(value);
+    const newValue = !isNaN(numValue) ? numValue : "";
+    return updateScheduleAt(state, path, newValue);
   }
 };

--- a/plugins/jobs/src/js/components/form/reducers/__tests__/JobReducers-test.ts
+++ b/plugins/jobs/src/js/components/form/reducers/__tests__/JobReducers-test.ts
@@ -50,16 +50,14 @@ describe("JobReducers", () => {
     describe("Override action", () => {
       it("overrides current state with JSON value while maintaining container options", () => {
         const jsonValue = {
-          job: {
-            id: "newId",
-            description: "desc",
-            run: {
-              cmd: "foo",
-              cpus: 1,
-              disk: 0,
-              mem: 32,
-              gpus: 0
-            }
+          id: "newId",
+          description: "desc",
+          run: {
+            cmd: "foo",
+            cpus: 1,
+            disk: 0,
+            mem: 32,
+            gpus: 0
           }
         };
         const expected = {
@@ -90,18 +88,16 @@ describe("JobReducers", () => {
 
       it("adds container image value to both container objects in job spec if present", () => {
         const jsonValue = {
-          job: {
-            id: "newId",
-            description: "desc",
-            run: {
-              cmd: "foo",
-              cpus: 1,
-              disk: 0,
-              mem: 32,
-              gpus: 0,
-              docker: {
-                image: "bar"
-              }
+          id: "newId",
+          description: "desc",
+          run: {
+            cmd: "foo",
+            cpus: 1,
+            disk: 0,
+            mem: 32,
+            gpus: 0,
+            docker: {
+              image: "bar"
             }
           }
         };

--- a/plugins/jobs/src/js/data/JobModel.ts
+++ b/plugins/jobs/src/js/data/JobModel.ts
@@ -36,7 +36,7 @@ import {
   JobSchema
 } from "#PLUGINS/jobs/src/js/types/Job";
 import { JobLink, JobLinkSchema } from "#PLUGINS/jobs/src/js/types/JobLink";
-import { JobOutput } from "../components/form/helpers/JobFormData";
+import { JobAPIOutput } from "../components/form/helpers/JobFormData";
 import { JobSchedule } from "../types/JobSchedule";
 
 export interface Query {
@@ -52,11 +52,11 @@ export interface ResolverArgs {
   pollingInterval: number;
   runJob: (id: string) => Observable<RequestResponse<JobLink>>;
   createJob: (
-    data: JobOutput
+    data: JobAPIOutput
   ) => Observable<RequestResponse<MetronomeJobDetailResponse>>;
   updateJob: (
     id: string,
-    data: JobOutput,
+    data: JobAPIOutput,
     existingSchedule?: boolean
   ) => Observable<RequestResponse<MetronomeJobDetailResponse>>;
   updateSchedule: (

--- a/src/js/events/MetronomeClient.ts
+++ b/src/js/events/MetronomeClient.ts
@@ -5,7 +5,7 @@ import { Observable, throwError } from "rxjs";
 import Config from "../config/Config";
 import {
   JobSchedule,
-  JobOutput
+  JobAPIOutput
 } from "plugins/jobs/src/js/components/form/helpers/JobFormData";
 import { switchMap, catchError } from "rxjs/operators";
 // Add interface information: https://jira.mesosphere.com/browse/DCOS-37725
@@ -160,7 +160,7 @@ const defaultHeaders = {
 };
 
 export function createJob(
-  data: JobOutput
+  data: JobAPIOutput
 ): Observable<RequestResponse<JobDetailResponse>> {
   const jobRequest = request(`${Config.metronomeAPI}/v1/jobs`, {
     method: "POST",
@@ -208,7 +208,7 @@ export function deleteJob(
 
 export function updateJob(
   jobID: string,
-  data: JobOutput,
+  data: JobAPIOutput,
   existingSchedule: boolean = true
 ): Observable<RequestResponse<JobDetailResponse>> {
   const updateJobRequest = request(`${Config.metronomeAPI}/v1/jobs/${jobID}`, {

--- a/tests/pages/jobs/JobJSONEditor-cy.js
+++ b/tests/pages/jobs/JobJSONEditor-cy.js
@@ -9,7 +9,7 @@ describe("Job JSON Editor", function() {
   });
 
   it("renders proper JSON for a simple job", function() {
-    const jobName = "job-with-inline-shell-script";
+    const jobName = "simple";
     const fullJobName = `${Cypress.env("TEST_UUID")}.${jobName}`;
     const cmdline = "while true; do echo 'test' ; sleep 100 ; done";
 
@@ -49,22 +49,20 @@ describe("Job JSON Editor", function() {
       .asJson()
       .should("deep.equal", [
         {
-          job: {
-            id: fullJobName,
-            description: "",
-            run: {
-              cpus: 1,
-              mem: 32,
-              disk: 0,
-              cmd: cmdline
-            }
+          id: fullJobName,
+          description: "",
+          run: {
+            cpus: 1,
+            mem: 32,
+            disk: 0,
+            cmd: cmdline
           }
         }
       ]);
   });
 
   it("renders proper JSON for a job with default container image", function() {
-    const jobName = "job-with-docker-config";
+    const jobName = "default";
     const fullJobName = `${Cypress.env("TEST_UUID")}.${jobName}`;
     const cmdline = "while true; do echo 'test' ; sleep 100 ; done";
 
@@ -112,20 +110,18 @@ describe("Job JSON Editor", function() {
       .asJson()
       .should("deep.equal", [
         {
-          job: {
-            id: fullJobName,
-            description: "",
-            run: {
-              cpus: 1,
-              mem: 32,
-              disk: 0,
-              gpus: 1,
-              cmd: cmdline,
-              ucr: {
-                image: {
-                  id: "nginx",
-                  kind: "docker"
-                }
+          id: fullJobName,
+          description: "",
+          run: {
+            cpus: 1,
+            mem: 32,
+            disk: 0,
+            gpus: 1,
+            cmd: cmdline,
+            ucr: {
+              image: {
+                id: "nginx",
+                kind: "docker"
               }
             }
           }
@@ -164,7 +160,7 @@ describe("Job JSON Editor", function() {
   });
 
   it("renders proper JSON for a job using UCR with advanced options", () => {
-    const jobName = "job-with-ucr-config";
+    const jobName = "ucr";
     const fullJobName = `${Cypress.env("TEST_UUID")}.${jobName}`;
     const cmdline = "while true; do echo 'test' ; sleep 100 ; done";
 
@@ -252,29 +248,27 @@ describe("Job JSON Editor", function() {
       .asJson()
       .should("deep.equal", [
         {
-          job: {
-            id: fullJobName,
-            description: "",
-            run: {
-              cpus: 1,
-              mem: 32,
-              disk: 0,
-              gpus: 1,
-              cmd: cmdline,
-              ucr: {
-                image: {
-                  id: "nginx",
-                  kind: "docker",
-                  forcePull: true
-                }
-              },
-              maxLaunchDelay: 1,
-              taskKillGracePeriodSeconds: 2,
-              user: "user1",
-              restart: {
-                policy: "ON_FAILURE",
-                activeDeadlineSeconds: 3
+          id: fullJobName,
+          description: "",
+          run: {
+            cpus: 1,
+            mem: 32,
+            disk: 0,
+            gpus: 1,
+            cmd: cmdline,
+            ucr: {
+              image: {
+                id: "nginx",
+                kind: "docker",
+                forcePull: true
               }
+            },
+            maxLaunchDelay: 1,
+            taskKillGracePeriodSeconds: 2,
+            user: "user1",
+            restart: {
+              policy: "ON_FAILURE",
+              activeDeadlineSeconds: 3
             }
           }
         }
@@ -282,7 +276,7 @@ describe("Job JSON Editor", function() {
   });
 
   it("renders proper JSON for a job using Docker with advanced options", () => {
-    const jobName = "job-with-docker-config";
+    const jobName = "docker";
     const fullJobName = `${Cypress.env("TEST_UUID")}.${jobName}`;
     const cmdline = "while true; do echo 'test' ; sleep 100 ; done";
 
@@ -344,19 +338,17 @@ describe("Job JSON Editor", function() {
       .asJson()
       .should("deep.equal", [
         {
-          job: {
-            id: fullJobName,
-            description: "",
-            run: {
-              cpus: 1,
-              mem: 32,
-              disk: 0,
-              cmd: cmdline,
-              docker: {
-                image: "nginx",
-                forcePullImage: true,
-                privileged: true
-              }
+          id: fullJobName,
+          description: "",
+          run: {
+            cpus: 1,
+            mem: 32,
+            disk: 0,
+            cmd: cmdline,
+            docker: {
+              image: "nginx",
+              forcePullImage: true,
+              privileged: true
             }
           }
         }
@@ -364,7 +356,7 @@ describe("Job JSON Editor", function() {
   });
 
   it("renders proper JSON for a job using Docker with parameters", () => {
-    const jobName = "job-with-docker-config";
+    const jobName = "params";
     const fullJobName = `${Cypress.env("TEST_UUID")}.${jobName}`;
     const cmdline = "while true; do echo 'test' ; sleep 100 ; done";
     const dockerParam = {
@@ -443,20 +435,18 @@ describe("Job JSON Editor", function() {
       .asJson()
       .should("deep.equal", [
         {
-          job: {
-            id: fullJobName,
-            description: "",
-            run: {
-              cpus: 1,
-              mem: 32,
-              disk: 0,
-              cmd: cmdline,
-              docker: {
-                image: "nginx",
-                forcePullImage: true,
-                privileged: true,
-                parameters: [dockerParam]
-              }
+          id: fullJobName,
+          description: "",
+          run: {
+            cpus: 1,
+            mem: 32,
+            disk: 0,
+            cmd: cmdline,
+            docker: {
+              image: "nginx",
+              forcePullImage: true,
+              privileged: true,
+              parameters: [dockerParam]
             }
           }
         }
@@ -464,7 +454,7 @@ describe("Job JSON Editor", function() {
   });
 
   it("renders proper JSON for a job using Docker with args", () => {
-    const jobName = "job-with-docker-config";
+    const jobName = "args";
     const fullJobName = `${Cypress.env("TEST_UUID")}.${jobName}`;
     const cmdline = "while true; do echo 'test' ; sleep 100 ; done";
     const arg = "arg";
@@ -536,20 +526,18 @@ describe("Job JSON Editor", function() {
       .asJson()
       .should("deep.equal", [
         {
-          job: {
-            id: fullJobName,
-            description: "",
-            run: {
-              args: [arg],
-              cpus: 1,
-              mem: 32,
-              disk: 0,
-              cmd: cmdline,
-              docker: {
-                image: "nginx",
-                forcePullImage: true,
-                privileged: true
-              }
+          id: fullJobName,
+          description: "",
+          run: {
+            args: [arg],
+            cpus: 1,
+            mem: 32,
+            disk: 0,
+            cmd: cmdline,
+            docker: {
+              image: "nginx",
+              forcePullImage: true,
+              privileged: true
             }
           }
         }
@@ -557,7 +545,7 @@ describe("Job JSON Editor", function() {
   });
 
   it("renders proper JSON for a job with a schedule", () => {
-    const jobName = "job-with-schedule";
+    const jobName = "schedule";
     const fullJobName = `${Cypress.env("TEST_UUID")}.${jobName}`;
     const cmdline = "while true; do echo 'test' ; sleep 100 ; done";
     const scheduleId = "schedule-id";
@@ -625,24 +613,24 @@ describe("Job JSON Editor", function() {
       .asJson()
       .should("deep.equal", [
         {
-          job: {
-            id: fullJobName,
-            description: "",
-            run: {
-              cpus: 1,
-              mem: 32,
-              disk: 0,
-              cmd: cmdline
-            }
+          id: fullJobName,
+          description: "",
+          run: {
+            cpus: 1,
+            mem: 32,
+            disk: 0,
+            cmd: cmdline
           },
-          schedule: {
-            enabled: true,
-            startingDeadlineSeconds: startingDeadline,
-            id: scheduleId,
-            timezone,
-            cron,
-            concurrencyPolicy: "ALLOW"
-          }
+          schedules: [
+            {
+              enabled: true,
+              startingDeadlineSeconds: startingDeadline,
+              id: scheduleId,
+              timezone,
+              cron,
+              concurrencyPolicy: "ALLOW"
+            }
+          ]
         }
       ]);
   });


### PR DESCRIPTION
Make the JSON editor contents of the job form appear to be in metronome V0 spec format. Send payload to the API in V1 format.

Backport of #3866. See original PR for more details and testing instructions. Please do still smoke test jobs form as this was not a direct cherry-pick.

Closes DCOS-55586
