### PR TITLE
remove VolumeList

### DIFF
--- a/plugins/services/src/js/components/PodVolumeTable.js
+++ b/plugins/services/src/js/components/PodVolumeTable.js
@@ -185,7 +185,7 @@ class PodVolumeTable extends React.Component {
         className="table table-flush table-borderless-outer table-borderless-inner-columns table-hover flush-bottom"
         columns={this.getColumns()}
         colGroup={this.getColGroup()}
-        data={this.getData(this.props.service.getVolumesData().getItems())}
+        data={this.getData(this.props.service.getVolumesData())}
         sortBy={{ prop: "id", order: "asc" }}
       />
     );

--- a/plugins/services/src/js/components/VolumeTable.js
+++ b/plugins/services/src/js/components/VolumeTable.js
@@ -169,7 +169,7 @@ class VolumeTable extends React.Component {
         className="table table-flush table-borderless-outer table-borderless-inner-columns table-hover flush-bottom"
         columns={this.getColumns()}
         colGroup={this.getColGroup()}
-        data={this.getData(this.props.service.getVolumes().getItems())}
+        data={this.getData(this.props.service.getVolumes())}
         sortBy={{ prop: "id", order: "asc" }}
       />
     );

--- a/plugins/services/src/js/containers/pod-detail/PodDetail.js
+++ b/plugins/services/src/js/containers/pod-detail/PodDetail.js
@@ -199,9 +199,7 @@ class PodDetail extends mixin(TabsMixin) {
   }
 
   hasVolumes() {
-    return (
-      !!this.props.pod && this.props.pod.getVolumesData().getItems().length > 0
-    );
+    return !!this.props.pod && this.props.pod.getVolumesData().length > 0;
   }
 
   getTabs() {

--- a/plugins/services/src/js/containers/service-detail/ServiceDetail.js
+++ b/plugins/services/src/js/containers/service-detail/ServiceDetail.js
@@ -153,10 +153,7 @@ class ServiceDetail extends mixin(TabsMixin) {
   }
 
   hasVolumes() {
-    return (
-      !!this.props.service &&
-      this.props.service.getVolumes().getItems().length > 0
-    );
+    return !!this.props.service && this.props.service.getVolumes().length > 0;
   }
 
   checkForVolumes() {
@@ -289,7 +286,7 @@ class ServiceDetail extends mixin(TabsMixin) {
       errors: MarathonErrorUtil.parseErrors(errors[ActionKeys.SERVICE_EDIT]),
       onClearError: this.handleEditClearError,
       onEditClick: actions.editService,
-      volumes: service.getVolumes().getItems()
+      volumes: service.getVolumes()
     };
 
     // TODO (DCOS_OSS-1038): Move cloned props to route parameters

--- a/plugins/services/src/js/containers/volume-detail/PodVolumeContainer.js
+++ b/plugins/services/src/js/containers/volume-detail/PodVolumeContainer.js
@@ -68,9 +68,9 @@ class PodVolumeContainer extends React.Component {
       );
     }
 
-    const volume = service.getVolumesData().findItem(volume => {
-      return volume.getId() === volumeId;
-    });
+    const volume = service
+      .getVolumesData()
+      .find(volume => volume.getId() === volumeId);
 
     if (!volume) {
       return (

--- a/plugins/services/src/js/containers/volume-detail/ServiceVolumeContainer.js
+++ b/plugins/services/src/js/containers/volume-detail/ServiceVolumeContainer.js
@@ -68,9 +68,9 @@ class ServiceVolumeContainer extends React.Component {
       );
     }
 
-    const volume = service.getVolumes().findItem(volume => {
-      return volume.getId() === volumeId;
-    });
+    const volume = service
+      .getVolumes()
+      .find(volume => volume.getId() === volumeId);
 
     if (!volume) {
       return (

--- a/plugins/services/src/js/containers/volume-detail/TaskVolumeContainer.js
+++ b/plugins/services/src/js/containers/volume-detail/TaskVolumeContainer.js
@@ -69,9 +69,9 @@ class TaskVolumeContainer extends React.Component {
       );
     }
 
-    const volume = service.getVolumes().findItem(volume => {
-      return volume.getId() === volumeId;
-    });
+    const volume = service
+      .getVolumes()
+      .find(volume => volume.getId() === volumeId);
 
     if (!volume) {
       return (

--- a/plugins/services/src/js/filters/ServiceAttributeHasVolumesFilter.js
+++ b/plugins/services/src/js/filters/ServiceAttributeHasVolumesFilter.js
@@ -30,7 +30,7 @@ class ServiceAttributeHasVolumesFilter extends DSLFilter {
     return resultset.filterItems(service => {
       const volumes = service.getVolumes();
 
-      return volumes.list && volumes.list.length > 0;
+      return volumes && volumes.length > 0;
     });
   }
 }

--- a/plugins/services/src/js/filters/__tests__/ServiceAttributeHasVolumesFilter-test.js
+++ b/plugins/services/src/js/filters/__tests__/ServiceAttributeHasVolumesFilter-test.js
@@ -1,7 +1,6 @@
 var List = require("#SRC/js/structs/List");
 var SearchDSL = require("#SRC/resources/grammar/SearchDSL");
 var ServiceAttributeHasVolumesFilter = require("../ServiceAttributeHasVolumesFilter");
-var VolumeList = require("../../structs/VolumeList");
 
 let thisMockItems;
 
@@ -10,17 +9,17 @@ describe("ServiceAttributeHasVolumesFilter", function() {
     thisMockItems = [
       {
         getVolumes() {
-          return new VolumeList({ items: [] });
+          return [];
         }
       },
       {
         getVolumes() {
-          return new VolumeList({ items: ["foo"] });
+          return ["foo"];
         }
       },
       {
         getVolumes() {
-          return new VolumeList({ items: ["foo", "bar"] });
+          return ["foo", "bar"];
         }
       }
     ];

--- a/plugins/services/src/js/structs/Application.js
+++ b/plugins/services/src/js/structs/Application.js
@@ -7,7 +7,6 @@ import HealthStatus from "../constants/HealthStatus";
 import Service from "./Service";
 import * as ServiceStatus from "../constants/ServiceStatus";
 import TaskStats from "./TaskStats";
-import VolumeList from "./VolumeList";
 
 module.exports = class Application extends Service {
   constructor() {
@@ -218,7 +217,7 @@ module.exports = class Application extends Service {
    * @override
    */
   getVolumes() {
-    return new VolumeList({ items: this.get("volumes") || [] });
+    return this.get("volumes") || [];
   }
 
   findTaskById(taskId) {

--- a/plugins/services/src/js/structs/Pod.js
+++ b/plugins/services/src/js/structs/Pod.js
@@ -9,7 +9,6 @@ import PodUtil from "../utils/PodUtil";
 import Service from "./Service";
 import * as ServiceStatus from "../constants/ServiceStatus";
 import ServiceImages from "../constants/ServiceImages";
-import VolumeList from "./VolumeList";
 
 module.exports = class Pod extends Service {
   constructor() {
@@ -219,7 +218,7 @@ module.exports = class Pod extends Service {
   }
 
   getVolumesData() {
-    return new VolumeList({ items: this.get("volumeData") || [] });
+    return this.get("volumeData") || [];
   }
 
   /**

--- a/plugins/services/src/js/structs/Service.js
+++ b/plugins/services/src/js/structs/Service.js
@@ -6,7 +6,6 @@ import HealthStatus from "../constants/HealthStatus";
 import ServiceImages from "../constants/ServiceImages";
 import * as ServiceStatus from "../constants/ServiceStatus";
 import ServiceSpec from "./ServiceSpec";
-import VolumeList from "./VolumeList";
 
 module.exports = class Service extends Item {
   constructor() {
@@ -43,7 +42,7 @@ module.exports = class Service extends Item {
   }
 
   getVolumes() {
-    return new VolumeList({ items: [] });
+    return [];
   }
 
   getStatus() {

--- a/plugins/services/src/js/structs/ServiceTree.js
+++ b/plugins/services/src/js/structs/ServiceTree.js
@@ -10,7 +10,6 @@ import Service from "./Service";
 import * as ServiceStatus from "../constants/ServiceStatus";
 import ServiceUtil from "../utils/ServiceUtil";
 import ServiceValidatorUtil from "../utils/ServiceValidatorUtil";
-import VolumeList from "../structs/VolumeList";
 
 module.exports = class ServiceTree extends Tree {
   /**
@@ -336,18 +335,17 @@ module.exports = class ServiceTree extends Tree {
   }
 
   getVolumes() {
-    const items = this.reduceItems(function(serviceTreeVolumes, item) {
-      if (item instanceof Service) {
-        const itemVolumes = item.getVolumes().getItems();
-        if (itemVolumes && itemVolumes.length) {
-          serviceTreeVolumes.push(itemVolumes);
-        }
+    return this.reduceItems(function(serviceTreeVolumes, item) {
+      if (!(item instanceof Service)) {
+        return serviceTreeVolumes;
+      }
+      const itemVolumes = item.getVolumes();
+      if (itemVolumes && itemVolumes.length) {
+        serviceTreeVolumes.push(itemVolumes);
       }
 
       return serviceTreeVolumes;
     }, []);
-
-    return new VolumeList({ items });
   }
 
   getLabels() {

--- a/plugins/services/src/js/structs/VolumeList.js
+++ b/plugins/services/src/js/structs/VolumeList.js
@@ -1,7 +1,0 @@
-import List from "#SRC/js/structs/List";
-import Volume from "./Volume";
-
-class VolumeList extends List {}
-VolumeList.type = Volume;
-
-module.exports = VolumeList;

--- a/plugins/services/src/js/structs/__tests__/Application-test.js
+++ b/plugins/services/src/js/structs/__tests__/Application-test.js
@@ -4,7 +4,6 @@ const Application = require("../Application");
 const HealthStatus = require("../../constants/HealthStatus");
 const ServiceImages = require("../../constants/ServiceImages");
 const TaskStats = require("../TaskStats");
-const VolumeList = require("../VolumeList");
 
 describe("Application", function() {
   describe("#getDeployments", function() {
@@ -489,28 +488,10 @@ describe("Application", function() {
   });
 
   describe("#getVolumes", function() {
-    it("returns volume list", function() {
-      const service = new Application({
-        volumes: [
-          {
-            containerPath: "path",
-            host: "0.0.0.1",
-            id: "volume-id",
-            mode: "RW",
-            size: 2048,
-            status: "Attached",
-            type: "Persistent"
-          }
-        ]
-      });
-
-      expect(service.getVolumes() instanceof VolumeList).toBeTruthy();
-    });
-
-    it("returns empty volume list if volumes data is undefined", function() {
+    it("returns empty list if volumes data is undefined", function() {
       const service = new Application({});
 
-      expect(service.getVolumes().getItems().length).toEqual(0);
+      expect(service.getVolumes().length).toEqual(0);
     });
   });
 

--- a/plugins/services/src/js/structs/__tests__/ServiceTree-test.js
+++ b/plugins/services/src/js/structs/__tests__/ServiceTree-test.js
@@ -4,7 +4,6 @@ const Application = require("../Application");
 const Framework = require("../Framework");
 const HealthStatus = require("../../constants/HealthStatus");
 const ServiceTree = require("../ServiceTree");
-const VolumeList = require("../../structs/VolumeList");
 
 let thisInstance;
 
@@ -1042,7 +1041,7 @@ describe("ServiceTree", function() {
       thisInstance = new ServiceTree();
     });
 
-    it("returns a VolumeList with all the volumes in the group", function() {
+    it("returns a List with all the volumes in the group", function() {
       thisInstance.add(
         new Application({
           id: "/persistent",
@@ -1070,8 +1069,7 @@ describe("ServiceTree", function() {
       );
 
       const volumeList = thisInstance.getVolumes();
-      expect(volumeList).toEqual(jasmine.any(VolumeList));
-      expect(volumeList.getItems().length).toEqual(2);
+      expect(volumeList.length).toEqual(2);
     });
   });
 


### PR DESCRIPTION
stumbled upon an abstraction that does not bring value (anymore), so this is a try to remove that.

we only ever used `getItems()` (which gives us the plain data) and `findItem`, which is implemented via the following code, so we can use `find` directly.

```typescript
  findItem(callback) {
    return this.getItems().find(callback);
  }
```

# Tradeoffs

we lose the ability to alter the behaviour of **most** `VolumeList`s at a central place, but it does not look like we need that currently. note that some places already use the `volumeList`-property directly, so we actually did not have properly working "central place".