### PR TITLE
[DCOS-55020] Drain/Deactivate actions on node details

### DIFF
--- a/plugins/nodes/src/js/columns/NodesTableActionsColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableActionsColumn.tsx
@@ -1,98 +1,27 @@
 import * as React from "react";
 import { Trans } from "@lingui/macro";
-import { i18nMark } from "@lingui/react";
-import { Cell, Icon } from "@dcos/ui-kit";
-import { Dropdown, Tooltip, MenuItem } from "reactjs-components";
-
-import { SystemIcons } from "@dcos/ui-kit/dist/packages/icons/dist/system-icons-enum";
-import { iconSizeXs } from "@dcos/ui-kit/dist/packages/design-tokens/build/js/designTokens";
+import { Cell } from "@dcos/ui-kit";
+import { Tooltip } from "reactjs-components";
 
 import Node from "#SRC/js/structs/Node";
-
-import { actionAllowed, StatusAction, Status } from "../types/Status";
-
-const NodeActionLabels = {
-  drain: i18nMark("Drain"),
-  deactivate: i18nMark("Deactivate"),
-  reactivate: i18nMark("Reactivate")
-};
-
-const MORE = "MORE";
-
-function renderActionsDropdown(
-  actions: MenuItem[],
-  handleAction: (action: string) => void
-) {
-  const wrapHandleAction = (item: MenuItem) => {
-    handleAction(String(item.id));
-  };
-
-  return (
-    <Dropdown
-      anchorRight={true}
-      buttonClassName="button button-mini button-link"
-      dropdownMenuClassName="dropdown-menu"
-      dropdownMenuListClassName="dropdown-menu-list"
-      dropdownMenuListItemClassName="clickable"
-      wrapperClassName="dropdown flush-bottom table-cell-icon actions-dropdown"
-      items={actions}
-      persistentID={MORE}
-      onItemSelection={wrapHandleAction}
-      scrollContainer=".gm-scroll-view"
-      scrollContainerParentSelector=".gm-prevented"
-      transition={true}
-      transitionName="dropdown-menu"
-    />
-  );
-}
-
-const getAllowedActionsForNode = (data: Node) => {
-  const status = Status.fromNode(data);
-  const actions: MenuItem[] = [];
-
-  actions.push({
-    className: "hidden",
-    id: MORE,
-    selectedHtml: (
-      <Icon shape={SystemIcons.EllipsisVertical} size={iconSizeXs} />
-    )
-  });
-
-  if (actionAllowed(StatusAction.DRAIN, status)) {
-    actions.push({
-      id: StatusAction.DRAIN,
-      html: <Trans render="span" id={NodeActionLabels.drain} />
-    });
-  }
-
-  if (actionAllowed(StatusAction.DEACTIVATE, status)) {
-    actions.push({
-      id: StatusAction.DEACTIVATE,
-      html: <Trans render="span" id={NodeActionLabels.deactivate} />
-    });
-  }
-
-  if (actionAllowed(StatusAction.REACTIVATE, status)) {
-    actions.push({
-      id: StatusAction.REACTIVATE,
-      html: <Trans render="span" id={NodeActionLabels.reactivate} />
-    });
-  }
-
-  return actions;
-};
+import NodeActionsDropdown, {
+  getAllowedActions
+} from "../components/NodeActionsDropdown";
 
 const generateActionsRenderer = (
   handleAction: (node: Node, action: string) => void
 ) => {
   return (data: Node): React.ReactNode => {
-    const actions = getAllowedActionsForNode(data);
+    const actions = getAllowedActions(data);
 
     return (
       <Cell>
         {actions.length > 1 ? (
           <Tooltip content={<Trans render="span">Actions</Trans>}>
-            {renderActionsDropdown(actions, handleAction.bind(null, data))}
+            <NodeActionsDropdown
+              node={data}
+              onAction={handleAction.bind(null, data)}
+            />
           </Tooltip>
         ) : (
           <span />

--- a/plugins/nodes/src/js/components/NodeActionsDropdown.tsx
+++ b/plugins/nodes/src/js/components/NodeActionsDropdown.tsx
@@ -1,0 +1,89 @@
+import * as React from "react";
+import { i18nMark } from "@lingui/react";
+import { Trans } from "@lingui/macro";
+
+import { Icon } from "@dcos/ui-kit";
+import { SystemIcons } from "@dcos/ui-kit/dist/packages/icons/dist/system-icons-enum";
+import { iconSizeXs } from "@dcos/ui-kit/dist/packages/design-tokens/build/js/designTokens";
+import { Dropdown, MenuItem } from "reactjs-components";
+
+import Node from "#SRC/js/structs/Node";
+
+import { actionAllowed, StatusAction, Status } from "../types/Status";
+
+const NodeActionLabels = {
+  drain: i18nMark("Drain"),
+  deactivate: i18nMark("Deactivate"),
+  reactivate: i18nMark("Reactivate")
+};
+
+const MORE = "MORE";
+
+function getAllowedActions(node: Node) {
+  const status = Status.fromNode(node);
+  const actions: MenuItem[] = [];
+
+  actions.push({
+    className: "hidden",
+    id: MORE,
+    selectedHtml: (
+      <Icon shape={SystemIcons.EllipsisVertical} size={iconSizeXs} />
+    )
+  });
+
+  if (actionAllowed(StatusAction.DRAIN, status)) {
+    actions.push({
+      id: StatusAction.DRAIN,
+      html: <Trans render="span" id={NodeActionLabels.drain} />
+    });
+  }
+
+  if (actionAllowed(StatusAction.DEACTIVATE, status)) {
+    actions.push({
+      id: StatusAction.DEACTIVATE,
+      html: <Trans render="span" id={NodeActionLabels.deactivate} />
+    });
+  }
+
+  if (actionAllowed(StatusAction.REACTIVATE, status)) {
+    actions.push({
+      id: StatusAction.REACTIVATE,
+      html: <Trans render="span" id={NodeActionLabels.reactivate} />
+    });
+  }
+
+  return actions;
+}
+
+interface Props {
+  onAction: (actionId: string) => void;
+  node: Node;
+}
+
+function NodeActionsDropdown(props: Props) {
+  const wrapHandleAction = (item: MenuItem) => {
+    props.onAction(String(item.id));
+  };
+
+  const actions = getAllowedActions(props.node);
+
+  return (
+    <Dropdown
+      anchorRight={true}
+      buttonClassName="button button-mini button-link"
+      dropdownMenuClassName="dropdown-menu"
+      dropdownMenuListClassName="dropdown-menu-list"
+      dropdownMenuListItemClassName="clickable"
+      wrapperClassName="dropdown flush-bottom table-cell-icon actions-dropdown"
+      items={actions}
+      persistentID={MORE}
+      onItemSelection={wrapHandleAction}
+      scrollContainer=".gm-scroll-view"
+      scrollContainerParentSelector=".gm-prevented"
+      transition={true}
+      transitionName="dropdown-menu"
+    />
+  );
+}
+
+export { NodeActionsDropdown as default, getAllowedActions };

--- a/plugins/nodes/src/js/pages/nodes/NodeDetailPage.js
+++ b/plugins/nodes/src/js/pages/nodes/NodeDetailPage.js
@@ -14,6 +14,9 @@ import Page from "#SRC/js/components/Page";
 import TabsMixin from "#SRC/js/mixins/TabsMixin";
 import RouterUtil from "#SRC/js/utils/RouterUtil";
 import { generateDefaultNetworkErrorHandler } from "#SRC/js/utils/DefaultErrorUtil";
+import { findNestedPropertyInObject } from "#SRC/js/utils/Util";
+// @ts-ignore
+import ConfigStore from "#SRC/js/stores/ConfigStore";
 
 import { Status, actionAllowed, StatusAction } from "../../types/Status";
 import DrainNodeModal from "../../components/modals/DrainNodeModal";
@@ -139,6 +142,15 @@ class NodeDetailPage extends mixin(TabsMixin, StoreMixin) {
   }
 
   getActions() {
+    const hasMaintenance = findNestedPropertyInObject(
+      ConfigStore.get("config"),
+      "uiConfiguration.features.maintenance"
+    );
+
+    if (!hasMaintenance) {
+      return [];
+    }
+
     const actions = [];
     const { node } = this.props;
     const status = Status.fromNode(node);

--- a/plugins/nodes/src/js/pages/nodes/NodeDetailPage.js
+++ b/plugins/nodes/src/js/pages/nodes/NodeDetailPage.js
@@ -1,4 +1,4 @@
-import { i18nMark } from "@lingui/react";
+import { i18nMark, withI18n } from "@lingui/react";
 import { Trans } from "@lingui/macro";
 import mixin from "reactjs-mixin";
 /* eslint-disable no-unused-vars */
@@ -13,7 +13,12 @@ import { withNode } from "#SRC/js/stores/MesosSummaryFetchers";
 import Page from "#SRC/js/components/Page";
 import TabsMixin from "#SRC/js/mixins/TabsMixin";
 import RouterUtil from "#SRC/js/utils/RouterUtil";
+import { generateDefaultNetworkErrorHandler } from "#SRC/js/utils/DefaultErrorUtil";
 
+import { Status, actionAllowed, StatusAction } from "../../types/Status";
+import DrainNodeModal from "../../components/modals/DrainNodeModal";
+import DeactivateNodeConfirm from "../../components/modals/DeactivateNodeConfirm";
+import NodeMaintenanceActions from "../../actions/NodeMaintenanceActions";
 import NodeBreadcrumbs from "../../components/NodeBreadcrumbs";
 import NodeHealthStore from "../../stores/NodeHealthStore";
 
@@ -38,8 +43,13 @@ class NodeDetailPage extends mixin(TabsMixin, StoreMixin) {
     };
 
     this.state = {
-      mesosStateLoaded: false
+      mesosStateLoaded: false,
+      selectedNodeToDrain: null,
+      selectedNodeToDeactivate: null
     };
+
+    this.handleNodeAction = this.handleNodeAction.bind(this);
+    this.handleCloseModal = this.handleCloseModal.bind(this);
   }
 
   componentWillMount() {
@@ -128,6 +138,58 @@ class NodeDetailPage extends mixin(TabsMixin, StoreMixin) {
     );
   }
 
+  getActions() {
+    const actions = [];
+    const { node } = this.props;
+    const status = Status.fromNode(node);
+
+    if (actionAllowed(StatusAction.DRAIN, status)) {
+      actions.push({
+        label: "Drain",
+        onItemSelect: this.handleNodeAction.bind(this, StatusAction.DRAIN)
+      });
+    }
+
+    if (actionAllowed(StatusAction.DEACTIVATE, status)) {
+      actions.push({
+        label: "Deactivate",
+        onItemSelect: this.handleNodeAction.bind(this, StatusAction.DEACTIVATE)
+      });
+    }
+
+    if (actionAllowed(StatusAction.REACTIVATE, status)) {
+      actions.push({
+        label: "Reactivate",
+        onItemSelect: this.handleNodeAction.bind(this, StatusAction.REACTIVATE)
+      });
+    }
+
+    return actions;
+  }
+
+  handleNodeAction(action) {
+    const { i18n, node } = this.props;
+
+    // TODO: Status#StatusAction enum
+    if (action === "drain") {
+      this.setState({ selectedNodeToDrain: node });
+    } else if (action === "deactivate") {
+      this.setState({ selectedNodeToDeactivate: node });
+    } else if (action === "reactivate") {
+      NodeMaintenanceActions.reactivateNode(node, {
+        onSuccess: () => {},
+        onError: generateDefaultNetworkErrorHandler(i18n)
+      });
+    }
+  }
+
+  handleCloseModal() {
+    this.setState({
+      selectedNodeToDeactivate: null,
+      selectedNodeToDrain: null
+    });
+  }
+
   render() {
     if (!this.state.summaryStatesProcessed || !this.state.mesosStateLoaded) {
       return this.getLoadingScreen();
@@ -140,7 +202,12 @@ class NodeDetailPage extends mixin(TabsMixin, StoreMixin) {
       return this.getNotFound(nodeID);
     }
 
-    const { currentTab } = this.state;
+    const {
+      currentTab,
+      selectedNodeToDrain,
+      selectedNodeToDeactivate
+    } = this.state;
+
     const tabs = [
       {
         label: i18nMark("Tasks"),
@@ -168,10 +235,21 @@ class NodeDetailPage extends mixin(TabsMixin, StoreMixin) {
     return (
       <Page>
         <Page.Header
+          actions={this.getActions()}
           breadcrumbs={<NodeBreadcrumbs node={node} />}
           tabs={tabs}
         />
         {React.cloneElement(this.props.children, { node })}
+        <DrainNodeModal
+          open={selectedNodeToDrain !== null}
+          node={selectedNodeToDrain}
+          onClose={this.handleCloseModal}
+        />
+        <DeactivateNodeConfirm
+          open={selectedNodeToDeactivate !== null}
+          node={selectedNodeToDeactivate}
+          onClose={this.handleCloseModal}
+        />
       </Page>
     );
   }
@@ -181,4 +259,4 @@ NodeDetailPage.contextTypes = {
   router: routerShape
 };
 
-module.exports = withNode(NodeDetailPage);
+module.exports = withNode(withI18n()(NodeDetailPage));

--- a/plugins/nodes/src/js/pages/nodes/NodeDetailPage.js
+++ b/plugins/nodes/src/js/pages/nodes/NodeDetailPage.js
@@ -1,4 +1,4 @@
-import { i18nMark, withI18n } from "@lingui/react";
+import { i18nMark } from "@lingui/react";
 import { Trans } from "@lingui/macro";
 import mixin from "reactjs-mixin";
 /* eslint-disable no-unused-vars */
@@ -13,7 +13,7 @@ import { withNode } from "#SRC/js/stores/MesosSummaryFetchers";
 import Page from "#SRC/js/components/Page";
 import TabsMixin from "#SRC/js/mixins/TabsMixin";
 import RouterUtil from "#SRC/js/utils/RouterUtil";
-import { generateDefaultNetworkErrorHandler } from "#SRC/js/utils/DefaultErrorUtil";
+import { defaultNetworkErrorHandler } from "#SRC/js/utils/DefaultErrorUtil";
 import { findNestedPropertyInObject } from "#SRC/js/utils/Util";
 // @ts-ignore
 import ConfigStore from "#SRC/js/stores/ConfigStore";
@@ -180,7 +180,7 @@ class NodeDetailPage extends mixin(TabsMixin, StoreMixin) {
   }
 
   handleNodeAction(action) {
-    const { i18n, node } = this.props;
+    const { node } = this.props;
 
     // TODO: Status#StatusAction enum
     if (action === "drain") {
@@ -190,7 +190,7 @@ class NodeDetailPage extends mixin(TabsMixin, StoreMixin) {
     } else if (action === "reactivate") {
       NodeMaintenanceActions.reactivateNode(node, {
         onSuccess: () => {},
-        onError: generateDefaultNetworkErrorHandler(i18n)
+        onError: defaultNetworkErrorHandler
       });
     }
   }
@@ -271,4 +271,4 @@ NodeDetailPage.contextTypes = {
   router: routerShape
 };
 
-module.exports = withNode(withI18n()(NodeDetailPage));
+module.exports = withNode(NodeDetailPage);

--- a/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
+++ b/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
@@ -1,31 +1,23 @@
 import mixin from "reactjs-mixin";
 import React from "react";
-import { i18nMark, withI18n } from "@lingui/react";
-import { Trans } from "@lingui/macro";
+import { withI18n } from "@lingui/react";
 import { StoreMixin } from "mesosphere-shared-reactjs";
 import { map, catchError } from "rxjs/operators";
 import { combineLatest, of } from "rxjs";
 import { graphqlObservable, componentFromStream } from "@dcos/data-service";
-import { NotificationServiceType } from "@extension-kid/notification-service";
-import {
-  ToastNotification,
-  ToastAppearance
-} from "@extension-kid/toast-notifications";
 import gql from "graphql-tag";
 
-import container from "#SRC/js/container";
 import MesosSummaryActions from "#SRC/js/events/MesosSummaryActions";
 import CompositeState from "#SRC/js/structs/CompositeState";
 import QueryParamsMixin from "#SRC/js/mixins/QueryParamsMixin";
 import NodesList from "#SRC/js/structs/NodesList";
 import Node from "#SRC/js/structs/Node";
+import { generateDefaultNetworkErrorHandler } from "#SRC/js/utils/DefaultErrorUtil";
 import { default as schema } from "#PLUGINS/nodes/src/js/data/NodesNetworkResolver";
 import NodesTable from "#PLUGINS/nodes/src/js/components/NodesTable";
 import DrainNodeModal from "#PLUGINS/nodes/src/js/components/modals/DrainNodeModal";
 import DeactivateNodeConfirm from "#PLUGINS/nodes/src/js/components/modals/DeactivateNodeConfirm";
 import NodeMaintenanceActions from "#PLUGINS/nodes/src/js/actions/NodeMaintenanceActions";
-
-const notificationService = container.get(NotificationServiceType);
 
 class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
   constructor() {
@@ -145,23 +137,7 @@ class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
         onSuccess: () => {
           MesosSummaryActions.fetchSummary();
         },
-        onError: ({ code, message }) => {
-          notificationService.push(
-            new ToastNotification(i18n._(i18nMark("Cannot Reactivate Node")), {
-              appearance: ToastAppearance.Danger,
-              autodismiss: true,
-              description:
-                code === 0 ? (
-                  <Trans>Network is offline</Trans>
-                ) : (
-                  <Trans>
-                    Unable to complete request. Please try again. The error
-                    returned was {code} {message}
-                  </Trans>
-                )
-            })
-          );
-        }
+        onError: generateDefaultNetworkErrorHandler(i18n)
       });
     }
   }

--- a/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
+++ b/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
@@ -1,6 +1,5 @@
 import mixin from "reactjs-mixin";
 import React from "react";
-import { withI18n } from "@lingui/react";
 import { StoreMixin } from "mesosphere-shared-reactjs";
 import { map, catchError } from "rxjs/operators";
 import { combineLatest, of } from "rxjs";
@@ -12,7 +11,7 @@ import CompositeState from "#SRC/js/structs/CompositeState";
 import QueryParamsMixin from "#SRC/js/mixins/QueryParamsMixin";
 import NodesList from "#SRC/js/structs/NodesList";
 import Node from "#SRC/js/structs/Node";
-import { generateDefaultNetworkErrorHandler } from "#SRC/js/utils/DefaultErrorUtil";
+import { defaultNetworkErrorHandler } from "#SRC/js/utils/DefaultErrorUtil";
 import { default as schema } from "#PLUGINS/nodes/src/js/data/NodesNetworkResolver";
 import NodesTable from "#PLUGINS/nodes/src/js/components/NodesTable";
 import DrainNodeModal from "#PLUGINS/nodes/src/js/components/modals/DrainNodeModal";
@@ -125,8 +124,6 @@ class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
   }
 
   handleNodeAction(node, action) {
-    const { i18n } = this.props;
-
     // TODO: Status#StatusAction enum
     if (action === "drain") {
       this.setState({ selectedNodeToDrain: node });
@@ -137,7 +134,7 @@ class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
         onSuccess: () => {
           MesosSummaryActions.fetchSummary();
         },
-        onError: generateDefaultNetworkErrorHandler(i18n)
+        onError: defaultNetworkErrorHandler
       });
     }
   }
@@ -198,12 +195,10 @@ const networks$ = graphqlObservable(
   catchError(() => of([]))
 );
 
-const NodesTableContainerWithI18n = withI18n()(NodesTableContainer);
-
 module.exports = componentFromStream(props$ =>
   combineLatest(props$, networks$).pipe(
     map(([props, networks]) => (
-      <NodesTableContainerWithI18n {...props} networks={networks} />
+      <NodesTableContainer {...props} networks={networks} />
     ))
   )
 );

--- a/src/js/utils/DefaultErrorUtil.tsx
+++ b/src/js/utils/DefaultErrorUtil.tsx
@@ -1,0 +1,38 @@
+import { i18nMark } from "@lingui/react";
+
+// @ts-ignore
+import {
+  ToastNotification,
+  ToastAppearance
+} from "@extension-kid/toast-notifications";
+
+import container from "#SRC/js/container";
+import {
+  NotificationService,
+  NotificationServiceType
+} from "@extension-kid/notification-service";
+
+const notificationService = container.get(
+  NotificationServiceType
+) as NotificationService;
+
+const generateDefaultNetworkErrorHandler = (i18n: any) => {
+  return ({ message, code }: { message: string; code: number }) => {
+    notificationService.push(
+      new ToastNotification(i18n._(i18nMark("Cannot Reactivate Node")), {
+        appearance: ToastAppearance.Danger,
+        autodismiss: true,
+        description:
+          code === 0
+            ? i18n._(i18nMark("Network is offline"))
+            : i18n._(
+                i18nMark(
+                  "Unable to complete request. Please try again. The error returned was:"
+                )
+              ) + ` ${code} ${message}`
+      })
+    );
+  };
+};
+
+export { generateDefaultNetworkErrorHandler };

--- a/src/js/utils/DefaultErrorUtil.tsx
+++ b/src/js/utils/DefaultErrorUtil.tsx
@@ -1,6 +1,8 @@
+import { I18n } from "@lingui/core";
 import { i18nMark } from "@lingui/react";
 
-// @ts-ignore
+import { TYPES } from "#SRC/js/types/containerTypes";
+
 import {
   ToastNotification,
   ToastAppearance
@@ -12,27 +14,34 @@ import {
   NotificationServiceType
 } from "@extension-kid/notification-service";
 
-const notificationService = container.get(
+const notificationService = container.get<NotificationService>(
   NotificationServiceType
-) as NotificationService;
+);
 
-const generateDefaultNetworkErrorHandler = (i18n: any) => {
-  return ({ message, code }: { message: string; code: number }) => {
-    notificationService.push(
-      new ToastNotification(i18n._(i18nMark("Cannot Reactivate Node")), {
-        appearance: ToastAppearance.Danger,
-        autodismiss: true,
-        description:
-          code === 0
-            ? i18n._(i18nMark("Network is offline"))
-            : i18n._(
-                i18nMark(
-                  "Unable to complete request. Please try again. The error returned was:"
-                )
-              ) + ` ${code} ${message}`
-      })
-    );
-  };
+const i18n = container.get<I18n>(TYPES.I18n);
+
+const defaultNetworkErrorHandler = ({
+  message,
+  code
+}: {
+  message: string;
+  code: number;
+}) => {
+  notificationService.push(
+    new ToastNotification(i18n._(i18nMark("Cannot Reactivate Node")), {
+      appearance: ToastAppearance.Danger,
+      autodismiss: true,
+      description:
+        code === 0
+          ? i18n._(i18nMark("Network is offline"))
+          : i18n._(
+              i18nMark(
+                "Unable to complete request. Please try again. The error returned was: {message}"
+              ),
+              { message: ` ${code} ${message}` }
+            )
+    })
+  );
 };
 
-export { generateDefaultNetworkErrorHandler };
+export { defaultNetworkErrorHandler };

--- a/tests/pages/nodes/node/NodeDetail-cy.js
+++ b/tests/pages/nodes/node/NodeDetail-cy.js
@@ -60,6 +60,51 @@ describe("Nodes Detail Page", function() {
         .configurationSection("Status")
         .configurationMapValue("Status")
         .contains("Draining");
+
+      // "Reactivate" action is available
+      cy.get(".page-header-actions .dropdown")
+        .click()
+        .get(".dropdown-menu-items")
+        .contains("Reactivate");
+    });
+
+    context("Actions", function() {
+      it("allows deactivation of active node", function() {
+        cy.visitUrl({
+          url: `/nodes/20151002-000353-1695027628-5050-1177-S1/details`,
+          identify: true
+        });
+
+        cy.get(".page-header").should(function($title) {
+          expect($title).to.contain("dcos-02");
+        });
+
+        // "Deactivate" action is available
+        cy.get(".page-header-actions .dropdown")
+          .click()
+          .get(".dropdown-menu-items")
+          .contains("Deactivate");
+      });
+
+      it("allows draining of active node", function() {
+        cy.visitUrl({
+          url: `/nodes/20151002-000353-1695027628-5050-1177-S1/details`,
+          identify: true
+        });
+
+        cy.get(".page-header").should(function($title) {
+          expect($title).to.contain("dcos-02");
+        });
+
+        // "Drain" action can be triggered
+        cy.get(".page-header-actions .dropdown")
+          .click()
+          .get(".dropdown-menu-items")
+          .contains("Drain")
+          .click();
+
+        cy.get(".modal").should("contain", "Max Grace Period");
+      });
     });
   });
 });


### PR DESCRIPTION
## Testing

1. add this key to the "uiConfiguration" key in Config.dev.ts
```
features: {
  maintenance: true
},
```
2. enable useUIConfigFixtures
3. Visit the node details page
4. Choose the details tab for more status clarity
5. Try deactivating & reactivating nodes
6. Ensure feature is not present unless feature flag is set

Should exhibit the same behaviors as nodes overview table. #4008 & #4004 

## Notes

Suggest reviewing commit-wise