### PR TITLE
DCOS-42072: make JSON editors resizable

### DIFF
--- a/plugins/services/src/js/components/modals/CreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/CreateServiceModalForm.js
@@ -17,6 +17,10 @@ import ErrorMessageUtil from "#SRC/js/utils/ErrorMessageUtil";
 import ErrorsAlert from "#SRC/js/components/ErrorsAlert";
 import FluidGeminiScrollbar from "#SRC/js/components/FluidGeminiScrollbar";
 import PageHeaderNavigationDropdown from "#SRC/js/components/PageHeaderNavigationDropdown";
+import SplitPanel, {
+  PrimaryPanel,
+  SidePanel
+} from "#SRC/js/components/SplitPanel";
 import TabButton from "#SRC/js/components/TabButton";
 import TabButtonList from "#SRC/js/components/TabButtonList";
 import Tabs from "#SRC/js/components/Tabs";
@@ -57,7 +61,8 @@ const METHODS_TO_BIND = [
   "handleJSONPropertyChange",
   "handleJSONErrorStateChange",
   "handleRemoveItem",
-  "handleClickItem"
+  "handleClickItem",
+  "onEditorResize"
 ];
 
 /**
@@ -801,6 +806,10 @@ class CreateServiceModalForm extends Component {
     });
   }
 
+  onEditorResize(newSize) {
+    this.setState({ editorWidth: newSize });
+  }
+
   render() {
     const { appConfig, batch } = this.state;
     const {
@@ -817,14 +826,6 @@ class CreateServiceModalForm extends Component {
     const unmutedErrors = this.getUnmutedErrors();
     const errors = this.getErrors();
 
-    const jsonEditorPlaceholderClasses = classNames(
-      "modal-full-screen-side-panel-placeholder",
-      { "is-visible": isJSONModeActive }
-    );
-    const jsonEditorClasses = classNames("modal-full-screen-side-panel", {
-      "is-visible": isJSONModeActive
-    });
-
     const errorMap = DataValidatorUtil.errorArrayToMap(unmutedErrors);
     const navigationItems = this.getFormNavigationItems(appConfig, data);
     const tabButtonListItems = this.getFormTabList(navigationItems);
@@ -834,8 +835,8 @@ class CreateServiceModalForm extends Component {
     );
 
     return (
-      <div className="flex flex-item-grow-1">
-        <div className="create-service-modal-form__scrollbar-container modal-body-offset gm-scrollbar-container-flex">
+      <SplitPanel onResize={this.onEditorResize}>
+        <PrimaryPanel className="create-service-modal-form__scrollbar-container modal-body-offset gm-scrollbar-container-flex">
           <PageHeaderNavigationDropdown
             handleNavigationItemSelection={
               this.handleDropdownNavigationSelection
@@ -886,9 +887,8 @@ class CreateServiceModalForm extends Component {
               </form>
             </div>
           </FluidGeminiScrollbar>
-        </div>
-        <div className={jsonEditorPlaceholderClasses} />
-        <div className={jsonEditorClasses}>
+        </PrimaryPanel>
+        <SidePanel isActive={isJSONModeActive} className="jsonEditorWrapper">
           <Suspense fallback={<div>Loading...</div>}>
             <JSONEditor
               errors={errors}
@@ -900,11 +900,13 @@ class CreateServiceModalForm extends Component {
               theme="monokai"
               height="100%"
               value={appConfig}
-              width="100%"
+              width={
+                this.state.editorWidth ? `${this.state.editorWidth}px` : "100%"
+              }
             />
           </Suspense>
-        </div>
-      </div>
+        </SidePanel>
+      </SplitPanel>
     );
   }
 }

--- a/src/js/components/FrameworkConfigurationForm.js
+++ b/src/js/components/FrameworkConfigurationForm.js
@@ -2,7 +2,6 @@ import { Trans, t } from "@lingui/macro";
 import { withI18n } from "@lingui/react";
 import PropTypes from "prop-types";
 import React, { Component, Suspense, lazy } from "react";
-import classNames from "classnames";
 import SchemaForm from "react-jsonschema-form";
 import { MountService } from "foundation-ui";
 import { InfoBoxInline } from "@dcos/ui-kit";
@@ -17,6 +16,10 @@ import JSONEditorLoading from "#SRC/js/components/JSONEditorLoading";
 import PageHeaderNavigationDropdown from "#SRC/js/components/PageHeaderNavigationDropdown";
 import UniversePackage from "#SRC/js/structs/UniversePackage";
 import SchemaField from "#SRC/js/components/SchemaField";
+import SplitPanel, {
+  PrimaryPanel,
+  SidePanel
+} from "#SRC/js/components/SplitPanel";
 import StringUtil from "#SRC/js/utils/StringUtil";
 import PlacementConstraintsSchemaField from "#SRC/js/components/PlacementConstraintsSchemaField";
 import FrameworkConfigurationConstants from "#SRC/js/constants/FrameworkConfigurationConstants";
@@ -56,7 +59,8 @@ const METHODS_TO_BIND = [
   "handleJSONChange",
   "handleBadgeClick",
   "validate",
-  "jsonSchemaErrorList"
+  "jsonSchemaErrorList",
+  "onEditorResize"
 ];
 
 class FrameworkConfigurationForm extends Component {
@@ -220,6 +224,10 @@ class FrameworkConfigurationForm extends Component {
     this.probeErrorsSchemaForm();
   }
 
+  onEditorResize(newSize) {
+    this.setState({ editorWidth: newSize });
+  }
+
   probeErrorsSchemaForm() {
     const { errorSchema } = this.schemaForm.state;
 
@@ -323,14 +331,6 @@ class FrameworkConfigurationForm extends Component {
       );
     };
 
-    const jsonEditorPlaceholderClasses = classNames(
-      "modal-full-screen-side-panel-placeholder",
-      { "is-visible": jsonEditorActive }
-    );
-    const jsonEditorClasses = classNames("modal-full-screen-side-panel", {
-      "is-visible": jsonEditorActive
-    });
-
     const schema = packageDetails.getConfig();
 
     let defaultConfigWarningMessage = null;
@@ -351,8 +351,8 @@ class FrameworkConfigurationForm extends Component {
     }
 
     return (
-      <div className="flex flex-item-grow-1">
-        <div className="create-service-modal-form__scrollbar-container modal-body-offset gm-scrollbar-container-flex">
+      <SplitPanel onResize={this.onEditorResize}>
+        <PrimaryPanel className="create-service-modal-form__scrollbar-container modal-body-offset gm-scrollbar-container-flex">
           <PageHeaderNavigationDropdown
             handleNavigationItemSelection={
               this.handleDropdownNavigationSelection
@@ -395,9 +395,8 @@ class FrameworkConfigurationForm extends Component {
               </div>
             </div>
           </FluidGeminiScrollbar>
-        </div>
-        <div className={jsonEditorPlaceholderClasses} />
-        <div className={jsonEditorClasses}>
+        </PrimaryPanel>
+        <SidePanel isActive={jsonEditorActive} className="jsonEditorWrapper">
           <Suspense fallback={<JSONEditorLoading isSidePanel={true} />}>
             <JSONEditor
               errors={this.getErrorsForJSONEditor()}
@@ -407,11 +406,13 @@ class FrameworkConfigurationForm extends Component {
               theme="monokai"
               height="100%"
               value={formData}
-              width="100%"
+              width={
+                this.state.editorWidth ? `${this.state.editorWidth}px` : "100%"
+              }
             />
           </Suspense>
-        </div>
-      </div>
+        </SidePanel>
+      </SplitPanel>
     );
   }
 }

--- a/src/js/components/SplitPanel.tsx
+++ b/src/js/components/SplitPanel.tsx
@@ -1,0 +1,244 @@
+import * as React from "react";
+import classNames from "classnames";
+import { Icon } from "@dcos/ui-kit";
+import { SystemIcons } from "@dcos/ui-kit/dist/packages/icons/dist/system-icons-enum";
+import { iconSizeXxs } from "@dcos/ui-kit/dist/packages/design-tokens/build/js/designTokens";
+import WindowResizeUtil from "#SRC/js/utils/WindowResizeUtil";
+
+type SplitPanelChildren<T> = [T, T];
+
+interface PanelProps {
+  children: React.ReactNode;
+  className?: string;
+  isResizing?: boolean;
+}
+
+interface SidePanelProps extends PanelProps {
+  initialWidth?: number;
+  isActive?: boolean;
+  width?: number;
+}
+
+export interface SplitPanelState {
+  isResizing: boolean;
+  sidePanelWidth?: number;
+}
+
+export interface SplitPanelProps {
+  children: SplitPanelChildren<
+    React.ReactElement<PanelProps> | React.ReactElement<SidePanelProps>
+  >;
+  onResize?: (resizedPanelWidth?: number) => void;
+}
+
+export const getSidePanelWidth = (
+  containerRect: ClientRect,
+  clientPosition: number
+) => {
+  const totalSize = containerRect.width;
+  let offset;
+
+  offset = clientPosition - containerRect.left;
+
+  if (offset < 0) {
+    offset = 0;
+  } else if (offset > totalSize) {
+    offset = totalSize;
+  }
+
+  return totalSize - offset;
+};
+
+export const getSidePanelProps = (
+  panelChildren: SplitPanelChildren<
+    React.ReactElement<PanelProps> | React.ReactElement<SidePanelProps>
+  >
+) => {
+  const sidePanelChild = panelChildren.find(
+    child => React.isValidElement(child) && child.type === SidePanel
+  ) as React.ReactElement<SidePanelProps>;
+  return sidePanelChild.props;
+};
+
+export const SidePanel = ({
+  children,
+  className,
+  isActive,
+  isResizing,
+  width
+}: SidePanelProps) => {
+  const sidePanelClasses = classNames("modal-full-screen-side-panel", {
+    "is-visible": isActive
+  });
+  return (
+    <React.Fragment>
+      <div
+        className={classNames("modal-full-screen-side-panel-placeholder", {
+          "is-visible": isActive
+        })}
+        style={{
+          width: isActive ? width : undefined,
+          transition: isResizing ? "none" : undefined
+        }}
+      />
+      <div
+        className={classNames(
+          "splitPanels-panel",
+          sidePanelClasses,
+          className,
+          {
+            noUserSelect: isResizing
+          }
+        )}
+        style={{
+          width,
+          right: isActive ? 0 : width && width * -1
+        }}
+      >
+        {children}
+      </div>
+    </React.Fragment>
+  );
+};
+
+export const PrimaryPanel = ({
+  children,
+  className,
+  isResizing
+}: PanelProps) => (
+  <div
+    className={classNames(
+      "splitPanels-panel",
+      "splitPanels-panel--primary",
+      className,
+      {
+        noUserSelect: isResizing
+      }
+    )}
+  >
+    {children}
+  </div>
+);
+
+function intersperse<A>(list: A[], sep: JSX.Element) {
+  return Array.prototype.concat(...list.map(e => [sep, e])).slice(1);
+}
+
+class SplitPanel extends React.PureComponent<SplitPanelProps, SplitPanelState> {
+  public containerRef = React.createRef<HTMLDivElement>();
+
+  constructor(props: SplitPanelProps) {
+    super(props);
+
+    this.handleMouseDown = this.handleMouseDown.bind(this);
+    this.handleMouseUp = this.handleMouseUp.bind(this);
+    this.handleMouseMove = this.handleMouseMove.bind(this);
+    this.handleWindowResize = this.handleWindowResize.bind(this);
+
+    this.state = {
+      isResizing: false
+    };
+  }
+
+  public componentDidMount() {
+    const { initialWidth } = getSidePanelProps(this.props.children);
+    WindowResizeUtil.add(this.handleWindowResize);
+
+    this.setState({ sidePanelWidth: initialWidth });
+  }
+
+  public componentWillUnmount() {
+    WindowResizeUtil.remove(this.handleWindowResize);
+  }
+
+  public render() {
+    const { children } = this.props;
+    const { isResizing, sidePanelWidth } = this.state;
+    const { isActive } = getSidePanelProps(this.props.children);
+    const panelChildren = React.Children.toArray(children) as Array<
+      React.ReactElement<PanelProps> & React.ReactElement<SidePanelProps>
+    >;
+    const panelChildrenArr = panelChildren.map(panel => {
+      if (React.isValidElement(panel)) {
+        if (panel.type === SidePanel) {
+          return React.cloneElement(panel, {
+            isResizing,
+            width: sidePanelWidth,
+            key: "sidePanel"
+          });
+        }
+        if (panel.type === PrimaryPanel) {
+          return React.cloneElement(panel, {
+            isResizing,
+            key: "primaryPanel"
+          });
+        }
+      }
+      return panel;
+    });
+
+    const panelSeparator = (
+      <div
+        className={classNames("splitPanels-separator", {
+          "splitPanels-separator--active": isActive
+        })}
+        style={{
+          transform: `translateX(${isActive ? 0 : sidePanelWidth}px)`,
+          right: isActive ? sidePanelWidth : 0,
+          transition: isResizing ? "none" : undefined
+        }}
+        onMouseDown={this.handleMouseDown}
+        key="separator"
+      >
+        <div className="splitPanels-resizeIconWrapper">
+          <Icon shape={SystemIcons.ResizeHorizontal} size={iconSizeXxs} />
+        </div>
+      </div>
+    );
+
+    return (
+      <div
+        className="splitPanels"
+        onMouseMove={this.handleMouseMove}
+        onMouseUp={this.handleMouseUp}
+        ref={this.containerRef}
+      >
+        {intersperse(panelChildrenArr, panelSeparator)}
+      </div>
+    );
+  }
+
+  private handleMouseDown() {
+    this.setState({ isResizing: true });
+  }
+
+  private handleMouseUp() {
+    if (this.state.isResizing && this.props.onResize) {
+      this.props.onResize(this.state.sidePanelWidth);
+    }
+    this.setState({ isResizing: false });
+  }
+
+  private handleMouseMove(e: React.MouseEvent<HTMLDivElement, MouseEvent>) {
+    const containerRefCurrent = this.containerRef.current;
+    if (this.state.isResizing && containerRefCurrent) {
+      const sidePanelWidth = getSidePanelWidth(
+        containerRefCurrent.getBoundingClientRect(),
+        e.clientX
+      );
+
+      this.setState({ sidePanelWidth });
+    }
+  }
+
+  private handleWindowResize() {
+    const { body } = document;
+    const { sidePanelWidth } = this.state;
+
+    if (sidePanelWidth && body.clientWidth < sidePanelWidth) {
+      this.setState({ sidePanelWidth: body.clientWidth });
+    }
+  }
+}
+
+export default SplitPanel;

--- a/src/js/components/__tests__/SplitPanel-test.js
+++ b/src/js/components/__tests__/SplitPanel-test.js
@@ -1,0 +1,125 @@
+import React from "react";
+import { shallow, mount } from "enzyme";
+
+import SplitPanel, {
+  PrimaryPanel,
+  SidePanel,
+  getSidePanelWidth,
+  getSidePanelProps
+} from "../SplitPanel";
+
+describe("SplitPanel", () => {
+  it("renders default", () => {
+    const component = shallow(
+      <SplitPanel>
+        <PrimaryPanel>PrimaryPanel</PrimaryPanel>
+        <SidePanel>SidePanel</SidePanel>
+      </SplitPanel>
+    );
+    expect(component).toMatchSnapshot();
+  });
+  it("renders with SidePanel isActive prop set to true", () => {
+    const component = shallow(
+      <SplitPanel>
+        <PrimaryPanel>PrimaryPanel</PrimaryPanel>
+        <SidePanel isActive={true}>SidePanel</SidePanel>
+      </SplitPanel>
+    );
+    expect(component).toMatchSnapshot();
+  });
+  it("renders SidePanel and PrimaryPanel with className passed", () => {
+    const component = shallow(
+      <SplitPanel>
+        <PrimaryPanel className="className">PrimaryPanel</PrimaryPanel>
+        <SidePanel className="className">SidePanel</SidePanel>
+      </SplitPanel>
+    );
+    expect(component).toMatchSnapshot();
+  });
+
+  describe("resizing", () => {
+    const mockContainerWidth = 100;
+    const resizeAmount = 10;
+
+    beforeEach(() => {
+      Element.prototype.getBoundingClientRect = jest.fn(() => {
+        return {
+          width: mockContainerWidth,
+          height: 0,
+          top: 0,
+          left: 0,
+          bottom: 0,
+          right: 0
+        };
+      });
+    });
+    it("calls onResize callback when finished dragging", () => {
+      const onResizeCallback = jest.fn();
+      const component = mount(
+        <SplitPanel onResize={onResizeCallback}>
+          <PrimaryPanel>PrimaryPanel</PrimaryPanel>
+          <SidePanel isActive={true}>SidePanel</SidePanel>
+        </SplitPanel>
+      );
+      const separator = component.find(".splitPanels-separator");
+      const panelContainer = component.find(".splitPanels"); // target the documentElement
+
+      Element.prototype.getBoundingClientRect = jest.fn(() => {
+        return {
+          width: mockContainerWidth,
+          height: 0,
+          top: 0,
+          left: 0,
+          bottom: 0,
+          right: 0
+        };
+      });
+
+      separator.simulate("mousedown");
+      panelContainer.simulate("mousemove", { clientX: resizeAmount });
+      separator.simulate("mouseup");
+      expect(onResizeCallback).toHaveBeenCalledWith(
+        mockContainerWidth - resizeAmount
+      );
+    });
+    describe("#getSidePanelWidth", () => {
+      it("returns difference between drag delta and full component width in pixels", () => {
+        const element = document.createElement("span");
+        const rect = element.getBoundingClientRect();
+        expect(getSidePanelWidth(rect, resizeAmount)).toBe(
+          mockContainerWidth - resizeAmount
+        );
+      });
+      it("returns 0 if difference between drag delta and full component width is =< 0", () => {
+        const element = document.createElement("span");
+        const rect = element.getBoundingClientRect();
+        expect(getSidePanelWidth(rect, mockContainerWidth + resizeAmount)).toBe(
+          0
+        );
+      });
+      it("returns full component width if difference between drag delta is >= full component width", () => {
+        const element = document.createElement("span");
+        const rect = element.getBoundingClientRect();
+        expect(
+          getSidePanelWidth(
+            rect,
+            parseInt((mockContainerWidth + resizeAmount) * -1, 10)
+          )
+        ).toBe(100);
+      });
+    });
+  });
+  describe("#getSidePanelProps", () => {
+    it("returns the props passed to the SidePanel child", () => {
+      const component = shallow(
+        <SplitPanel>
+          <PrimaryPanel>PrimaryPanel</PrimaryPanel>
+          <SidePanel isActive={true}>SidePanel</SidePanel>
+        </SplitPanel>
+      );
+      expect(component.find(SidePanel).props()).toEqual(
+        getSidePanelProps(component.prop("children"))
+      );
+    });
+  });
+});

--- a/src/js/components/__tests__/__snapshots__/SplitPanel-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/SplitPanel-test.js.snap
@@ -1,0 +1,910 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SplitPanel renders SidePanel and PrimaryPanel with className passed 1`] = `
+ShallowWrapper {
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <SplitPanel>
+    <Unknown
+      className="className"
+    >
+      PrimaryPanel
+    </Unknown>
+    <Unknown
+      className="className"
+    >
+      SidePanel
+    </Unknown>
+  </SplitPanel>,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "checkPropTypes": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateError": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <Unknown
+          className="className"
+          isResizing={false}
+        >
+          PrimaryPanel
+        </Unknown>,
+        <div
+          className="splitPanels-separator"
+          onMouseDown={[Function]}
+          style={
+            Object {
+              "right": 0,
+              "transform": "translateX(undefinedpx)",
+              "transition": undefined,
+            }
+          }
+        >
+          <div
+            className="splitPanels-resizeIconWrapper"
+          >
+            <Icon
+              shape="system-resize-horizontal"
+              size="12px"
+            />
+          </div>
+        </div>,
+        <Unknown
+          className="className"
+          isResizing={false}
+          width={undefined}
+        >
+          SidePanel
+        </Unknown>,
+      ],
+      "className": "splitPanels",
+      "onMouseMove": [Function],
+      "onMouseUp": [Function],
+    },
+    "ref": Object {
+      "current": null,
+    },
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": "primaryPanel",
+        "nodeType": "function",
+        "props": Object {
+          "children": "PrimaryPanel",
+          "className": "className",
+          "isResizing": false,
+        },
+        "ref": null,
+        "rendered": "PrimaryPanel",
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": "separator",
+        "nodeType": "host",
+        "props": Object {
+          "children": <div
+            className="splitPanels-resizeIconWrapper"
+          >
+            <Icon
+              shape="system-resize-horizontal"
+              size="12px"
+            />
+          </div>,
+          "className": "splitPanels-separator",
+          "onMouseDown": [Function],
+          "style": Object {
+            "right": 0,
+            "transform": "translateX(undefinedpx)",
+            "transition": undefined,
+          },
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": <Icon
+              shape="system-resize-horizontal"
+              size="12px"
+            />,
+            "className": "splitPanels-resizeIconWrapper",
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "function",
+            "props": Object {
+              "shape": "system-resize-horizontal",
+              "size": "12px",
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          "type": "div",
+        },
+        "type": "div",
+      },
+      Object {
+        "instance": null,
+        "key": "sidePanel",
+        "nodeType": "function",
+        "props": Object {
+          "children": "SidePanel",
+          "className": "className",
+          "isResizing": false,
+          "width": undefined,
+        },
+        "ref": null,
+        "rendered": "SidePanel",
+        "type": [Function],
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <Unknown
+            className="className"
+            isResizing={false}
+          >
+            PrimaryPanel
+          </Unknown>,
+          <div
+            className="splitPanels-separator"
+            onMouseDown={[Function]}
+            style={
+              Object {
+                "right": 0,
+                "transform": "translateX(undefinedpx)",
+                "transition": undefined,
+              }
+            }
+          >
+            <div
+              className="splitPanels-resizeIconWrapper"
+            >
+              <Icon
+                shape="system-resize-horizontal"
+                size="12px"
+              />
+            </div>
+          </div>,
+          <Unknown
+            className="className"
+            isResizing={false}
+            width={undefined}
+          >
+            SidePanel
+          </Unknown>,
+        ],
+        "className": "splitPanels",
+        "onMouseMove": [Function],
+        "onMouseUp": [Function],
+      },
+      "ref": Object {
+        "current": null,
+      },
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": "primaryPanel",
+          "nodeType": "function",
+          "props": Object {
+            "children": "PrimaryPanel",
+            "className": "className",
+            "isResizing": false,
+          },
+          "ref": null,
+          "rendered": "PrimaryPanel",
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": "separator",
+          "nodeType": "host",
+          "props": Object {
+            "children": <div
+              className="splitPanels-resizeIconWrapper"
+            >
+              <Icon
+                shape="system-resize-horizontal"
+                size="12px"
+              />
+            </div>,
+            "className": "splitPanels-separator",
+            "onMouseDown": [Function],
+            "style": Object {
+              "right": 0,
+              "transform": "translateX(undefinedpx)",
+              "transition": undefined,
+            },
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": <Icon
+                shape="system-resize-horizontal"
+                size="12px"
+              />,
+              "className": "splitPanels-resizeIconWrapper",
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "function",
+              "props": Object {
+                "shape": "system-resize-horizontal",
+                "size": "12px",
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            "type": "div",
+          },
+          "type": "div",
+        },
+        Object {
+          "instance": null,
+          "key": "sidePanel",
+          "nodeType": "function",
+          "props": Object {
+            "children": "SidePanel",
+            "className": "className",
+            "isResizing": false,
+            "width": undefined,
+          },
+          "ref": null,
+          "rendered": "SidePanel",
+          "type": [Function],
+        },
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
+        "lifecycles": Object {
+          "componentDidUpdate": Object {
+            "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
+          },
+          "getDerivedStateFromProps": Object {
+            "hasShouldComponentUpdateBug": false,
+          },
+          "getSnapshotBeforeUpdate": true,
+          "setState": Object {
+            "skipsComponentDidUpdateOnNullish": true,
+          },
+        },
+      },
+    },
+  },
+  Symbol(enzyme.__childContext__): null,
+}
+`;
+
+exports[`SplitPanel renders default 1`] = `
+ShallowWrapper {
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <SplitPanel>
+    <Unknown>
+      PrimaryPanel
+    </Unknown>
+    <Unknown>
+      SidePanel
+    </Unknown>
+  </SplitPanel>,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "checkPropTypes": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateError": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <Unknown
+          isResizing={false}
+        >
+          PrimaryPanel
+        </Unknown>,
+        <div
+          className="splitPanels-separator"
+          onMouseDown={[Function]}
+          style={
+            Object {
+              "right": 0,
+              "transform": "translateX(undefinedpx)",
+              "transition": undefined,
+            }
+          }
+        >
+          <div
+            className="splitPanels-resizeIconWrapper"
+          >
+            <Icon
+              shape="system-resize-horizontal"
+              size="12px"
+            />
+          </div>
+        </div>,
+        <Unknown
+          isResizing={false}
+          width={undefined}
+        >
+          SidePanel
+        </Unknown>,
+      ],
+      "className": "splitPanels",
+      "onMouseMove": [Function],
+      "onMouseUp": [Function],
+    },
+    "ref": Object {
+      "current": null,
+    },
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": "primaryPanel",
+        "nodeType": "function",
+        "props": Object {
+          "children": "PrimaryPanel",
+          "isResizing": false,
+        },
+        "ref": null,
+        "rendered": "PrimaryPanel",
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": "separator",
+        "nodeType": "host",
+        "props": Object {
+          "children": <div
+            className="splitPanels-resizeIconWrapper"
+          >
+            <Icon
+              shape="system-resize-horizontal"
+              size="12px"
+            />
+          </div>,
+          "className": "splitPanels-separator",
+          "onMouseDown": [Function],
+          "style": Object {
+            "right": 0,
+            "transform": "translateX(undefinedpx)",
+            "transition": undefined,
+          },
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": <Icon
+              shape="system-resize-horizontal"
+              size="12px"
+            />,
+            "className": "splitPanels-resizeIconWrapper",
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "function",
+            "props": Object {
+              "shape": "system-resize-horizontal",
+              "size": "12px",
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          "type": "div",
+        },
+        "type": "div",
+      },
+      Object {
+        "instance": null,
+        "key": "sidePanel",
+        "nodeType": "function",
+        "props": Object {
+          "children": "SidePanel",
+          "isResizing": false,
+          "width": undefined,
+        },
+        "ref": null,
+        "rendered": "SidePanel",
+        "type": [Function],
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <Unknown
+            isResizing={false}
+          >
+            PrimaryPanel
+          </Unknown>,
+          <div
+            className="splitPanels-separator"
+            onMouseDown={[Function]}
+            style={
+              Object {
+                "right": 0,
+                "transform": "translateX(undefinedpx)",
+                "transition": undefined,
+              }
+            }
+          >
+            <div
+              className="splitPanels-resizeIconWrapper"
+            >
+              <Icon
+                shape="system-resize-horizontal"
+                size="12px"
+              />
+            </div>
+          </div>,
+          <Unknown
+            isResizing={false}
+            width={undefined}
+          >
+            SidePanel
+          </Unknown>,
+        ],
+        "className": "splitPanels",
+        "onMouseMove": [Function],
+        "onMouseUp": [Function],
+      },
+      "ref": Object {
+        "current": null,
+      },
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": "primaryPanel",
+          "nodeType": "function",
+          "props": Object {
+            "children": "PrimaryPanel",
+            "isResizing": false,
+          },
+          "ref": null,
+          "rendered": "PrimaryPanel",
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": "separator",
+          "nodeType": "host",
+          "props": Object {
+            "children": <div
+              className="splitPanels-resizeIconWrapper"
+            >
+              <Icon
+                shape="system-resize-horizontal"
+                size="12px"
+              />
+            </div>,
+            "className": "splitPanels-separator",
+            "onMouseDown": [Function],
+            "style": Object {
+              "right": 0,
+              "transform": "translateX(undefinedpx)",
+              "transition": undefined,
+            },
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": <Icon
+                shape="system-resize-horizontal"
+                size="12px"
+              />,
+              "className": "splitPanels-resizeIconWrapper",
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "function",
+              "props": Object {
+                "shape": "system-resize-horizontal",
+                "size": "12px",
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            "type": "div",
+          },
+          "type": "div",
+        },
+        Object {
+          "instance": null,
+          "key": "sidePanel",
+          "nodeType": "function",
+          "props": Object {
+            "children": "SidePanel",
+            "isResizing": false,
+            "width": undefined,
+          },
+          "ref": null,
+          "rendered": "SidePanel",
+          "type": [Function],
+        },
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
+        "lifecycles": Object {
+          "componentDidUpdate": Object {
+            "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
+          },
+          "getDerivedStateFromProps": Object {
+            "hasShouldComponentUpdateBug": false,
+          },
+          "getSnapshotBeforeUpdate": true,
+          "setState": Object {
+            "skipsComponentDidUpdateOnNullish": true,
+          },
+        },
+      },
+    },
+  },
+  Symbol(enzyme.__childContext__): null,
+}
+`;
+
+exports[`SplitPanel renders with SidePanel isActive prop set to true 1`] = `
+ShallowWrapper {
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <SplitPanel>
+    <Unknown>
+      PrimaryPanel
+    </Unknown>
+    <Unknown
+      isActive={true}
+    >
+      SidePanel
+    </Unknown>
+  </SplitPanel>,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "checkPropTypes": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateError": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <Unknown
+          isResizing={false}
+        >
+          PrimaryPanel
+        </Unknown>,
+        <div
+          className="splitPanels-separator splitPanels-separator--active"
+          onMouseDown={[Function]}
+          style={
+            Object {
+              "right": undefined,
+              "transform": "translateX(0px)",
+              "transition": undefined,
+            }
+          }
+        >
+          <div
+            className="splitPanels-resizeIconWrapper"
+          >
+            <Icon
+              shape="system-resize-horizontal"
+              size="12px"
+            />
+          </div>
+        </div>,
+        <Unknown
+          isActive={true}
+          isResizing={false}
+          width={undefined}
+        >
+          SidePanel
+        </Unknown>,
+      ],
+      "className": "splitPanels",
+      "onMouseMove": [Function],
+      "onMouseUp": [Function],
+    },
+    "ref": Object {
+      "current": null,
+    },
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": "primaryPanel",
+        "nodeType": "function",
+        "props": Object {
+          "children": "PrimaryPanel",
+          "isResizing": false,
+        },
+        "ref": null,
+        "rendered": "PrimaryPanel",
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": "separator",
+        "nodeType": "host",
+        "props": Object {
+          "children": <div
+            className="splitPanels-resizeIconWrapper"
+          >
+            <Icon
+              shape="system-resize-horizontal"
+              size="12px"
+            />
+          </div>,
+          "className": "splitPanels-separator splitPanels-separator--active",
+          "onMouseDown": [Function],
+          "style": Object {
+            "right": undefined,
+            "transform": "translateX(0px)",
+            "transition": undefined,
+          },
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": <Icon
+              shape="system-resize-horizontal"
+              size="12px"
+            />,
+            "className": "splitPanels-resizeIconWrapper",
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "function",
+            "props": Object {
+              "shape": "system-resize-horizontal",
+              "size": "12px",
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          "type": "div",
+        },
+        "type": "div",
+      },
+      Object {
+        "instance": null,
+        "key": "sidePanel",
+        "nodeType": "function",
+        "props": Object {
+          "children": "SidePanel",
+          "isActive": true,
+          "isResizing": false,
+          "width": undefined,
+        },
+        "ref": null,
+        "rendered": "SidePanel",
+        "type": [Function],
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <Unknown
+            isResizing={false}
+          >
+            PrimaryPanel
+          </Unknown>,
+          <div
+            className="splitPanels-separator splitPanels-separator--active"
+            onMouseDown={[Function]}
+            style={
+              Object {
+                "right": undefined,
+                "transform": "translateX(0px)",
+                "transition": undefined,
+              }
+            }
+          >
+            <div
+              className="splitPanels-resizeIconWrapper"
+            >
+              <Icon
+                shape="system-resize-horizontal"
+                size="12px"
+              />
+            </div>
+          </div>,
+          <Unknown
+            isActive={true}
+            isResizing={false}
+            width={undefined}
+          >
+            SidePanel
+          </Unknown>,
+        ],
+        "className": "splitPanels",
+        "onMouseMove": [Function],
+        "onMouseUp": [Function],
+      },
+      "ref": Object {
+        "current": null,
+      },
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": "primaryPanel",
+          "nodeType": "function",
+          "props": Object {
+            "children": "PrimaryPanel",
+            "isResizing": false,
+          },
+          "ref": null,
+          "rendered": "PrimaryPanel",
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": "separator",
+          "nodeType": "host",
+          "props": Object {
+            "children": <div
+              className="splitPanels-resizeIconWrapper"
+            >
+              <Icon
+                shape="system-resize-horizontal"
+                size="12px"
+              />
+            </div>,
+            "className": "splitPanels-separator splitPanels-separator--active",
+            "onMouseDown": [Function],
+            "style": Object {
+              "right": undefined,
+              "transform": "translateX(0px)",
+              "transition": undefined,
+            },
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": <Icon
+                shape="system-resize-horizontal"
+                size="12px"
+              />,
+              "className": "splitPanels-resizeIconWrapper",
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "function",
+              "props": Object {
+                "shape": "system-resize-horizontal",
+                "size": "12px",
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            "type": "div",
+          },
+          "type": "div",
+        },
+        Object {
+          "instance": null,
+          "key": "sidePanel",
+          "nodeType": "function",
+          "props": Object {
+            "children": "SidePanel",
+            "isActive": true,
+            "isResizing": false,
+            "width": undefined,
+          },
+          "ref": null,
+          "rendered": "SidePanel",
+          "type": [Function],
+        },
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
+        "lifecycles": Object {
+          "componentDidUpdate": Object {
+            "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
+          },
+          "getDerivedStateFromProps": Object {
+            "hasShouldComponentUpdateBug": false,
+          },
+          "getSnapshotBeforeUpdate": true,
+          "setState": Object {
+            "skipsComponentDidUpdateOnNullish": true,
+          },
+        },
+      },
+    },
+  },
+  Symbol(enzyme.__childContext__): null,
+}
+`;

--- a/src/js/utils/WindowResizeUtil.ts
+++ b/src/js/utils/WindowResizeUtil.ts
@@ -1,0 +1,49 @@
+let handlers: Array<() => void> = [],
+  running = false;
+
+// Runs all registered handlers on resize, unless awaiting requestAnimationFrame
+function resize(): void {
+  if (running) {
+    return;
+  }
+
+  running = true;
+  window.requestAnimationFrame(runHandlers);
+}
+
+// run the actual callbacks
+function runHandlers(): void {
+  handlers.forEach(handler => handler());
+  running = false;
+}
+
+function addHandler(callback: () => void): void {
+  handlers.push(callback);
+}
+
+function hasHandlers(): boolean {
+  return Boolean(handlers.length);
+}
+
+function removeHandler(callback: () => void) {
+  handlers = handlers.filter(existing => existing !== callback);
+}
+
+export default {
+  // public method to add additional callback
+  add: (handler: () => void, global = window): void => {
+    if (!hasHandlers()) {
+      // Lazy attach
+      global.addEventListener("resize", resize);
+    }
+    addHandler(handler);
+  },
+  remove: (handler: () => void, global = window): void => {
+    removeHandler(handler);
+
+    if (!hasHandlers()) {
+      global.removeEventListener("resize", resize);
+      running = false;
+    }
+  }
+};

--- a/src/js/utils/__tests__/WindowResizeUtil-test.js
+++ b/src/js/utils/__tests__/WindowResizeUtil-test.js
@@ -1,0 +1,36 @@
+import WindowResizeUtil from "../WindowResizeUtil";
+
+describe("WindowResizeUtil", () => {
+  describe("add/remove handlers", () => {
+    beforeEach(() => {
+      jest
+        .spyOn(window, "requestAnimationFrame")
+        .mockImplementation(cb => cb());
+    });
+
+    it("can be triggered globally", () => {
+      const testHandler = jest.fn();
+
+      WindowResizeUtil.add(testHandler);
+      window.dispatchEvent(new Event("resize"));
+
+      expect(testHandler).toHaveBeenCalled();
+      WindowResizeUtil.remove(testHandler);
+    });
+
+    it("removes global listener when all listeners are removed", () => {
+      const removeSpy = jest.spyOn(window, "removeEventListener");
+
+      const testHandler1 = jest.fn();
+      const testHandler2 = jest.fn();
+
+      WindowResizeUtil.add(testHandler1);
+      WindowResizeUtil.add(testHandler2);
+
+      WindowResizeUtil.remove(testHandler1);
+      expect(removeSpy).not.toHaveBeenCalled();
+      WindowResizeUtil.remove(testHandler2);
+      expect(removeSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/styles/components/modal/full-screen/styles.less
+++ b/src/styles/components/modal/full-screen/styles.less
@@ -28,17 +28,17 @@
     .modal-body {
       display: flex;
       flex: 1 0 auto;
-      min-height: 100%;
+      flex-direction: column;
+      height: 100%;
       overflow: hidden;
+    }
+
+    .splitPanels {
+      flex-grow: 1;
     }
 
     .modal-body-offset {
       margin: -@modal-full-screen-body-padding-vertical -@modal-full-screen-body-padding-horizontal;
-
-      & > .gm-scrollbar-container {
-        flex: 1 1 auto;
-        height: auto;
-      }
     }
   }
 
@@ -83,28 +83,6 @@
 
   .modal-full-screen-actions-secondary {
     margin-right: @base-spacing-unit * 1/2;
-  }
-
-  .modal-full-screen-side-panel {
-    height: 100%;
-    position: absolute;
-    right: @modal-full-screen-side-panel-width * -1;
-    top: 0;
-    transition: right 0.35s, visibility 0.35s;
-    visibility: hidden;
-    width: @modal-full-screen-side-panel-width;
-    will-change: right;
-    z-index: @z-index-modal-side-panel;
-
-    &.is-visible {
-      right: 0;
-      transition: right 0.35s;
-      visibility: visible;
-    }
-  }
-
-  .modal-full-screen-side-panel-placeholder {
-    display: none;
   }
 }
 
@@ -198,22 +176,6 @@
 
     .modal-full-screen-actions-secondary {
       left: @pod-margin-left-screen-large;
-    }
-
-    .modal-full-screen-side-panel {
-      right: @modal-full-screen-side-panel-width-screen-large * -1;
-      width: @modal-full-screen-side-panel-width-screen-large;
-    }
-
-    .modal-full-screen-side-panel-placeholder {
-      display: block;
-      flex-shrink: 0;
-      transition: width 0.35s;
-      width: 0;
-
-      &.is-visible {
-        width: @modal-full-screen-side-panel-width-screen-large;
-      }
     }
   }
 }

--- a/src/styles/components/modal/full-screen/variables.less
+++ b/src/styles/components/modal/full-screen/variables.less
@@ -18,6 +18,3 @@
 @modal-full-screen-body-padding-horizontal-screen-medium: @pod-margin-left-screen-medium;
 @modal-full-screen-body-padding-horizontal-screen-large: @pod-margin-left-screen-large;
 @modal-full-screen-body-padding-horizontal-screen-jumbo: @pod-margin-left-screen-jumbo;
-
-@modal-full-screen-side-panel-width: 100%;
-@modal-full-screen-side-panel-width-screen-large: 50vw;

--- a/src/styles/components/split-panel/styles.less
+++ b/src/styles/components/split-panel/styles.less
@@ -1,0 +1,112 @@
+@import '~@dcos/ui-kit/dist/packages/design-tokens/build/less/_designTokens';
+
+.splitPanels {
+  display: flex;
+  flex-direction: row;
+  height: 100%;
+  width: 100%;
+}
+
+.panel {
+  flex: 0 0 auto;
+  overflow: auto;
+}
+
+.panel--primary {
+  flex: 1 1 auto;
+}
+
+.splitPanels-separator {
+  background-color: @greyLight-lighten-5;
+  bottom: 0;
+  cursor: col-resize;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 0;
+  transition: @transition-timing transform, @transition-timing right;
+
+  svg {
+    fill: @text-color-secondary;
+  }
+
+  &:hover,
+  &:active {
+    background-color: @grey-light-lighten-4;
+
+    svg {
+      fill: @text-color-primary;
+    }
+  }
+}
+
+.splitPanels-separator--active {
+  right: @modal-full-screen-side-panel-width;
+  width: 16px;
+}
+
+.splitPanels-resizeIconWrapper {
+  left: 50%;
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.noUserSelect {
+  user-select: none;
+}
+
+.modal-full-screen-side-panel {
+  height: 100%;
+  position: absolute;
+  right: @modal-full-screen-side-panel-width * -1;
+  top: 0;
+  transition: right @transition-timing, visibility @transition-timing;
+  visibility: hidden;
+  width: @modal-full-screen-side-panel-width;
+  will-change: right;
+  z-index: @z-index-modal-side-panel;
+
+  &.is-visible {
+    right: 0;
+    transition: right @transition-timing;
+    visibility: visible;
+  }
+}
+
+.modal-full-screen-side-panel-placeholder {
+  display: none;
+}
+
+.jsonEditorWrapper {
+
+  > div {
+    min-width: 100%;
+  }
+}
+
+& when (@modal-full-screen-enabled) and (@layout-screen-large-enabled) {
+
+  @media (min-width: @layout-screen-large-min-width) {
+
+    .modal-full-screen-side-panel {
+      right: @modal-full-screen-side-panel-width-screen-large * -1;
+      width: @modal-full-screen-side-panel-width-screen-large;
+    }
+
+    .splitPanels-separator {
+      right: @modal-full-screen-side-panel-width-screen-large;
+    }
+
+    .modal-full-screen-side-panel-placeholder {
+      display: block;
+      flex-shrink: 0;
+      transition: width @transition-timing;
+      width: 0;
+
+      &.is-visible {
+        width: @modal-full-screen-side-panel-width-screen-large;
+      }
+    }
+  }
+}

--- a/src/styles/components/split-panel/variables.less
+++ b/src/styles/components/split-panel/variables.less
@@ -1,0 +1,3 @@
+@modal-full-screen-side-panel-width: 100%;
+@modal-full-screen-side-panel-width-screen-large: 50vw;
+@transition-timing: 0.35s;

--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -376,6 +376,11 @@
 @import 'components/modal/server-error/variables.less';
 @import 'components/modal/server-error/styles.less';
 
+// Split Panel
+
+@import 'components/split-panel/variables.less';
+@import 'components/split-panel/styles.less';
+
 // Multiple Form
 
 @import 'components/multiple-form/variables.less';

--- a/src/styles/views/create-service-modal/styles.less
+++ b/src/styles/views/create-service-modal/styles.less
@@ -6,6 +6,7 @@
       align-items: stretch;
       display: flex;
       flex-direction: column;
+      height: 100%;
       justify-content: center;
 
       &-option {


### PR DESCRIPTION
## Testing
1. Go to either the create service form, create job form, or framework configuration form
2. Toggle the JSON editor open
3. Drag the handle on the left of the editor to resize the editor

## Trade-offs
The component I made (`SplitPanel`) to handle this only supports a side panel on the right. I can easily support it being on the left or right, but we don't have any cases where the side panel appears on the left.

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots
![JSONResizeDemo](https://user-images.githubusercontent.com/2313998/62167197-b0d2a200-b2f0-11e9-95a1-141b6fc18774.gif)

