### PR TITLE
DCOS-49719: feat(servicetable): add view plans action for sdk

### DIFF
--- a/plugins/services/src/js/columns/ServicesTableActionsColumn.tsx
+++ b/plugins/services/src/js/columns/ServicesTableActionsColumn.tsx
@@ -17,6 +17,7 @@ import { ServiceActionItem } from "../constants/ServiceActionItem";
 
 const DELETE = ServiceActionItem.DELETE;
 const EDIT = ServiceActionItem.EDIT;
+const VIEW_PLANS = ServiceActionItem.VIEW_PLANS;
 const MORE = ServiceActionItem.MORE;
 const OPEN = ServiceActionItem.OPEN;
 const RESTART = ServiceActionItem.RESTART;
@@ -51,6 +52,7 @@ function onActionsItemSelection(
 
   if (
     actionItem.id !== EDIT &&
+    actionItem.id !== VIEW_PLANS &&
     actionItem.id !== DELETE &&
     (containsSDKService || isSDKService(service)) &&
     !Hooks.applyFilter(
@@ -133,6 +135,13 @@ export function actionsRendererFactory(
       actions.push({
         id: EDIT,
         html: <Trans render="span" id={ServiceActionLabels.edit} />
+      });
+    }
+
+    if (isSDK) {
+      actions.push({
+        id: VIEW_PLANS,
+        html: <Trans render="span" id={ServiceActionLabels.view_plans} />
       });
     }
 

--- a/plugins/services/src/js/constants/ServiceActionItem.ts
+++ b/plugins/services/src/js/constants/ServiceActionItem.ts
@@ -11,5 +11,6 @@ export enum ServiceActionItem {
   STOP = "stop",
   MORE = "more",
   KILL_POD_INSTANCES = "kill_pod_instances",
-  KILL_TASKS = "kill_tasks"
+  KILL_TASKS = "kill_tasks",
+  VIEW_PLANS = "view_plans"
 }

--- a/plugins/services/src/js/constants/ServiceActionLabels.ts
+++ b/plugins/services/src/js/constants/ServiceActionLabels.ts
@@ -10,6 +10,7 @@ interface ServiceActionLabelsInterface {
   scale_by: string;
   reset_delayed: string;
   stop: string;
+  view_plans: string;
 }
 
 const ServiceActionLabels: ServiceActionLabelsInterface = {
@@ -21,7 +22,8 @@ const ServiceActionLabels: ServiceActionLabelsInterface = {
   scale: i18nMark("Scale"),
   reset_delayed: i18nMark("Reset Delay"),
   scale_by: i18nMark("Scale By"),
-  stop: i18nMark("Stop")
+  stop: i18nMark("Stop"),
+  view_plans: i18nMark("View Plans")
 };
 
 export default ServiceActionLabels;

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -63,6 +63,7 @@ const RESUME = ServiceActionItem.RESUME;
 const SCALE = ServiceActionItem.SCALE;
 const STOP = ServiceActionItem.STOP;
 const RESET_DELAYED = ServiceActionItem.RESET_DELAYED;
+const VIEW_PLANS = ServiceActionItem.VIEW_PLANS;
 
 const METHODS_TO_BIND = [
   "handleServiceAction",
@@ -189,6 +190,11 @@ class ServicesTable extends React.Component {
       case EDIT:
         router.push(
           `/services/detail/${encodeURIComponent(service.getId())}/edit/`
+        );
+        break;
+      case VIEW_PLANS:
+        router.push(
+          `/services/detail/${encodeURIComponent(service.getId())}/plans/`
         );
         break;
       case SCALE:


### PR DESCRIPTION
This adds a view plans action to sdk services action menu.

CLOSES DCOS-49719

## Testing

Run a SDK Service
Visit the Service Table
Check if the action menu of the SDK service is containing "View Plans"
Click the Action the Service Plans table should be shown now.

## Trade-offs

N/A

## Dependencies

N/A

## Screenshots

![image](https://user-images.githubusercontent.com/156010/62562788-0b847480-b882-11e9-8e48-cca65dd94e88.png)

