### PR TITLE
Remove feature flag for Node Maintenance

### DIFF
--- a/plugins/nodes/src/js/actions/NodeMaintenanceActions.ts
+++ b/plugins/nodes/src/js/actions/NodeMaintenanceActions.ts
@@ -5,7 +5,7 @@ import Node from "#SRC/js/structs/Node";
 
 interface MesosDrainAgentOptions {
   max_grace_period?: { seconds: number };
-  mark_gone?: { value: boolean };
+  mark_gone?: boolean;
 }
 
 const NodeMaintenanceActions = {
@@ -71,13 +71,12 @@ const NodeMaintenanceActions = {
     }
 
     if (drainOptions.decommission) {
-      options.mark_gone = { value: true };
+      options.mark_gone = true;
     }
 
     return request({
       type: "DRAIN_AGENT",
-      drain_agent: { agent_id: { value: node.getID() } },
-      ...options
+      drain_agent: { agent_id: { value: node.getID() }, ...options }
     }).subscribe({
       next: onSuccess,
       error: onError

--- a/plugins/nodes/src/js/components/NodesTable.tsx
+++ b/plugins/nodes/src/js/components/NodesTable.tsx
@@ -14,9 +14,6 @@ import Node from "#SRC/js/structs/Node";
 import Loader from "#SRC/js/components/Loader";
 import TableUtil from "#SRC/js/utils/TableUtil";
 import TableColumnResizeStore from "#SRC/js/stores/TableColumnResizeStore";
-import { findNestedPropertyInObject } from "#SRC/js/utils/Util";
-// @ts-ignore
-import ConfigStore from "#SRC/js/stores/ConfigStore";
 
 import { SortDirection } from "../types/SortDirection";
 
@@ -172,11 +169,6 @@ export default class NodesTable extends React.Component<
     if (data === null) {
       return <Loader />;
     }
-
-    const hasMaintenance = findNestedPropertyInObject(
-      ConfigStore.get("config"),
-      "uiConfiguration.features.maintenance"
-    );
 
     const columns = [
       <Column
@@ -368,16 +360,14 @@ export default class NodesTable extends React.Component<
         onResize={this.handleResize("gpu")}
         width={hasCustomWidth("gpu") ? customWidthFor("gpu") : undefined}
       />,
-      hasMaintenance ? (
-        <Column
-          key="actions"
-          header=""
-          cellRenderer={generateActionsRenderer(this.props.onNodeAction)}
-          growToFill={true}
-          minWidth={24}
-          maxWidth={36}
-        />
-      ) : null
+      <Column
+        key="actions"
+        header=""
+        cellRenderer={generateActionsRenderer(this.props.onNodeAction)}
+        growToFill={true}
+        minWidth={24}
+        maxWidth={36}
+      />
     ].filter((col): col is React.ReactElement => col !== null);
 
     return (

--- a/plugins/nodes/src/js/pages/nodes/NodeDetailPage.js
+++ b/plugins/nodes/src/js/pages/nodes/NodeDetailPage.js
@@ -14,9 +14,6 @@ import Page from "#SRC/js/components/Page";
 import TabsMixin from "#SRC/js/mixins/TabsMixin";
 import RouterUtil from "#SRC/js/utils/RouterUtil";
 import { defaultNetworkErrorHandler } from "#SRC/js/utils/DefaultErrorUtil";
-import { findNestedPropertyInObject } from "#SRC/js/utils/Util";
-// @ts-ignore
-import ConfigStore from "#SRC/js/stores/ConfigStore";
 
 import { Status, actionAllowed, StatusAction } from "../../types/Status";
 import DrainNodeModal from "../../components/modals/DrainNodeModal";
@@ -142,15 +139,6 @@ class NodeDetailPage extends mixin(TabsMixin, StoreMixin) {
   }
 
   getActions() {
-    const hasMaintenance = findNestedPropertyInObject(
-      ConfigStore.get("config"),
-      "uiConfiguration.features.maintenance"
-    );
-
-    if (!hasMaintenance) {
-      return [];
-    }
-
     const actions = [];
     const { node } = this.props;
     const status = Status.fromNode(node);

--- a/tests/_fixtures/config/no-plugins.json
+++ b/tests/_fixtures/config/no-plugins.json
@@ -1,7 +1,6 @@
 {
   "uiConfiguration": {
     "features": {
-      "maintenance": true,
       "quota": true
     },
     "plugins": {}


### PR DESCRIPTION
## Testing

- Node maintenance actions and node status column should work without the feature flag present
- Fixed: Decommissioning a node when draining it should remove the node from the list and actually decommission it.

