### PR TITLE
DCOS-57482: Quota - Remove "no limit" badges & banner from ServicesTable

### DIFF
--- a/plugins/services/src/js/columns/ServicesTableNameColumn.tsx
+++ b/plugins/services/src/js/columns/ServicesTableNameColumn.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
-import { TextCell, Icon, Badge } from "@dcos/ui-kit";
+import { TextCell, Icon } from "@dcos/ui-kit";
 import { Link } from "react-router";
-import { Trans } from "@lingui/macro";
 
 import { SystemIcons } from "@dcos/ui-kit/dist/packages/icons/dist/system-icons-enum";
 import {
@@ -20,19 +19,15 @@ import { columnWidthsStorageKey } from "../containers/services/ServicesTable";
 const ServiceName = React.memo(
   ({
     isFiltered,
-    hasQuota,
     id,
     isGroup,
-    isNoLimit,
     name,
     image,
     webUrl
   }: {
     isFiltered: boolean;
-    hasQuota: boolean;
     id: string;
     isGroup: boolean;
-    isNoLimit: boolean;
     name: string;
     image: string | null;
     webUrl: string | null;
@@ -40,15 +35,6 @@ const ServiceName = React.memo(
     const serviceLink = isGroup
       ? `/services/overview/${id}`
       : `/services/detail/${id}`;
-
-    const badge =
-      hasQuota && isNoLimit ? (
-        <Badge>
-          <Trans render="span" className="quota-no-limit">
-            No Limit
-          </Trans>
-        </Badge>
-      ) : null;
 
     return (
       <TextCell>
@@ -63,7 +49,6 @@ const ServiceName = React.memo(
             {getServiceLink(id, name, isGroup, isFiltered)}
             {getOpenInNewWindowLink(webUrl)}
           </span>
-          {badge}
         </div>
       </TextCell>
     );
@@ -72,7 +57,6 @@ const ServiceName = React.memo(
 
 export function nameRenderer(
   isFiltered: boolean,
-  hasQuota: boolean,
   service: Service | Pod | ServiceTree
 ): React.ReactNode {
   // These do not work with instanceof ServiceTree due to TS
@@ -85,27 +69,14 @@ export function nameRenderer(
       ? service.getWebURL()
       : null;
 
-  const IDArray = service.getId().split("/");
-  // If the service is in a top-level group,
-  // IDArray would look like ["","group-name","service-name"]
-
-  const isNoLimit =
-    service instanceof Pod || service instanceof Service
-      ? IDArray.length > 2 &&
-        service.getRole() !== IDArray[1] &&
-        service.getName() === IDArray[2]
-      : false;
-
   return (
     <ServiceName
       id={encodeURIComponent(service.getId().toString())}
       isGroup={service instanceof ServiceTree}
-      isNoLimit={isNoLimit}
       name={service.getName()}
       image={image}
       webUrl={webUrl}
       isFiltered={isFiltered}
-      hasQuota={hasQuota}
     />
   );
 }

--- a/plugins/services/src/js/containers/services/ServiceTreeView.js
+++ b/plugins/services/src/js/containers/services/ServiceTreeView.js
@@ -3,10 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 import { routerShape } from "react-router";
 import { i18nMark } from "@lingui/react";
-import { Trans, Plural } from "@lingui/macro";
-import { InfoBoxInline, Icon, SpacingBox } from "@dcos/ui-kit";
-import { SystemIcons } from "@dcos/ui-kit/dist/packages/icons/dist/system-icons-enum";
-import { iconSizeXs } from "@dcos/ui-kit/dist/packages/design-tokens/build/js/designTokens";
+import { Trans } from "@lingui/macro";
 
 import DSLExpression from "#SRC/js/structs/DSLExpression";
 import DSLFilterField from "#SRC/js/components/DSLFilterField";
@@ -52,43 +49,6 @@ class ServiceTreeView extends React.Component {
           />
         </div>
       </div>
-    );
-  }
-
-  getNoLimitInfobox(hasQuota) {
-    if (!hasQuota) {
-      return null;
-    }
-    const { serviceTree } = this.props;
-
-    const { servicesCount, groupRolesCount } = serviceTree.getRoleLength();
-    const nonLimited = servicesCount - groupRolesCount;
-
-    if (!nonLimited) {
-      return null;
-    }
-
-    return (
-      <SpacingBox side="bottom" spacingSize="l">
-        <InfoBoxInline
-          appearance="default"
-          message={
-            <React.Fragment>
-              <Icon
-                shape={SystemIcons.CircleInformation}
-                size={iconSizeXs}
-                color="currentColor"
-              />
-              <Plural
-                render={<span id="quota-no-limit-infobox" />}
-                value={nonLimited}
-                one={`# service is not limited by quota. Update role to have quota enforced.`}
-                other={`# services are not limited by quota. Update role to have quota enforced.`}
-              />
-            </React.Fragment>
-          }
-        />
-      </SpacingBox>
     );
   }
 
@@ -226,10 +186,8 @@ class ServiceTreeView extends React.Component {
         <div className="flex-item-grow-1 flex flex-direction-top-to-bottom">
           {this.getFilterBar()}
           {this.getSearchHeader()}
-          {this.getNoLimitInfobox(hasQuota)}
           <ServicesTable
             isFiltered={filterExpression.defined}
-            hasQuota={hasQuota}
             modalHandlers={modalHandlers}
             services={services}
             hideTable={this.context.router.routes.some(

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -301,7 +301,6 @@ class ServicesTable extends React.Component {
             cellRenderer={nameRenderer.bind(
               null,
               this.props.isFiltered,
-              this.props.hasQuota,
               ...arguments
             )}
             growToFill={
@@ -637,7 +636,6 @@ ServicesTable.defaultProps = {
 
 ServicesTable.propTypes = {
   isFiltered: PropTypes.bool,
-  hasQuota: PropTypes.bool,
   services: PropTypes.array
 };
 

--- a/tests/pages/services/ServiceTable-cy.js
+++ b/tests/pages/services/ServiceTable-cy.js
@@ -546,28 +546,4 @@ describe("Service Table", function() {
       cy.get(".tooltip").contains("1 Stopped");
     });
   });
-
-  context("Quota groups", function() {
-    beforeEach(function() {
-      cy.configureCluster({
-        mesos: "1-task-healthy-with-quota",
-        nodeHealth: true
-      });
-      cy.visitUrl({ url: "/services/overview" });
-    });
-
-    it("Shows no limit banner and badge if services have no quota enforced", function() {
-      cy.get(".table-cell-link-primary")
-        .contains("2_apps")
-        .click();
-      cy.get("#quota-no-limit-infobox")
-        .contains(
-          "1 service is not limited by quota. Update role to have quota enforced."
-        )
-        .should("exist");
-      cy.get(".quota-no-limit")
-        .contains("No Limit")
-        .should("exist");
-    });
-  });
 });


### PR DESCRIPTION
Remove from ServiceTreeView the infobox and the
badge that inform the user that a service is not enforced.

Closes https://jira.mesosphere.com/browse/DCOS-57482

## Testing
1. Go to services tab.
2. Create a group with at least one quota field, but with a legacy role (expand the advanced settings to change the role).
3. Run a service inside this group.
4. Verify that no infobox and badge are shown.
5. Switch branch to master and verify that they are shown there.

## Trade-offs
None.

## Dependencies
https://github.com/dcos/dcos-ui/pull/4034

## Screenshots
### Before
![Screenshot from 2019-08-12 13-30-37](https://user-images.githubusercontent.com/40791275/62861118-179d8580-bd0b-11e9-9832-8bb24ed68526.png)

### After
![Screenshot from 2019-08-12 14-03-57](https://user-images.githubusercontent.com/40791275/62861124-1b310c80-bd0b-11e9-9287-bec5bebf4654.png)

