### PR TITLE
don't let useUIConfigFixtures interfere with cypress

### DIFF
--- a/src/js/config/Config.ts
+++ b/src/js/config/Config.ts
@@ -92,4 +92,11 @@ if (Config.environment === "development") {
   Config.useFixtures = false;
 }
 
+// we want to stub requests sometimes.
+// as tests bring their own, we never want to stub if cypress is at work.
+if (window.Cypress) {
+  Config.useFixtures = false;
+  Config.useUIConfigFixtures = false;
+}
+
 export default Config;

--- a/src/js/data/ui-update/index.ts
+++ b/src/js/data/ui-update/index.ts
@@ -15,12 +15,6 @@ import {
 import Config from "#SRC/js/config/Config";
 import { parseVersion } from "./utils";
 
-declare global {
-  interface Window {
-    DCOS_UI_VERSION: string;
-  }
-}
-
 type PossibleMutationArgs = Partial<UIUpdateArgs>;
 
 interface QueryContext {

--- a/src/js/utils/crypto/index.ts
+++ b/src/js/utils/crypto/index.ts
@@ -12,8 +12,8 @@ function arrayBufferToBase64(buffer: ArrayBuffer): string {
 }
 
 function getCryptoApi(): SubtleCrypto {
-  const cryptoLib = window.crypto || (window as any).msCrypto;
-  return cryptoLib.subtle || (cryptoLib as any).webkitSubtle;
+  const cryptoLib = window.crypto || window.msCrypto;
+  return cryptoLib.subtle || cryptoLib.webkitSubtle;
 }
 
 function printableBase64(base64: string): string {

--- a/src/typings/dcos-ui.d.ts
+++ b/src/typings/dcos-ui.d.ts
@@ -1,7 +1,6 @@
-declare global {
-  interface Window {
-    DCOS_UI_VERSION: string;
-  }
+interface Window {
+  Cypress?: unknown;
+  DCOS_UI_VERSION: string;
 }
 
 interface Resources {

--- a/src/typings/dcos-ui.d.ts
+++ b/src/typings/dcos-ui.d.ts
@@ -1,6 +1,11 @@
 interface Window {
   Cypress?: unknown;
   DCOS_UI_VERSION: string;
+  msCrypto?: Crypto;
+}
+
+interface Crypto {
+  readonly webkitSubtle?: SubtleCrypto;
 }
 
 interface Resources {


### PR DESCRIPTION
we already stub the plugins-setting of ui-config.json in our tests.
if we load a developers usual fixture here, the followin happens:

* the (ee-)plugins specified in that fixture will be loaded
* those plugins might make requests
* those requests might not be stubbed
* unstubbed requests return a bad status code
* the router points us to #/access-denied
* the test is broken :(

i'm usually not a fan of changing production-code so the tests don't break, but
this change seems to be worth it, as devs don't need to figure out what's going
on when integration-tests fail.

IF WE WANTED TO SOLVE THIS PROPERLY
we would need to change the way cypress and `RequestUtil.stubRequest` interact,
because it currently hides stubbed requests from cypress completely, directly
firing (flux- or redux-)actions.
coming up with an elegant solution will require more holistic changes. maybe
something for a spike day!

## Testing

verify that nothing breaks and that you can run cypress regardless of whether `useFixtures` or `useUIConfigFixtures` are true.

## Trade-offs

we touch production code to make tests run better... 😒 