### PR TITLE
[DCOS-55014] add drain status to node details

### DIFF
--- a/plugins/nodes/src/js/pages/nodes/NodeDetailTab.js
+++ b/plugins/nodes/src/js/pages/nodes/NodeDetailTab.js
@@ -2,6 +2,8 @@ import { Trans, DateFormat } from "@lingui/macro";
 import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import { request } from "@dcos/mesos-client";
+import { Icon } from "@dcos/ui-kit";
+import { iconSizeXs } from "@dcos/ui-kit/dist/packages/design-tokens/build/js/designTokens";
 
 import { MESOS_STATE_CHANGE } from "#SRC/js/constants/EventTypes";
 import MesosStateStore from "#SRC/js/stores/MesosStateStore";
@@ -18,6 +20,7 @@ import StringUtil from "#SRC/js/utils/StringUtil";
 import DateUtil from "#SRC/js/utils/DateUtil";
 import Units from "#SRC/js/utils/Units";
 import Loader from "#SRC/js/components/Loader";
+import { Status } from "../../types/Status";
 
 class NodeDetailTab extends PureComponent {
   constructor() {
@@ -57,12 +60,24 @@ class NodeDetailTab extends PureComponent {
     });
   }
 
+  hasMaintenanceData() {
+    const { node } = this.props;
+
+    // Detecting whether DCOS already supports maintenance mode.
+    // We might want to remove this flag at some point in the future.
+    return (
+      node.get("drain_info") !== undefined ||
+      node.get("deactivated") !== undefined
+    );
+  }
+
   render() {
     const { node } = this.props;
     if (!node) {
       return null;
     }
     const resources = node.get("resources");
+    const status = Status.fromNode(node);
 
     return (
       <div className="container">
@@ -74,14 +89,16 @@ class NodeDetailTab extends PureComponent {
               </ConfigurationMapLabel>
               <ConfigurationMapValue>{node.id}</ConfigurationMapValue>
             </ConfigurationMapRow>
-            <ConfigurationMapRow>
-              <ConfigurationMapLabel>
-                <Trans render="span">Active</Trans>
-              </ConfigurationMapLabel>
-              <ConfigurationMapValue>
-                {StringUtil.capitalize(node.active.toString().toLowerCase())}
-              </ConfigurationMapValue>
-            </ConfigurationMapRow>
+            {!this.hasMaintenanceData() && (
+              <ConfigurationMapRow>
+                <ConfigurationMapLabel>
+                  <Trans render="span">Active</Trans>
+                </ConfigurationMapLabel>
+                <ConfigurationMapValue>
+                  {StringUtil.capitalize(node.active.toString().toLowerCase())}
+                </ConfigurationMapValue>
+              </ConfigurationMapRow>
+            )}
             <ConfigurationMapRow>
               <ConfigurationMapLabel>
                 <Trans render="span">Registered</Trans>
@@ -124,6 +141,34 @@ class NodeDetailTab extends PureComponent {
             </ConfigurationMapRow>
           </ConfigurationMapSection>
           <HashMapDisplay hash={node.attributes} headline="Attributes" />
+          {this.hasMaintenanceData() && (
+            <ConfigurationMapSection>
+              <ConfigurationMapHeading>
+                <Trans render="span">Status</Trans>
+              </ConfigurationMapHeading>
+              <ConfigurationMapRow>
+                <ConfigurationMapLabel>
+                  <Trans render="span">Active</Trans>
+                </ConfigurationMapLabel>
+                <ConfigurationMapValue>
+                  {StringUtil.capitalize(node.active.toString().toLowerCase())}
+                </ConfigurationMapValue>
+              </ConfigurationMapRow>
+              <ConfigurationMapRow>
+                <ConfigurationMapLabel>
+                  <Trans render="span">Status</Trans>
+                </ConfigurationMapLabel>
+                <ConfigurationMapValue>
+                  <span>
+                    <Icon {...status.icon} size={iconSizeXs} />
+                    <span style={{ marginLeft: "7px" }}>
+                      {status.displayName}
+                    </span>
+                  </span>
+                </ConfigurationMapValue>
+              </ConfigurationMapRow>
+            </ConfigurationMapSection>
+          )}
           <ConfigurationMapSection>
             <ConfigurationMapHeading>
               <Trans render="span">Resources</Trans>

--- a/tests/_fixtures/marathon-1-task/summary.json
+++ b/tests/_fixtures/marathon-1-task/summary.json
@@ -46,9 +46,7 @@
       "TASK_STARTING": 0,
       "active": true,
       "attributes": {},
-      "framework_ids": [
-        "20150827-210452-1695027628-5050-1445-0000"
-      ],
+      "framework_ids": ["20150827-210452-1695027628-5050-1445-0000"],
       "hostname": "dcos-01",
       "domain": {
         "fault_domain": {
@@ -87,7 +85,9 @@
         "disk": 0,
         "mem": 16,
         "ports": "[10000-10000]"
-      }
+      },
+      "deactivated": true,
+      "drain_info": { "state": "DRAINING", "config": {} }
     },
     {
       "TASK_ERROR": 0,
@@ -100,9 +100,7 @@
       "TASK_STARTING": 0,
       "active": true,
       "attributes": {},
-      "framework_ids": [
-        "20150827-210452-1695027628-5050-1445-0000"
-      ],
+      "framework_ids": ["20150827-210452-1695027628-5050-1445-0000"],
       "hostname": "dcos-01",
       "id": "20151002-000353-1695027628-5050-1177-S0",
       "offered_resources": {
@@ -134,12 +132,15 @@
         "mem": 2933,
         "ports": "[1025-2180, 2182-3887, 3889-5049, 5052-8079, 8082-8180, 8182-32000]"
       },
+
       "used_resources": {
         "cpus": 0.1,
         "disk": 0,
         "mem": 16,
         "ports": "[10000-10000]"
-      }
+      },
+      "deactivated": true,
+      "drain_info": { "state": "DRAINED", "config": {} }
     },
     {
       "TASK_ERROR": 0,
@@ -152,9 +153,7 @@
       "TASK_STARTING": 0,
       "active": true,
       "attributes": {},
-      "framework_ids": [
-        "20150827-210452-1695027628-5050-1445-0000"
-      ],
+      "framework_ids": ["20150827-210452-1695027628-5050-1445-0000"],
       "hostname": "dcos-02",
       "id": "20151002-000353-1695027628-5050-1177-S1",
       "domain": {
@@ -206,9 +205,7 @@
       "TASK_STARTING": 0,
       "active": true,
       "attributes": {},
-      "framework_ids": [
-        "20150827-210452-1695027628-5050-1445-0000"
-      ],
+      "framework_ids": ["20150827-210452-1695027628-5050-1445-0000"],
       "hostname": "dcos-03",
       "id": "20151002-000353-1695027628-5050-1177-S2",
       "domain": {

--- a/tests/pages/nodes/node/NodeDetail-cy.js
+++ b/tests/pages/nodes/node/NodeDetail-cy.js
@@ -1,3 +1,5 @@
+require("../../../_support/utils/ServicesUtil");
+
 describe("Nodes Detail Page", function() {
   beforeEach(function() {
     cy.configureCluster({
@@ -20,6 +22,7 @@ describe("Nodes Detail Page", function() {
         .click({ force: true });
 
       cy.hash().should("match", /nodes\/[a-zA-Z0-9-]+/);
+
       cy.get(".page-header").should(function($title) {
         expect($title).to.contain(nodeName);
       });
@@ -32,6 +35,31 @@ describe("Nodes Detail Page", function() {
       cy.get(".page-body-content h3").should(function($title) {
         expect($title).to.contain("Error finding node");
       });
+    });
+  });
+
+  context("Node Details", function() {
+    it("shows node status", function() {
+      cy.visitUrl({
+        url: `/nodes/20151002-000353-1695027628-5050-1177-S0/details`,
+        identify: true
+      });
+
+      cy.get("h1.configuration-map-heading").should(function($h1) {
+        // Should have found 2 elements
+        expect($h1).to.have.length(2);
+
+        // First should be Status
+        expect($h1.eq(0)).to.contain("Status");
+
+        // Second should be Resources
+        expect($h1.eq(1)).to.contain("Resources");
+      });
+
+      cy.root()
+        .configurationSection("Status")
+        .configurationMapValue("Status")
+        .contains("Draining");
     });
   });
 });


### PR DESCRIPTION
## Testing

There is a bug that prevents the mesos state store from loading when useFixtures is true (this does not seem to affect integration tests?) Let me know if you are affected by the same issue. If so, just bypass the state store loading by changing NodeDetailPage line 41 from `mesosStateLoaded: false` to `mesosStateLoaded: true`

Visit the node details page (details tab) and see the drain status and new section there

## Dependencies

This PR is currently based on #3960 

## Screenshots

![Screen Shot 2019-07-01 at 3 01 25 PM](https://user-images.githubusercontent.com/174332/60483988-074ab300-9c55-11e9-8f49-483eb91afcd9.png)
