### PR TITLE
remove dead code

### DIFF
--- a/src/js/structs/UniversePackage.js
+++ b/src/js/structs/UniversePackage.js
@@ -4,30 +4,8 @@ import Util from "../utils/Util";
 import StringUtil from "../utils/StringUtil";
 
 class UniversePackage extends Item {
-  getActiveBlock() {
-    return Math.floor(Math.random() * 10) + 1;
-  }
-
-  getActiveDecisionPoint() {
-    return this.getActiveBlock();
-  }
-
   getAppId() {
     return this.get("appId");
-  }
-
-  getAppIdName() {
-    let appId = this.getAppId();
-    // Remove initial slash if present
-    if (appId.charAt(0) === "/") {
-      appId = appId.slice(1);
-    }
-
-    return appId;
-  }
-
-  getBlockCount() {
-    return this.getActiveBlock() + 10;
   }
 
   getConfig() {
@@ -36,10 +14,6 @@ class UniversePackage extends Item {
 
   getDescription() {
     return this.get("description");
-  }
-
-  getDecisionPointCount() {
-    return this.getActiveBlock() + 10;
   }
 
   getIcons() {


### PR DESCRIPTION
while having a look at some universe-related things i noticed that packages
bring postInstallNotes. curious where we use them i noticed that we don't.

so `getPostInstallNotes` is removed here. afterwards i grepped for every method
in this struct and found a couple more dead ends that are removed as well.

Despite ongoing discussion this PR is ready to be :eyes: and 🚢.

## Testing

grep for those methods (in OSS and EE). try smoke testing some places that could potentially make use of those methods. (i also tried grepping for parts of those methods in case they are created dynamically, e.g. `"get" + preOrPost + "InstallNotes"` - could not find anything).