### PR TITLE
DCOS-57522: Creating a service inside quota group does not create it in the group

### DIFF
--- a/plugins/services/src/js/containers/services/ServicesQuotaView.tsx
+++ b/plugins/services/src/js/containers/services/ServicesQuotaView.tsx
@@ -55,13 +55,18 @@ class ServicesQuotaView extends React.Component<ServicesQuotaViewProps, {}> {
   render() {
     const { children, serviceTree } = this.props;
     const { modalHandlers } = this.context;
-    const createService = () => {
-      this.context.router.push("/services/overview/create");
-    };
     const tabs = this.getTabs();
     const id: string = serviceTree.getId();
     const isRoot = serviceTree.isRoot();
-
+    const createService = () => {
+      isRoot
+        ? this.context.router.push("/services/overview/create")
+        : this.context.router.push(
+            "/services/overview/" +
+              encodeURIComponent(serviceTree.getId()) +
+              "/create"
+          );
+    };
     const content = isRoot ? (
       <ServicesQuotaOverview />
     ) : (


### PR DESCRIPTION
Add group id when creating a service from
the quota tab.

Closes https://jira.mesosphere.com/browse/DCOS-57522

## Testing
1. Go to services tab.
2. Create a group with at least one quota limit (CPU, memory, etc.) set.
3. Open the quota detail page for that group.
4. Use the + button in the top right corner to open the dropdown and open the create service modal.
5. Open the single container service modal.
6. Verify that the group name is shown in the id.
7. Verify the same for pods.

## Trade-offs
None.

## Dependencies
None.

## Screenshots
### Before
![Peek 2019-08-13 14-53](https://user-images.githubusercontent.com/40791275/62939494-1d15d100-bdda-11e9-9c0b-56489f8cc08f.gif)

### After
![Peek 2019-08-13 14-52](https://user-images.githubusercontent.com/40791275/62939502-2010c180-bdda-11e9-87dd-989a32aadfba.gif)

