### PR TITLE
Simplify CLI installation instructions on UNIX

### DIFF
--- a/src/js/components/modals/CliInstallModal.js
+++ b/src/js/components/modals/CliInstallModal.js
@@ -75,10 +75,9 @@ class CliInstallModal extends React.Component {
     }
 
     const instructions = [
-      `[ -d /usr/local/bin ] || sudo mkdir -p /usr/local/bin`,
       `curl ${downloadUrl} -o dcos`,
+      `chmod +x ./dcos`,
       `sudo mv dcos /usr/local/bin`,
-      `sudo chmod +x /usr/local/bin/dcos`,
       `dcos cluster setup ${clusterUrl}`,
       `dcos`
     ].filter(instruction => instruction !== undefined);


### PR DESCRIPTION
This removes the need to have `sudo` 2 times, by running `chmod`
before moving the file.

It also removes the creation of `/usr/local/bin` directory, it should be
present in any UNIX installation. Having this line is not really useful,
if the directory is missing it's most likely not in the $PATH either,
so the subsequent `dcos cluster setup` command would still fail anyways.