### PR TITLE
DCOS-56383: center aligns alert icon for inactive nodes

### DIFF
--- a/src/styles/components/charts/styles.less
+++ b/src/styles/components/charts/styles.less
@@ -12,7 +12,7 @@
     }
 
     svg {
-      display: block;
+      display: inline-block;
 
       .background {
         fill: fade(@neutral, 5%);


### PR DESCRIPTION
## Testing
Change line 101 of plugins/nodes/src/js/components/NodesGridDials.js to `if (!node.isActive()) {`

Confirm the yield icon is center-aligned.

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots
**Before:**
<img width="514" alt="Screen Shot 2019-07-15 at 12 19 34 PM" src="https://user-images.githubusercontent.com/2313998/61231982-3fdd9880-a6fb-11e9-873d-74b95c66f91f.png">

**After:**
<img width="524" alt="Screen Shot 2019-07-15 at 12 19 20 PM" src="https://user-images.githubusercontent.com/2313998/61231992-4409b600-a6fb-11e9-8843-9c9330200b7d.png">
