### PR TITLE
test: quickfix flakes

### DIFF
--- a/system-tests/_support/constants.js
+++ b/system-tests/_support/constants.js
@@ -5,7 +5,7 @@ const Timeouts = {
    * This should include the time required for the service to download it's
    * resources, allocate volumes and start the containers.
    */
-  SERVICE_DEPLOYMENT_TIMEOUT: 60000,
+  SERVICE_DEPLOYMENT_TIMEOUT: 180000,
 
   /**
    * How long to wait until an job is fully deployed.


### PR DESCRIPTION
we want to ship something really badly right now but jenkins appears to be slow
so that new services are not "running" in the time we expect them to. this is a
desperate measure to get master green again by just waiting longer for services
to be up and running!

