### PR TITLE
[COPS-4214] Parse datetime in Service version

### DIFF
--- a/plugins/services/src/js/components/MarathonTaskDetailsList.js
+++ b/plugins/services/src/js/components/MarathonTaskDetailsList.js
@@ -94,7 +94,9 @@ class MarathonTaskDetailsList extends React.Component {
           <ConfigurationMapLabel>
             <Trans render="span">Version</Trans>
           </ConfigurationMapLabel>
-          <ConfigurationMapValue>{task.version}</ConfigurationMapValue>
+          <ConfigurationMapValue>
+            {this.getTimeField(task.version)}
+          </ConfigurationMapValue>
         </ConfigurationMapRow>
       </ConfigurationMapSection>
     );

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
@@ -117,14 +117,18 @@ class ServiceConfiguration extends mixin(StoreMixin) {
 
     if (service.getVersion() !== selectedVersionID) {
       applyButton = (
-        <button
-          className="button button-primary-link"
-          disabled={isSDKService(service)}
-          key="version-button-apply"
-          onClick={() => this.handleApplyButtonClick()}
+        <Trans
+          render={
+            <button
+              className="button button-primary-link"
+              disabled={isSDKService(service)}
+              key="version-button-apply"
+              onClick={() => this.handleApplyButtonClick()}
+            />
+          }
         >
           Apply
-        </button>
+        </Trans>
       );
     }
 

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
@@ -144,22 +144,6 @@ class ServiceConfiguration extends mixin(StoreMixin) {
         return new Date(a) - new Date(b);
       })
       .map(version => {
-        const localeVersion = new Date(version).toLocaleString();
-        let itemCaption = localeVersion;
-        if (version === service.getVersion()) {
-          itemCaption = (
-            <span className="badge-container flex">
-              <span className="badge-container-text services-version-text text-overflow">
-                <DateFormat
-                  value={version}
-                  format={DateUtil.getFormatOptions()}
-                />
-              </span>
-              <Trans render={<Badge />}>Active</Trans>
-            </span>
-          );
-        }
-
         return {
           id: version,
           html: (
@@ -182,7 +166,17 @@ class ServiceConfiguration extends mixin(StoreMixin) {
                 className="button-split-content-item flex-item-grow-1 text-overflow"
                 title={version}
               >
-                {itemCaption}
+                <span className="badge-container flex">
+                  <span className="badge-container-text services-version-text text-overflow">
+                    <DateFormat
+                      value={version}
+                      format={DateUtil.getFormatOptions()}
+                    />
+                  </span>
+                  {version === service.getVersion() && (
+                    <Trans render={<Badge />}>Active</Trans>
+                  )}
+                </span>
               </span>
             </div>
           )

--- a/plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js
@@ -1,10 +1,11 @@
-import { Trans } from "@lingui/macro";
+import { Trans, DateFormat } from "@lingui/macro";
 import { i18nMark } from "@lingui/react";
 import React from "react";
 import { Table } from "reactjs-components";
 
 import { findNestedPropertyInObject } from "#SRC/js/utils/Util";
 import { formatResource } from "#SRC/js/utils/Units";
+import DateUtil from "#SRC/js/utils/DateUtil";
 
 import ContainerConstants from "../constants/ContainerConstants";
 import ServiceConfigBaseSectionDisplay from "./ServiceConfigBaseSectionDisplay";
@@ -240,7 +241,17 @@ class ServiceGeneralConfigSection extends ServiceConfigBaseSectionDisplay {
         },
         {
           key: "version",
-          label: <Trans render="span">Version</Trans>
+          label: <Trans render="span">Version</Trans>,
+          transformValue(value = []) {
+            const timeString = new Date(value);
+
+            return (
+              <DateFormat
+                value={timeString}
+                format={DateUtil.getFormatOptions()}
+              />
+            );
+          }
         },
         {
           key: "fetch",


### PR DESCRIPTION
Turned out `version` in Marathon [has always been](https://github.com/mesosphere/marathon/blob/master/docs/docs/rest-api/public/api/v2/types/app.raml#L318) `datetime` and we though it could be a free form string that is happen to be datetime in dcos.

Given we've thought it was a freeform string we still would parse it in the versions dropdown, but only for the active version

## Testing

Create any _app_ and edit it couple of times to get several versions in history

## Screenshots
Before | After
-- | --
![Screenshot 2019-07-05 at 15 42 50](https://user-images.githubusercontent.com/186223/60726349-9c8ec580-9f3b-11e9-9ef3-13d1d2a2b81d.png) ![Screenshot 2019-07-05 at 15 42 47](https://user-images.githubusercontent.com/186223/60726351-9c8ec580-9f3b-11e9-8088-c75a254cb8c5.png) | ![Screenshot 2019-07-05 at 15 41 40](https://user-images.githubusercontent.com/186223/60726352-9c8ec580-9f3b-11e9-8d40-36656c75b48e.png) ![Screenshot 2019-07-05 at 15 41 35](https://user-images.githubusercontent.com/186223/60726353-9d275c00-9f3b-11e9-9f33-17316a8beffa.png)
