### PR TITLE
add an lingui-things-extracted-check

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,6 +68,10 @@ pipeline {
 
     stage("Build") {
       steps {
+        // check that all translatable elements have been extracted
+        sh "npm run util:lingui:extract"
+        sh "git diff-index --quiet HEAD || echo 'found elements that have not been extracted. please run `npm run util:lingui:extract` and commit the changes'"
+
         sh "npm run build"
       }
     }

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -932,6 +932,7 @@
   "Version": "",
   "View Cluster Configuration": "",
   "View Documentation": "",
+  "View Plans": "",
   "View Services": "",
   "View all {componentCount} {componentCountWord}": "",
   "View all {servicesCount} Services": "",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -932,6 +932,7 @@
   "Version": "版本",
   "View Cluster Configuration": "查看集群配置",
   "View Documentation": "查看文档",
+  "View Plans": "",
   "View Services": "查看服务",
   "View all {componentCount} {componentCountWord}": "查看全部 {componentCount} {componentCountWord}",
   "View all {servicesCount} Services": "查看全部 {servicesCount} 服务",


### PR DESCRIPTION
we frequently have non-extracted things on master. let's add a CI-check!

N.B. i also feel that `npm build` and the jenkins-build-stage have totally weird semantics but let's clean that up some other time!

# testing

see that red cross right below this box? (it's not here anymore. it's still in [jenkins](https://jenkins.mesosphere.com/service/jenkins/blue/organizations/jenkins/frontend%2Fdcos-ui-oss-pipeline/detail/PR-4053/1/pipeline/)... 🤦‍♂) that's the run that failed because of translatables not being extracted 🎉 	(i improved the error message as a fixup)

so it's red when there are strings to extract. afterwards i added a commit adding the most recent extractions - if CI is now green that would mean that the check does not fail and stuff works as expected. :shipit:!