### PR TITLE
DCOS-55634: Group quota detail page - No limit services banner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -429,7 +429,7 @@
     "@dcos/copychars": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@dcos/copychars/-/copychars-0.1.2.tgz",
-      "integrity": "sha512-lS8hkmBZHf9f7JTJfCBtJ8n/WGyl5471J4hkIyzUihHwQHAx2+nbTMH4d3EudGD1Zrdi8YyAADyrjSQ6tQy2Uw=="
+      "integrity": "sha1-wpx1n+btFAaJMktSfLTW+6txCQs="
     },
     "@dcos/data-service": {
       "version": "2.0.0",
@@ -4303,7 +4303,7 @@
     },
     "bl": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "dev": true,
       "requires": {
@@ -11193,7 +11193,7 @@
     },
     "graphql-tools": {
       "version": "2.23.1",
-      "resolved": "http://registry.npmjs.org/graphql-tools/-/graphql-tools-2.23.1.tgz",
+      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-2.23.1.tgz",
       "integrity": "sha512-f85OdRuPcHvMhNqiotvgtzpx7RlY2pZW9UnmBu6AcooKVipWVyy0um9q17f78BBI+1UzwAMsfU9S6R38UGMjTQ==",
       "requires": {
         "apollo-link": "^1.2.1",
@@ -11854,7 +11854,7 @@
     },
     "html-webpack-plugin": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
       "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
       "dev": true,
       "requires": {
@@ -20649,7 +20649,7 @@
         },
         "external-editor": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
           "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
           "dev": true,
           "requires": {
@@ -20687,7 +20687,7 @@
         },
         "node-fetch": {
           "version": "1.6.3",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
+          "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
           "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
           "dev": true,
           "requires": {
@@ -26412,7 +26412,7 @@
     },
     "speed-measure-webpack-plugin": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.2.2.tgz",
+      "resolved": "http://registry.npmjs.org/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.2.2.tgz",
       "integrity": "sha512-OPssnUTAdOwl/ijqToLrYUi8xHxdC9SOVV9e2AxkOC02Hua7+Jkfh3tdFCZxiMbtlghHK5Eyz87kG/XNpeM77w==",
       "dev": true,
       "requires": {
@@ -29041,7 +29041,7 @@
       "dependencies": {
         "qs": {
           "version": "2.3.3",
-          "resolved": "http://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
           "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ=",
           "dev": true
         }

--- a/plugins/services/src/js/components/ServicesQuotaOverviewDetail.tsx
+++ b/plugins/services/src/js/components/ServicesQuotaOverviewDetail.tsx
@@ -1,4 +1,4 @@
-import { Trans } from "@lingui/macro";
+import { Trans, Plural } from "@lingui/macro";
 import React from "react";
 import { of, Observable } from "rxjs";
 import {
@@ -10,6 +10,9 @@ import {
 import { componentFromStream } from "@dcos/data-service";
 import gql from "graphql-tag";
 import { DataLayer, DataLayerType } from "@extension-kid/data-layer";
+import { InfoBoxInline, Icon } from "@dcos/ui-kit";
+import { SystemIcons } from "@dcos/ui-kit/dist/packages/icons/dist/system-icons-enum";
+import { iconSizeXs } from "@dcos/ui-kit/dist/packages/design-tokens/build/js/designTokens";
 
 import Loader from "#SRC/js/components/Loader";
 import container from "#SRC/js/container";
@@ -119,6 +122,42 @@ function getCard(group: ServiceGroup, resource: string): React.ReactNode {
   );
 }
 
+function getNoLimitInfobox(group: ServiceGroup) {
+  if (!group.quota || !group.quota.serviceRoles) {
+    return null;
+  }
+
+  const { count, groupRoleCount } = group.quota.serviceRoles;
+  const nonLimited = count - groupRoleCount;
+
+  if (!nonLimited) {
+    return null;
+  }
+
+  return (
+    <InfoBoxInline
+      className="quota-info"
+      appearance="default"
+      message={
+        <React.Fragment>
+          <Icon
+            shape={SystemIcons.CircleInformation}
+            size={iconSizeXs}
+            color="currentColor"
+          />
+          <Plural
+            value={nonLimited}
+            one="# service is not limited by quota. Update role to have quota
+            enforced."
+            other="# services are not limited by quota. Update role to
+            have quota enforced."
+          />
+        </React.Fragment>
+      }
+    />
+  );
+}
+
 export interface ServicesQuotaOverviewDetailProps {
   id: string;
 }
@@ -158,11 +197,14 @@ const ServicesQuotaOverviewDetail = componentFromStream<
       }
 
       return (
-        <div className="quota-details">
-          {getCard(group, "cpus")}
-          {getCard(group, "memory")}
-          {getCard(group, "disk")}
-          {getCard(group, "gpus")}
+        <div>
+          {getNoLimitInfobox(group)}
+          <div className="quota-details">
+            {getCard(group, "cpus")}
+            {getCard(group, "memory")}
+            {getCard(group, "disk")}
+            {getCard(group, "gpus")}
+          </div>
         </div>
       );
     }),

--- a/plugins/services/src/js/components/ServicesQuotaOverviewDetail.tsx
+++ b/plugins/services/src/js/components/ServicesQuotaOverviewDetail.tsx
@@ -10,7 +10,7 @@ import {
 import { componentFromStream } from "@dcos/data-service";
 import gql from "graphql-tag";
 import { DataLayer, DataLayerType } from "@extension-kid/data-layer";
-import { InfoBoxInline, Icon } from "@dcos/ui-kit";
+import { InfoBoxInline, Icon, SpacingBox } from "@dcos/ui-kit";
 import { SystemIcons } from "@dcos/ui-kit/dist/packages/icons/dist/system-icons-enum";
 import { iconSizeXs } from "@dcos/ui-kit/dist/packages/design-tokens/build/js/designTokens";
 
@@ -135,26 +135,28 @@ function getNoLimitInfobox(group: ServiceGroup) {
   }
 
   return (
-    <InfoBoxInline
-      className="quota-info"
-      appearance="default"
-      message={
-        <React.Fragment>
-          <Icon
-            shape={SystemIcons.CircleInformation}
-            size={iconSizeXs}
-            color="currentColor"
-          />
-          <Plural
-            value={nonLimited}
-            one="# service is not limited by quota. Update role to have quota
+    <SpacingBox side="bottom" spacingSize="l">
+      <InfoBoxInline
+        className="quota-info"
+        appearance="default"
+        message={
+          <React.Fragment>
+            <Icon
+              shape={SystemIcons.CircleInformation}
+              size={iconSizeXs}
+              color="currentColor"
+            />
+            <Plural
+              value={nonLimited}
+              one="# service is not limited by quota. Update role to have quota
             enforced."
-            other="# services are not limited by quota. Update role to
+              other="# services are not limited by quota. Update role to
             have quota enforced."
-          />
-        </React.Fragment>
-      }
-    />
+            />
+          </React.Fragment>
+        }
+      />
+    </SpacingBox>
   );
 }
 

--- a/src/styles/components/quota/variables.less
+++ b/src/styles/components/quota/variables.less
@@ -1,3 +1,4 @@
 @quota-font-size-large: 3rem;
 @quota-card-min-width: 200px;
 @quota-progress-bar-width: 60%;
+@quota-main-font-weight: 300;

--- a/src/styles/components/quota/variables.less
+++ b/src/styles/components/quota/variables.less
@@ -1,4 +1,3 @@
 @quota-font-size-large: 3rem;
 @quota-card-min-width: 200px;
 @quota-progress-bar-width: 60%;
-@quota-main-font-weight: 300;

--- a/tests/pages/services/QuotaOverview-cy.js
+++ b/tests/pages/services/QuotaOverview-cy.js
@@ -196,6 +196,15 @@ describe("Quota Tab", function() {
         cy.get(".quota-details").should("exist");
       });
 
+      it("Shows the info banner for services with no limit", function() {
+        cy.visitUrl({ url: "/services/quota/%2F2_apps" });
+        cy.get(".quota-info")
+          .contains(
+            "1 service is not limited by quota. Update role to have quota enforced."
+          )
+          .should("exist");
+      });
+
       it("Shows the correct number of cards", function() {
         cy.get(".quota-card").should("have.length", 4);
       });


### PR DESCRIPTION
Add a banner to quota detail page
showing how many services do not have quota enforced.

Closes https://jira.mesosphere.com/browse/DCOS-55634

## Testing
0. Start localhost and login.
1. Update your `Config.dev.ts`
```
uiConfiguration: {
...
  features: {
    quota: true
  }
},
  useFixtures: true,
  ...
```
2. Go to services page and open the quota tab.
3. Open a group that has services without quota (for example "2_apps")
4. Verify that the infobox is shown.
5. Verify that the added test makes sense.

## Trade-offs
None.

## Dependencies
None.

## Screenshots
![Снимка от 2019-07-17 11-37-08](https://user-images.githubusercontent.com/40791275/61362066-3a628880-a88a-11e9-993b-47bc9bf0bc6a.png)



