### PR TITLE
DCOS_OSS-2208: add space between ports

### DIFF
--- a/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
+++ b/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
@@ -250,7 +250,7 @@ class PodInstancesTable extends React.Component {
       const addressComponents = container
         .getEndpoints()
         .map(function(endpoint, i) {
-          return (
+          return [
             <a
               className="text-muted"
               href={`http://${agentAddress}:${endpoint.allocatedHostPort}`}
@@ -259,8 +259,9 @@ class PodInstancesTable extends React.Component {
               title="Open in a new window"
             >
               {endpoint.allocatedHostPort}
-            </a>
-          );
+            </a>,
+            " "
+          ];
         });
 
       return {


### PR DESCRIPTION
Closes DCOS_OSS-2208

## Testing

<details><summary>Launch this pod</summary>
<p>

```
{
  "id": "/ports-test",
  "version": "2019-07-05T08:57:46.306Z",
  "containers": [
    {
      "name": "container-1",
      "resources": {
        "cpus": 0.1,
        "mem": 128,
        "disk": 0,
        "gpus": 0
      },
      "exec": {
        "command": {
          "shell": "sleep infinity;"
        }
      },
      "endpoints": [
        {
          "name": "ping",
          "containerPort": 9000,
          "hostPort": 0,
          "protocol": [
            "tcp"
          ]
        },
        {
          "name": "test",
          "containerPort": 8000,
          "hostPort": 0,
          "protocol": [
            "tcp"
          ]
        }
      ]
    }
  ],
  "networks": [
    {
      "name": "dcos",
      "mode": "container"
    }
  ],
  "scaling": {
    "instances": 1,
    "kind": "fixed"
  },
  "scheduling": {
    "backoff": {
      "backoff": 1,
      "backoffFactor": 1.15,
      "maxLaunchDelay": 300
    },
    "upgrade": {
      "minimumHealthCapacity": 1,
      "maximumOverCapacity": 1
    },
    "killSelection": "YOUNGEST_FIRST",
    "unreachableStrategy": {
      "inactiveAfterSeconds": 0,
      "expungeAfterSeconds": 0
    },
    "placement": {
      "constraints": []
    }
  },
  "executorResources": {
    "cpus": 0.1,
    "mem": 32,
    "disk": 10
  },
  "volumes": [],
  "fetch": []
}
```

</p>
</details>

## Trade-offs

We have trailing empty space character that doesn't get in a way

## Screenshots

Before | After
------ | ------
![Screenshot 2019-07-05 at 11 53 39](https://user-images.githubusercontent.com/186223/60714558-925ccf00-9f1b-11e9-9e99-472ea579baf0.png) | ![Screenshot 2019-07-05 at 11 53 21](https://user-images.githubusercontent.com/186223/60714559-925ccf00-9f1b-11e9-8fff-aa082c770552.png)
