### PR TITLE
DCOS-57466 fix(quota): support pods in quota limit

### DIFF
--- a/plugins/services/src/js/structs/Pod.js
+++ b/plugins/services/src/js/structs/Pod.js
@@ -248,4 +248,15 @@ module.exports = class Pod extends Service {
     const queue = this.getQueue();
     return findNestedPropertyInObject(queue, "delay.overdue") === false;
   }
+
+  /**
+   * @override
+   */
+  getRole() {
+    const spec = this.getSpec();
+    if (spec) {
+      return spec.role || "";
+    }
+    return "";
+  }
 };


### PR DESCRIPTION
Added a getRole override on Pod struct to support returning the role
value from a Pod using the Pod.spec instead of looking for the role at
the root of the Pod object like it is on the Service object.

- Closes DCOS-57466

## Testing

See JIRA for steps to reproduce.

- Create Group with Quota & use group roles
- Create pod inside group
- Ensure Pod is not seen as "no limit" (no badges or banners displayed with pod is running in group with quota)


## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
