### PR TITLE
simplify lingui-extraction-script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -565,7 +565,7 @@ Add this part to your `jsconfig.json` in the root of this project
     "paths": {
       "#SRC/*": ["dcos-ui/src/*"],
       "#LOCALE/*": ["dcos-ui/locale/*"],
-      "#EXTERNAL_PLUGINS/*": ["dcos-ui-plugins-private/*"],
+      "#EXTERNAL_PLUGINS/*": ["dcos-ui/plugins-ee/*"],
       "#PLUGINS/*": ["dcos-ui/plugins/*"]
     }
   }

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ DC/OS UI comes bundled with some internal plugins within the `/plugins` director
 
 ```sh
 # for dcos-ui-plugins-private
-npm config set externalplugins ../dcos-ui-plugins-private
+npm config set externalplugins ./plugins-ee
 
 # to simplify development of external plugins and enable automated translation catalog extraction
 npm run util:env:link-externalplugins
@@ -62,7 +62,7 @@ npm run util:env:link-externalplugins
 npm config set externalplugins ../path/to/plugins
 ```
 
-Note that `dcos-ui-plugins-private` currently _must_ be set up at `../dcos-ui-plugins-private`. You also might want to copy its `Config.template.js` to `src/js/config/Config.dev.ts` to enable the enterprise edition.
+Note that `dcos-ui-plugins-private` currently _must_ be set up at `./plugins-ee` for CI and all tooling to work. You also might want to copy its `Config.template.js` to `src/js/config/Config.dev.ts` to enable the enterprise edition.
 
 5.  Start the development server:
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -35,7 +35,7 @@ module.exports = {
   moduleFileExtensions: ["js", "json", "ts", "tsx"],
   modulePathIgnorePatterns: ["/tmp/", "/node_modules/", "/.module-cache/"],
   moduleNameMapper: {
-    "#EXTERNAL_PLUGINS/([^\\.]*)$": "<rootDir>/../dcos-ui-plugins-private/$1",
+    "#EXTERNAL_PLUGINS/([^\\.]*)$": "<rootDir>/plugins-ee/$1",
     "\\.(jpe?g|png|gif|bmp|svg|less|raml)$": "<rootDir>/jest/fileMock.js"
   },
   timers: "fake",

--- a/scripts/lingui-extract
+++ b/scripts/lingui-extract
@@ -1,31 +1,8 @@
 #!/usr/bin/env bash
-
 SCRIPT_PATH="$(dirname "$0")/$(dirname "$(readlink "$0")")"
 
 # Import utils
 source "${SCRIPT_PATH}/utils/message"
-
-function eeSanityCheck {
-  if [ ! -f "$SCRIPT_PATH/../plugins-ee/.babelrc" ]; then
-    warning "plugins-ee/.babelrc file not found. Did this script fail previously? Try running with --unpatch to fix"
-    return 1
-  else
-    return 0
-  fi
-}
-
-# This function temporarily replaces the lingui config and temporarily hides
-# the .babelrc file. lingui extract cannot extract messages from macros that
-# are outside of the package due to the way packages are resolved from each source file. 
-function patch {
-  info "Hiding .babelrc for external plugin extraction"
-  mv "$SCRIPT_PATH/../plugins-ee/.babelrc" "$SCRIPT_PATH/../plugins-ee/.tmp.babelrc"
-}
-
-function unpatch {
-  mv "$SCRIPT_PATH/../plugins-ee/.tmp.babelrc" "$SCRIPT_PATH/../plugins-ee/.babelrc"
-  info "Restored .babelrc"
-}
 
 title "lingui extract"
 
@@ -34,18 +11,11 @@ if [[ $* == *--verbose* ]]; then
   VERBOSE="--verbose "
 fi
 
-if [[ $* == *--unpatch ]]; then
-  unpatch
-else
-  info "Extracting message catalogs for dcos-ui..."
-  eval "lingui extract $VERBOSE--clean --config ./linguirc"
-  if [ -d "$SCRIPT_PATH/../plugins-ee" ]; then
-    eeSanityCheck
-    if [[ $? == 0 ]]; then
-      info "Extracting message catalogs for dcos-ui-plugins-private"
-      patch
-      eval "lingui extract $VERBOSE--clean  --config ./plugins-ee/.linguirc"
-      unpatch
-    fi
+info "Extracting message catalogs for dcos-ui..."
+eval "lingui extract $VERBOSE--clean --config ./linguirc"
+if [ -d "$SCRIPT_PATH/../plugins-ee" ]; then
+  if [[ $? == 0 ]]; then
+    info "Extracting message catalogs for dcos-ui-plugins-private"
+    eval "lingui extract $VERBOSE--clean  --config ./plugins-ee/.linguirc"
   fi
 fi

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,7 +35,7 @@
       "*": ["*", "packages/*", "src/typings/*"],
       "#SRC/*": ["src/*"],
       "#LOCALE/*": ["locale/*"],
-      "#EXTERNAL_PLUGINS/*": ["../dcos-ui-plugins-private/*"],
+      "#EXTERNAL_PLUGINS/*": ["plugins-ee/*"],
       "#PLUGINS/*": ["plugins/*"]
     }
   },


### PR DESCRIPTION
by making the following change in plugins-ee, we should be able to evade the
need for .babelrc-handling.

```diff
- { "extends": "../dcos-ui/.babelrc" }
+ { "extends": "../.babelrc" }
```

This change makes use of the fact that we now work with a symlink at plugins-ee.

To enable the aforementioned change, we need to change a couple details in our build-phase. Please review commit-by-commit to best be able to think about implications i might have missed.

## Testing

Make sure you checked out the [according ee-branch](https://github.com/mesosphere/dcos-ui-plugins-private/pull/1048).

Test that the extraction still works properly. OSS and EE each have their own localization-files. 

# ⚠️ 	The EE-PR should merge at the same time or before this!