### PR TITLE
DCOS-56452: DCOS UI to recognize DELAYED state of SDK services

### DIFF
--- a/plugins/services/src/js/constants/ServiceStatus.ts
+++ b/plugins/services/src/js/constants/ServiceStatus.ts
@@ -149,6 +149,7 @@ function fromHttpCode(code: number): Status | null {
     204: DEPLOYING_AWAITING_RESOURCES,
     205: DEGRADED_RECOVERING,
     206: DEGRADED,
+    208: DELAYED,
     318: INITIALIZING,
     320: BACKING_UP,
     321: RESTORING,

--- a/tests/_fixtures/marathon-pods/groups.js
+++ b/tests/_fixtures/marathon-pods/groups.js
@@ -1,5 +1,5 @@
 const createFrameworks = () =>
-  [318, 200, 500, 204, 202, 203, 205, 206, 320, 321, 326, 503].map(
+  [318, 200, 500, 204, 202, 203, 205, 206, 208, 320, 321, 326, 503].map(
     statusCode => ({
       id: `/${statusCode}-hello-world`,
       backoffFactor: 1.15,


### PR DESCRIPTION
Add delayed service status with 208 HTTP code.

Closes https://jira.mesosphere.com/browse/DCOS-56452

## Testing
1. In `Config.dev.ts` make `useFixtures` to be `true`.
2. Find the service `208-hello-world` and verify that it has a "Delayed" status.

## Trade-offs
I left the status name as it is, but maybe we want to change it to "Delayed (Failed to launch tasks)"?

## Dependencies
None.

## Screenshots
![Screenshot from 2019-07-18 16-35-02](https://user-images.githubusercontent.com/40791275/61461907-63624680-a97a-11e9-9b72-e0d249864981.png)
