### PR TITLE
Quota UI Clean-up

### DIFF
--- a/plugins/services/src/js/columns/ServicesTableNameColumn.tsx
+++ b/plugins/services/src/js/columns/ServicesTableNameColumn.tsx
@@ -20,7 +20,7 @@ import { columnWidthsStorageKey } from "../containers/services/ServicesTable";
 const ServiceName = React.memo(
   ({
     isFiltered,
-    isRoleEnforced,
+    hasQuota,
     id,
     isGroup,
     isNoLimit,
@@ -29,7 +29,7 @@ const ServiceName = React.memo(
     webUrl
   }: {
     isFiltered: boolean;
-    isRoleEnforced: boolean;
+    hasQuota: boolean;
     id: string;
     isGroup: boolean;
     isNoLimit: boolean;
@@ -42,7 +42,7 @@ const ServiceName = React.memo(
       : `/services/detail/${id}`;
 
     const badge =
-      isRoleEnforced && isNoLimit ? (
+      hasQuota && isNoLimit ? (
         <Badge>
           <Trans render="span" className="quota-no-limit">
             No Limit
@@ -72,7 +72,7 @@ const ServiceName = React.memo(
 
 export function nameRenderer(
   isFiltered: boolean,
-  isRoleEnforced: boolean,
+  hasQuota: boolean,
   service: Service | Pod | ServiceTree
 ): React.ReactNode {
   // These do not work with instanceof ServiceTree due to TS
@@ -105,7 +105,7 @@ export function nameRenderer(
       image={image}
       webUrl={webUrl}
       isFiltered={isFiltered}
-      isRoleEnforced={isRoleEnforced}
+      hasQuota={hasQuota}
     />
   );
 }

--- a/plugins/services/src/js/containers/services/ServiceTreeView.js
+++ b/plugins/services/src/js/containers/services/ServiceTreeView.js
@@ -150,8 +150,6 @@ class ServiceTreeView extends React.Component {
     const routePath = serviceTree.isRoot()
       ? "/services/overview/create"
       : `/services/overview/${encodeURIComponent(serviceTree.id)}/create`;
-    const isRoleEnforced =
-      !serviceTree.isRoot() && serviceTree.getEnforceRole();
     const hasQuota = serviceTreeHasQuota(serviceTree, roles);
 
     const createService = () => {
@@ -198,7 +196,7 @@ class ServiceTreeView extends React.Component {
           {this.getNoLimitInfobox(hasQuota)}
           <ServicesTable
             isFiltered={filterExpression.defined}
-            isRoleEnforced={isRoleEnforced}
+            hasQuota={hasQuota}
             modalHandlers={modalHandlers}
             services={services}
             hideTable={this.context.router.routes.some(

--- a/plugins/services/src/js/containers/services/ServiceTreeView.js
+++ b/plugins/services/src/js/containers/services/ServiceTreeView.js
@@ -231,7 +231,8 @@ ServiceTreeView.propTypes = {
       PropTypes.instanceOf(ServiceTree)
     ])
   ).isRequired,
-  serviceTree: PropTypes.instanceOf(ServiceTree)
+  serviceTree: PropTypes.instanceOf(ServiceTree),
+  roles: PropTypes.array
 };
 
 module.exports = ServiceTreeView;

--- a/plugins/services/src/js/containers/services/ServiceTreeView.js
+++ b/plugins/services/src/js/containers/services/ServiceTreeView.js
@@ -23,6 +23,7 @@ import ServiceOtherDSLSection from "../../components/dsl/ServiceOtherDSLSection"
 import ServicesTable from "./ServicesTable";
 import ServiceStatusDSLSection from "../../components/dsl/ServiceStatusDSLSection";
 import ServiceTree from "../../structs/ServiceTree";
+import { serviceTreeHasQuota } from "../../utils/QuotaUtil";
 
 const DSL_FORM_SECTIONS = [
   ServiceStatusDSLSection,
@@ -54,13 +55,16 @@ class ServiceTreeView extends React.Component {
     );
   }
 
-  getNoLimitInfobox() {
+  getNoLimitInfobox(hasQuota) {
+    if (!hasQuota) {
+      return null;
+    }
     const { serviceTree } = this.props;
 
-    const { rolesCount, groupRolesCount } = serviceTree.getRoleLength();
-    const nonLimited = rolesCount - groupRolesCount;
+    const { servicesCount, groupRolesCount } = serviceTree.getRoleLength();
+    const nonLimited = servicesCount - groupRolesCount;
 
-    if (serviceTree.isRoot() || !serviceTree.getEnforceRole() || !nonLimited) {
+    if (!nonLimited) {
       return null;
     }
 
@@ -101,7 +105,7 @@ class ServiceTreeView extends React.Component {
     return null;
   }
 
-  getTabs() {
+  getTabs(hasQuota) {
     // Workaround for Cypress.
     const createModalOpen = this.context.router.routes.some(
       ({ isFullscreenModal }) => isFullscreenModal
@@ -112,7 +116,7 @@ class ServiceTreeView extends React.Component {
     }
     const { serviceTree } = this.props;
     const id = serviceTree.getId();
-    if (id.split("/").length <= 2) {
+    if (serviceTree.isRoot() || hasQuota) {
       return [
         {
           label: i18nMark("Services"),
@@ -137,7 +141,8 @@ class ServiceTreeView extends React.Component {
       filterExpression,
       isEmpty,
       serviceTree,
-      services
+      services,
+      roles
     } = this.props;
 
     const { modalHandlers } = this.context;
@@ -147,11 +152,12 @@ class ServiceTreeView extends React.Component {
       : `/services/overview/${encodeURIComponent(serviceTree.id)}/create`;
     const isRoleEnforced =
       !serviceTree.isRoot() && serviceTree.getEnforceRole();
+    const hasQuota = serviceTreeHasQuota(serviceTree, roles);
 
     const createService = () => {
       this.context.router.push(routePath);
     };
-    const tabs = this.getTabs();
+    const tabs = this.getTabs(hasQuota);
 
     if (isEmpty) {
       return (
@@ -189,7 +195,7 @@ class ServiceTreeView extends React.Component {
         <div className="flex-item-grow-1 flex flex-direction-top-to-bottom">
           {this.getFilterBar()}
           {this.getSearchHeader()}
-          {this.getNoLimitInfobox()}
+          {this.getNoLimitInfobox(hasQuota)}
           <ServicesTable
             isFiltered={filterExpression.defined}
             isRoleEnforced={isRoleEnforced}

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -295,7 +295,7 @@ class ServicesTable extends React.Component {
             cellRenderer={nameRenderer.bind(
               null,
               this.props.isFiltered,
-              this.props.isRoleEnforced,
+              this.props.hasQuota,
               ...arguments
             )}
             growToFill={
@@ -631,7 +631,7 @@ ServicesTable.defaultProps = {
 
 ServicesTable.propTypes = {
   isFiltered: PropTypes.bool,
-  isRoleEnforced: PropTypes.bool,
+  hasQuota: PropTypes.bool,
   services: PropTypes.array
 };
 

--- a/plugins/services/src/js/data/groups/resolvers.ts
+++ b/plugins/services/src/js/data/groups/resolvers.ts
@@ -106,6 +106,9 @@ export function resolvers({ pollingInterval }: ResolverArgs): IResolvers {
       },
       groups() {
         return groups$.pipe(map(groups => groups.map(processServiceGroup)));
+      },
+      roles() {
+        return roles$;
       }
     }
   };

--- a/plugins/services/src/js/data/groups/schema.ts
+++ b/plugins/services/src/js/data/groups/schema.ts
@@ -26,4 +26,27 @@ export const GroupTypes = `
     name: String!
     quota: ServiceGroupQuota
   }
+  
+  type MesosResources {
+    cpus: Float
+    disk: Float
+    gpus: Float
+    mem: Float
+    ports: String
+  }
+  
+  type MesosQuota {
+    role: String
+    guarantee: MesosResources
+    limit: MesosResources
+    consumed: MesosResources
+  }
+  
+  type MesosRole {
+    name: String!
+    weight: Float!
+    frameworks: [String!]
+    resources: MesosResources
+    quota: MesosQuota
+  }
 `;

--- a/plugins/services/src/js/data/schema.ts
+++ b/plugins/services/src/js/data/schema.ts
@@ -9,5 +9,6 @@ export const typeDefs = `
     group(id: String!): ServiceGroup
     groups: [ServiceGroup!]!
     service(id: String!): Service
+    roles: [MesosRole!]!
   }
 `;

--- a/plugins/services/src/js/utils/QuotaUtil.ts
+++ b/plugins/services/src/js/utils/QuotaUtil.ts
@@ -6,7 +6,8 @@ import {
   ServiceGroupQuotaLimit,
   ServiceGroupQuotaRoles
 } from "../types/ServiceGroup";
-import { MesosRole } from "#PLUGINS/services/src/js/types/MesosRoles";
+import { MesosRole } from "../types/MesosRoles";
+import ServiceTree from "../structs/ServiceTree";
 
 export function quotaHasLimit(
   quota: ServiceGroupQuota | null | undefined
@@ -95,4 +96,26 @@ export function getQuotaLimit(
   }
 
   return i18nMark("N/A") as ServiceGroupQuotaLimit;
+}
+
+export function serviceTreeHasQuota(
+  item: ServiceTree,
+  roles: MesosRole[]
+): boolean {
+  if (item.isRoot()) {
+    return false;
+  }
+  if (item.getId().split("/").length > 2) {
+    //This is not a top-level group, don't bother checking for quota
+    return false;
+  }
+  const role = roles.find(role => role.name === item.getName());
+  if (!role) {
+    return false;
+  }
+  return !!(
+    role.quota &&
+    role.quota.limit &&
+    Object.keys(role.quota.limit).length > 0
+  );
 }

--- a/tests/pages/services/ServiceTable-cy.js
+++ b/tests/pages/services/ServiceTable-cy.js
@@ -631,7 +631,7 @@ describe("Service Table", function() {
   context("Quota groups", function() {
     beforeEach(function() {
       cy.configureCluster({
-        mesos: "1-task-healthy",
+        mesos: "1-task-healthy-with-quota",
         nodeHealth: true
       });
       cy.visitUrl({ url: "/services/overview" });


### PR DESCRIPTION
Removed usage of `enforceRole` for showing information related to Quota. Introduced checking roles for quota on the serviceTree instead.

## Testing

Quota and no limit banners should continue to work.

1. Create a top-level group
2. Using the Mesos API set quota for a role with the same name as your group
```
$ ## Set Quota
curl -X "POST" -k "<CLUSTER_URL>/mesos/api/v1?SET_QUOTA" \
     -H 'Authorization: token=<token>' \
     -H 'Accept: application/json' \
     -H 'Content-Type: application/json' \
     -d $'{
  "type": "SET_QUOTA",
  "set_quota": {
    "quota_request": {
      "force": true,
      "guarantee": [
        {
          "scalar": {
            "value": 1
          },
          "name": "cpus",
          "role": "*",
          "type": "SCALAR"
        },
        {
          "scalar": {
            "value": 512
          },
          "name": "mem",
          "role": "*",
          "type": "SCALAR"
        }
      ],
      "role": "<group_name>"
    }
  }
}'
```
3. Navigate to Quota tab Services -> Quota tab
4. Verify the group you created is displayed in the list.
5. Deploy a service into your group
6. Verify no limit banner is displayed on Quota, Quota Detail and Services tab for the Group.

## Trade-offs

I added a graphql query subscription for MesosRoles to `ServicesContainer` so that the roles could be used to check for quota. I initially tried to add this to the MarathonStore & DCOSStore without success due to circular dependencies. 

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
