### PR TITLE
    DCOS-21165  Assign Automatically Host port checkbox is not in line for multi container apps

### DIFF
--- a/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
@@ -157,7 +157,10 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
         />
         <FieldError>{hostPortError}</FieldError>
       </FormGroup>,
-      <FormGroup className="column-auto flush-left" key="assign-automatically">
+      <FormGroup
+        className="column-auto flush-left flex flex-direction-top-to-bottom flex-justify-items-end"
+        key="assign-automatically"
+      >
         <FieldLabel />
         <FieldLabel matchInputHeight={true}>
           <FieldInput


### PR DESCRIPTION
Align "Auto Assigned" checkbox in the Networking tab for pods.

Closes https://jira.mesosphere.com/browse/DCOS-21165

## Testing
1. Go to services tab.
2. Open the create service modal.
3. Select Pod.
4. Go to the networking tab.
5. Click "Add Service Endpoint".
6. Verify that the "Assign Automatically checkbox is aligned with the other checkboxes.
7. Verify that it's still aligned after zooming in and out and using different browsers (I tested it in Chrome and Firefox).

## Trade-offs
~There might be better solutions using css magic, but I think this is good enough.~

## Dependencies
None.

## Screenshots
### Before
![Снимка от 2019-08-13 16-51-08](https://user-images.githubusercontent.com/40791275/62947081-91f10700-bdea-11e9-864c-001947a21c8b.png)

### After
![Снимка от 2019-08-13 16-39-42](https://user-images.githubusercontent.com/40791275/62947092-961d2480-bdea-11e9-84e4-0c84418e5d7e.png)
