### PR TITLE
DCOS-57387: Review & Run Service page in edit mode cannot be scrolled

### DIFF
--- a/src/styles/components/modal/full-screen/styles.less
+++ b/src/styles/components/modal/full-screen/styles.less
@@ -31,7 +31,7 @@
       display: flex;
       flex: 1 0 auto;
       flex-direction: column;
-      height: 100%;
+      min-height: 100%;
       overflow: hidden;
     }
 

--- a/src/styles/views/create-service-modal/styles.less
+++ b/src/styles/views/create-service-modal/styles.less
@@ -6,7 +6,7 @@
       align-items: stretch;
       display: flex;
       flex-direction: column;
-      height: 100%;
+      flex-grow: 1;
       justify-content: center;
 
       &-option {


### PR DESCRIPTION
## Testing
1. Create a new service
2. Set up a configuration that will cause the "Review & Run" screen to scroll. [Here's what I used](https://gist.github.com/mperrotti/165dd5cb887992c20afe1954d28fb75f)

Confirm you can scroll the Review & Run screen

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots
![ReviewAndRunScroll](https://user-images.githubusercontent.com/2313998/62556559-21267980-b843-11e9-9a1b-904eabd02d28.gif)

