### PR TITLE
DCOS-56244: Networks empty IP subnet

### DIFF
--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkDetailsTab.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkDetailsTab.js
@@ -28,7 +28,7 @@ class VirtualNetworkDetailsTab extends React.Component {
                 <Trans render="span">IP Subnet</Trans>
               </ConfigurationMapLabel>
               <ConfigurationMapValue>
-                {overlay.getSubnet()}
+                {overlay.getSubnet() || overlay.getSubnet6()}
               </ConfigurationMapValue>
             </ConfigurationMapRow>
           </ConfigurationMapSection>


### PR DESCRIPTION
Show IP Subnet on the virtual network detail tab if is is a ipv6 value.

Closes https://jira.mesosphere.com/browse/DCOS-56244

## Testing
1. Go to Networking > Networks page.
2. Open an ipv6 network, for example dcos6 on our daily cluster.
3. Open the details tab.
4. Verify that the ip subnet is shown and is correct (same as the ip subnet on the Networks page).

## Trade-offs
None.

## Dependencies
None.

## Screenshots
### Before
![Screenshot from 2019-07-09 10-03-00](https://user-images.githubusercontent.com/40791275/60878435-60fc4000-a248-11e9-9197-f92b19bf9ca5.png)

### After
![Screenshot from 2019-07-09 12-47-32](https://user-images.githubusercontent.com/40791275/60878455-6b1e3e80-a248-11e9-836c-51cea067e4db.png)

