### PR TITLE
DCOS-56382 Fix Maintenance Status Change in NodesTable

### DIFF
--- a/plugins/nodes/src/js/components/NodesTable.tsx
+++ b/plugins/nodes/src/js/components/NodesTable.tsx
@@ -37,7 +37,6 @@ import PublicIPColumn from "../columns/NodesTablePublicIPColumn";
 interface NodesTableProps {
   withPublicIP: boolean;
   hosts: NodesList;
-  nodeHealthResponse: boolean;
   masterRegion: string;
 }
 

--- a/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
+++ b/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
@@ -20,7 +20,6 @@ class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
     this.state = {
       filteredNodes: null,
       filters: { health: "all", name: "", service: null },
-      nodeHealthResponse: false,
       masterRegion: null
     };
     this.store_listeners = [
@@ -106,10 +105,7 @@ class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
   }
 
   onNodeHealthStoreSuccess() {
-    this.setState({
-      filteredNodes: this.getFilteredNodes(),
-      nodeHealthResponse: true
-    });
+    this.setState({ filteredNodes: this.getFilteredNodes() });
   }
 
   onStateStoreSuccess() {
@@ -119,7 +115,7 @@ class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
   }
 
   render() {
-    const { nodeHealthResponse, filteredNodes, masterRegion } = this.state;
+    const { filteredNodes, masterRegion } = this.state;
     const { networks = [] } = this.props;
 
     // Detecting whether DCOS already supports maintenance mode.
@@ -128,7 +124,6 @@ class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
       <NodesTable
         withPublicIP={networks.length > 0}
         hosts={filteredNodes}
-        nodeHealthResponse={nodeHealthResponse}
         masterRegion={masterRegion}
       />
     );

--- a/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
+++ b/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
@@ -49,12 +49,9 @@ class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
       service: query.filterService || null
     };
 
-    if (
-      this.props.location.query.filterExpression !== query.filterExpression ||
-      this.props.location.query.filterService !== query.filterService
-    ) {
-      this.setFilters(hosts, networks, filters);
-    }
+    // when trying to optimize here, please account for data that may change in `hosts`,
+    // like `TASK_RUNNING`, `resources.*` or `drain_info`.
+    this.setFilters(hosts, networks, filters);
   }
 
   getFilteredNodes(filters = this.state.filters) {


### PR DESCRIPTION
## Testing


### Setup

make sure you're using the maintenance feature in `Config.dev.ts`:

```
  useFixtures: false,
  useUIConfigFixtures: true,
  uiConfigurationFixture: {
    uiConfiguration: {
      features: {
        maintenance: true,
      },
```

Is a bit tricky. Either follow the instructions in https://jira.mesosphere.com/browse/DCOS-56382. Create a cluster via ccm with channel `testing/pull/6158` and use the curl-commands given in the JIRA to initiate the draining/reactivation of a Node (make sure you add a cookie-header and adapt the agent-ID).

OR 

apply this patch, if you think it makes sense:
```
curl https://gist.githubusercontent.com/pierrebeitz/94dc57b43f3702f9464856cf0271c2b6/raw/727f75cc6ef28b328bd2e7f2b0415ddb101af363/gistfile1.txt | git apply
```

It makes use of the randomized `drain_info` that now changes for each node with every stubbed request. Note that you need to `useFixtures: true` for this method.

### To confirm

The data (i.e. the maintenance status) in the table would not change before. Now it does! 🎉

## Screenshots

![OS Enterprise 2019-07-15 12-45-08](https://user-images.githubusercontent.com/300861/61210979-8680c200-a6fe-11e9-8b4f-dbea87b0a879.png)
