### PR TITLE
fix(quota): consumption -> consumed

### DIFF
--- a/plugins/services/src/js/data/groups/__tests__/_fixtures/roles-all.json
+++ b/plugins/services/src/js/data/groups/__tests__/_fixtures/roles-all.json
@@ -32,7 +32,7 @@
           "gpus": 0,
           "mem": 0
         },
-        "consumption": {
+        "consumed": {
           "cpus": 0,
           "disk": 0,
           "gpus": 0,
@@ -62,7 +62,7 @@
           "gpus": 0,
           "mem": 0
         },
-        "consumption": {
+        "consumed": {
           "cpus": 0,
           "disk": 0,
           "gpus": 0,
@@ -92,7 +92,7 @@
           "gpus": 0,
           "mem": 0
         },
-        "consumption": {
+        "consumed": {
           "cpus": 0,
           "disk": 0,
           "gpus": 0,

--- a/plugins/services/src/js/data/groups/__tests__/_fixtures/roles-dev.json
+++ b/plugins/services/src/js/data/groups/__tests__/_fixtures/roles-dev.json
@@ -32,7 +32,7 @@
           "gpus": 0,
           "mem": 0
         },
-        "consumption": {
+        "consumed": {
           "cpus": 0,
           "disk": 0,
           "gpus": 0,

--- a/plugins/services/src/js/types/MesosRoles.ts
+++ b/plugins/services/src/js/types/MesosRoles.ts
@@ -18,6 +18,6 @@ export type MesosRole = {
     principal?: string;
     guarantee?: MesosResources;
     limit?: MesosResources;
-    consumption?: MesosResources;
+    consumed?: MesosResources;
   };
 };

--- a/plugins/services/src/js/utils/QuotaUtil.ts
+++ b/plugins/services/src/js/utils/QuotaUtil.ts
@@ -57,11 +57,11 @@ export function populateResourcesFromRole(
       quota.disk.limit = getValue(groupQuota.limit.disk);
       quota.gpus.limit = getValue(groupQuota.limit.gpus);
     }
-    if (groupQuota.consumption) {
-      quota.cpus.consumed = getValue(groupQuota.consumption.cpus);
-      quota.memory.consumed = getValue(groupQuota.consumption.mem);
-      quota.disk.consumed = getValue(groupQuota.consumption.disk);
-      quota.gpus.consumed = getValue(groupQuota.consumption.gpus);
+    if (groupQuota.consumed) {
+      quota.cpus.consumed = getValue(groupQuota.consumed.cpus);
+      quota.memory.consumed = getValue(groupQuota.consumed.mem);
+      quota.disk.consumed = getValue(groupQuota.consumed.disk);
+      quota.gpus.consumed = getValue(groupQuota.consumed.gpus);
     }
   }
 

--- a/plugins/services/src/js/utils/__tests__/QuotaUtil-test.ts
+++ b/plugins/services/src/js/utils/__tests__/QuotaUtil-test.ts
@@ -244,7 +244,7 @@ describe("QuotaUtil", () => {
         name: "unit-test",
         weight: 0,
         quota: {
-          consumption: {
+          consumed: {
             cpus: 3,
             mem: 100,
             disk: 0,

--- a/tests/_fixtures/quota-management/roles.json
+++ b/tests/_fixtures/quota-management/roles.json
@@ -27,7 +27,7 @@
           "gpus": 10,
           "mem": 1024.0
         },
-        "consumption": {
+        "consumed": {
           "cpus": 1.5,
           "disk": 0,
           "gpus": 2,
@@ -58,7 +58,7 @@
           "gpus": 0,
           "mem": 1024.0
         },
-        "consumption": {
+        "consumed": {
           "cpus": 0.5,
           "disk": 5,
           "gpus": 0,
@@ -89,7 +89,7 @@
           "gpus": 2.0,
           "mem": 2048.0
         },
-        "consumption": {
+        "consumed": {
           "cpus": 0.5,
           "disk": 0,
           "gpus": 0,
@@ -120,7 +120,7 @@
           "gpus": 2.0,
           "mem": 2048.0
         },
-        "consumption": {
+        "consumed": {
           "cpus": 1.0,
           "disk": 0,
           "gpus": 0,


### PR DESCRIPTION
Small fix to use `consumed` as the quota key instead of `consumption`. `consumed` is what we're seeing on the final API but `consumption` was used in original design doc. This PR also updates our tests and fixtures to use the same key.

## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
