### PR TITLE
chore: dont use volumeList for volumesData

### DIFF
--- a/plugins/services/src/js/components/PodVolumeTable.js
+++ b/plugins/services/src/js/components/PodVolumeTable.js
@@ -185,7 +185,7 @@ class PodVolumeTable extends React.Component {
         className="table table-flush table-borderless-outer table-borderless-inner-columns table-hover flush-bottom"
         columns={this.getColumns()}
         colGroup={this.getColGroup()}
-        data={this.getData(this.props.service.getVolumesData().getItems())}
+        data={this.getData(this.props.service.getVolumesData())}
         sortBy={{ prop: "id", order: "asc" }}
       />
     );

--- a/plugins/services/src/js/containers/pod-detail/PodDetail.js
+++ b/plugins/services/src/js/containers/pod-detail/PodDetail.js
@@ -199,9 +199,7 @@ class PodDetail extends mixin(TabsMixin) {
   }
 
   hasVolumes() {
-    return (
-      !!this.props.pod && this.props.pod.getVolumesData().getItems().length > 0
-    );
+    return !!this.props.pod && this.props.pod.getVolumesData().length > 0;
   }
 
   getTabs() {

--- a/plugins/services/src/js/containers/volume-detail/PodVolumeContainer.js
+++ b/plugins/services/src/js/containers/volume-detail/PodVolumeContainer.js
@@ -68,9 +68,9 @@ class PodVolumeContainer extends React.Component {
       );
     }
 
-    const volume = service.getVolumesData().findItem(volume => {
-      return volume.getId() === volumeId;
-    });
+    const volume = service
+      .getVolumesData()
+      .find(volume => volume.getId() === volumeId);
 
     if (!volume) {
       return (

--- a/plugins/services/src/js/structs/Pod.js
+++ b/plugins/services/src/js/structs/Pod.js
@@ -9,7 +9,6 @@ import PodUtil from "../utils/PodUtil";
 import Service from "./Service";
 import * as ServiceStatus from "../constants/ServiceStatus";
 import ServiceImages from "../constants/ServiceImages";
-import VolumeList from "./VolumeList";
 
 module.exports = class Pod extends Service {
   constructor() {
@@ -219,7 +218,7 @@ module.exports = class Pod extends Service {
   }
 
   getVolumesData() {
-    return new VolumeList({ items: this.get("volumeData") || [] });
+    return this.get("volumeData") || [];
   }
 
   /**


### PR DESCRIPTION
random find while reviewing another commit. should be good to merge once CI is green.

we wrap the data in an volumelist only to unpack it or `find` an element.

looks like a good place to reduce some complexity.