### PR TITLE
Rename React methods

### DIFF
--- a/packages/foundation-ui/src/mount/Mount.js
+++ b/packages/foundation-ui/src/mount/Mount.js
@@ -35,11 +35,11 @@ class Mount extends React.Component {
     });
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     MountService.addListener(CHANGE, this.onMountServiceChange);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { type } = nextProps;
 
     if (this.props.type === type) {

--- a/plugins/jobs/src/js/components/JobsFormModal.tsx
+++ b/plugins/jobs/src/js/components/JobsFormModal.tsx
@@ -113,7 +113,7 @@ class JobFormModal extends React.Component<
     this.validateSpec = this.validateSpec.bind(this);
   }
 
-  componentWillReceiveProps(nextProps: JobFormModalProps) {
+  UNSAFE_componentWillReceiveProps(nextProps: JobFormModalProps) {
     if (!isEqual(nextProps.job, this.props.job)) {
       const jobSpec = nextProps.job
         ? this.getJobSpecFromResponse(nextProps.job)

--- a/plugins/nodes/src/js/components/NodesTable.tsx
+++ b/plugins/nodes/src/js/components/NodesTable.tsx
@@ -156,7 +156,7 @@ export default class NodesTable extends React.Component<
     return !isEqual(this.props, nextProps) || !isEqual(this.state, nextState);
   }
 
-  componentWillReceiveProps(nextProps: NodesTableProps): void {
+  UNSAFE_componentWillReceiveProps(nextProps: NodesTableProps): void {
     this.setState({
       data: nextProps.hosts ? this.sortData(nextProps.hosts.getItems()) : null
     });

--- a/plugins/nodes/src/js/pages/NodesAgents.js
+++ b/plugins/nodes/src/js/pages/NodesAgents.js
@@ -82,7 +82,7 @@ var NodesAgents = createReactClass({
     return { selectedResource: "cpus", ...DEFAULT_FILTER_OPTIONS };
   },
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.mesosHosts = getMesosHosts(this.state);
 
     this.store_listeners = [

--- a/plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.js
+++ b/plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.js
@@ -59,11 +59,11 @@ class HostsPageContent extends React.PureComponent {
     });
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.propsToState(this.props);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.propsToState(nextProps);
   }
 

--- a/plugins/nodes/src/js/pages/nodes/NodeDetailPage.js
+++ b/plugins/nodes/src/js/pages/nodes/NodeDetailPage.js
@@ -52,7 +52,7 @@ class NodeDetailPage extends mixin(TabsMixin, StoreMixin) {
     this.handleCloseModal = this.handleCloseModal.bind(this);
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     super.componentWillMount(...arguments);
 
     const { node } = this.props;
@@ -79,7 +79,7 @@ class NodeDetailPage extends mixin(TabsMixin, StoreMixin) {
     this.updateCurrentTab();
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.updateCurrentTab(nextProps);
   }
 

--- a/plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.js
+++ b/plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.js
@@ -47,7 +47,7 @@ class NodesGridContainer extends mixin(StoreMixin) {
     });
   }
 
-  componentWillReceiveProps(props) {
+  UNSAFE_componentWillReceiveProps(props) {
     const {
       services,
       location: { query },

--- a/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
+++ b/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
@@ -44,7 +44,7 @@ class NodesTableContainer extends mixin(StoreMixin) {
     this.handleCloseModal = this.handleCloseModal.bind(this);
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.onStateStoreSuccess();
     const { location, hosts, networks } = this.props;
 
@@ -57,7 +57,7 @@ class NodesTableContainer extends mixin(StoreMixin) {
     this.setFilters(hosts, networks, filters);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { location, hosts, networks } = nextProps;
     const filters = {
       health: location.query.filterHealth || "all",

--- a/plugins/oauth/components/LoginPage.js
+++ b/plugins/oauth/components/LoginPage.js
@@ -13,7 +13,7 @@ const SDK = require("../SDK").getSDK();
 const METHODS_TO_BIND = ["handleModalClose", "onMessageReceived"];
 
 class LoginPage extends mixin(StoreMixin) {
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     super.componentWillMount();
 
     if (AuthStore.getUser()) {

--- a/plugins/services/src/js/components/DeploymentStatusIndicator.js
+++ b/plugins/services/src/js/components/DeploymentStatusIndicator.js
@@ -39,7 +39,7 @@ class DeploymentStatusIndicator extends mixin(StoreMixin) {
     });
   }
 
-  componentWillReceiveProps() {
+  UNSAFE_componentWillReceiveProps() {
     const deployments = DCOSStore.deploymentsList.getItems();
 
     if (this.state.isOpen && deployments.length === 0) {

--- a/plugins/services/src/js/components/LogView.js
+++ b/plugins/services/src/js/components/LogView.js
@@ -60,7 +60,7 @@ class LogView extends React.Component {
     this.handleUpdateScrollPosition();
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.handleUpdateScrollPosition(nextProps);
   }
 

--- a/plugins/services/src/js/components/MesosLogContainer.js
+++ b/plugins/services/src/js/components/MesosLogContainer.js
@@ -57,7 +57,7 @@ class MesosLogContainer extends mixin(StoreMixin) {
     MesosLogStore.startTailing(task.slave_id, filePath);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     super.componentWillReceiveProps(...arguments);
     const { props } = this;
     if (props.filePath === nextProps.filePath) {

--- a/plugins/services/src/js/components/SearchLog.js
+++ b/plugins/services/src/js/components/SearchLog.js
@@ -30,7 +30,7 @@ class SearchLog extends React.PureComponent {
     });
   }
 
-  componentWillReceiveProps(nextProps, nextState) {
+  UNSAFE_componentWillReceiveProps(nextProps, nextState) {
     const nextSearchString = nextState.searchString;
     const nextTotalFound = nextState.totalFound;
     const updatedState = {};

--- a/plugins/services/src/js/components/ServicesQuotaOverviewTable.tsx
+++ b/plugins/services/src/js/components/ServicesQuotaOverviewTable.tsx
@@ -76,7 +76,7 @@ class ServicesQuotaOverviewTable extends React.Component<
     };
   }
 
-  componentWillReceiveProps(nextProps: ServicesQuotaOverviewTableProps) {
+  UNSAFE_componentWillReceiveProps(nextProps: ServicesQuotaOverviewTableProps) {
     this.setState({ groups: this.sortData(nextProps.groups || []) });
   }
 

--- a/plugins/services/src/js/components/__tests__/MesosLogContainer-test.js
+++ b/plugins/services/src/js/components/__tests__/MesosLogContainer-test.js
@@ -59,9 +59,9 @@ describe("MesosLogContainer", function() {
     });
   });
 
-  describe("#componentWillReceiveProps", function() {
+  describe("#UNSAFE_componentWillReceiveProps", function() {
     it("calls startTailing when new path is provided", function() {
-      thisInstance.componentWillReceiveProps({
+      thisInstance.UNSAFE_componentWillReceiveProps({
         filePath: "/other/file/path",
         task: { slave_id: "foo" }
       });
@@ -69,7 +69,7 @@ describe("MesosLogContainer", function() {
     });
 
     it("calls stopTailing when new path is provided", function() {
-      thisInstance.componentWillReceiveProps({
+      thisInstance.UNSAFE_componentWillReceiveProps({
         filePath: "/other/file/path",
         task: { slave_id: "foo" }
       });
@@ -77,7 +77,7 @@ describe("MesosLogContainer", function() {
     });
 
     it("doesn't call startTailing when same path is provided", function() {
-      thisInstance.componentWillReceiveProps({
+      thisInstance.UNSAFE_componentWillReceiveProps({
         filePath: "/some/file/path",
         task: { slave_id: "foo" }
       });
@@ -85,7 +85,7 @@ describe("MesosLogContainer", function() {
     });
 
     it("doesn't call stopTailing when same path is provided", function() {
-      thisInstance.componentWillReceiveProps({
+      thisInstance.UNSAFE_componentWillReceiveProps({
         filePath: "/some/file/path",
         task: { slave_id: "foo" }
       });

--- a/plugins/services/src/js/components/dsl/FuzzyTextDSLSection.js
+++ b/plugins/services/src/js/components/dsl/FuzzyTextDSLSection.js
@@ -37,7 +37,7 @@ class FuzzyTextDSLSection extends React.Component {
     });
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { expression } = nextProps;
     const data = DSLUtil.getPartValues(expression, EXPRESSION_PARTS);
 

--- a/plugins/services/src/js/components/modals/CreateServiceJsonOnly.js
+++ b/plugins/services/src/js/components/modals/CreateServiceJsonOnly.js
@@ -36,7 +36,7 @@ class CreateServiceJsonOnly extends React.Component {
   /**
    * @override
    */
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { service } = nextProps;
     const prevJSON = ServiceUtil.getServiceJSON(this.props.service);
     const nextJSON = ServiceUtil.getServiceJSON(service);

--- a/plugins/services/src/js/components/modals/CreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/CreateServiceModal.js
@@ -153,7 +153,7 @@ class CreateServiceModal extends Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { location, params } = this.props;
     // Skip update if there was no change to props
     if (

--- a/plugins/services/src/js/components/modals/CreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/CreateServiceModalForm.js
@@ -146,7 +146,7 @@ class CreateServiceModalForm extends Component {
     });
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const prevJSON = ServiceUtil.getServiceJSON(this.props.service);
     const nextJSON = ServiceUtil.getServiceJSON(nextProps.service);
     const isPod = nextProps.service instanceof PodSpec;

--- a/plugins/services/src/js/components/modals/KillPodInstanceModal.js
+++ b/plugins/services/src/js/components/modals/KillPodInstanceModal.js
@@ -39,7 +39,7 @@ class KillPodInstanceModal extends React.PureComponent {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { errors } = nextProps;
     if (!errors) {
       this.setState({ errorMsg: null });

--- a/plugins/services/src/js/components/modals/KillTaskModal.js
+++ b/plugins/services/src/js/components/modals/KillTaskModal.js
@@ -38,7 +38,7 @@ class KillTaskModal extends React.PureComponent {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { errors } = nextProps;
     if (!errors) {
       this.setState({ errorMsg: null });

--- a/plugins/services/src/js/components/modals/ServiceActionDisabledModal.js
+++ b/plugins/services/src/js/components/modals/ServiceActionDisabledModal.js
@@ -40,7 +40,7 @@ class ServiceActionDisabledModal extends React.Component {
     });
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (this.props.open !== nextProps.open) {
       this.setState({ copiedCommand: false });
     }

--- a/plugins/services/src/js/components/modals/ServiceDestroyModal.js
+++ b/plugins/services/src/js/components/modals/ServiceDestroyModal.js
@@ -66,7 +66,7 @@ class ServiceDestroyModal extends React.PureComponent {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { i18n } = this.props;
     const { errors } = nextProps;
     const defaultErrorMsg = i18n._(

--- a/plugins/services/src/js/components/modals/ServiceRestartModal.js
+++ b/plugins/services/src/js/components/modals/ServiceRestartModal.js
@@ -30,7 +30,7 @@ class ServiceRestartModal extends React.PureComponent {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { errors } = nextProps;
     if (!errors) {
       this.setState({ errorMsg: null });

--- a/plugins/services/src/js/components/modals/ServiceResumeModal.js
+++ b/plugins/services/src/js/components/modals/ServiceResumeModal.js
@@ -38,7 +38,7 @@ class ServiceResumeModal extends React.PureComponent {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { errors, open } = nextProps;
 
     if (open && !this.props.open) {

--- a/plugins/services/src/js/components/modals/ServiceScaleFormModal.js
+++ b/plugins/services/src/js/components/modals/ServiceScaleFormModal.js
@@ -30,7 +30,7 @@ class ServiceScaleFormModal extends React.PureComponent {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { errors } = nextProps;
     if (!errors) {
       this.setState({ errorMsg: null });

--- a/plugins/services/src/js/components/modals/ServiceStopModal.js
+++ b/plugins/services/src/js/components/modals/ServiceStopModal.js
@@ -30,7 +30,7 @@ class ServiceStopModal extends React.PureComponent {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { errors } = nextProps;
     if (!errors) {
       this.setState({ errorMsg: null });

--- a/plugins/services/src/js/containers/pod-debug/PodDebugContainer.js
+++ b/plugins/services/src/js/containers/pod-debug/PodDebugContainer.js
@@ -32,7 +32,7 @@ class PodDebugTabView extends React.Component {
     });
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     MarathonStore.setShouldEmbedLastUnusedOffers(true);
   }
 

--- a/plugins/services/src/js/containers/pod-detail/PodDetail.js
+++ b/plugins/services/src/js/containers/pod-detail/PodDetail.js
@@ -54,12 +54,12 @@ class PodDetail extends mixin(TabsMixin) {
     });
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     super.componentWillMount(...arguments);
     this.updateCurrentTab();
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     super.componentWillReceiveProps(...arguments);
     this.updateCurrentTab(nextProps);
   }

--- a/plugins/services/src/js/containers/pod-instances/PodInstancesContainer.js
+++ b/plugins/services/src/js/containers/pod-instances/PodInstancesContainer.js
@@ -67,7 +67,7 @@ class PodInstancesContainer extends React.Component {
     this.dispatcher = AppDispatcher.register(this.handleServerAction);
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.setFilterOptions(this.props);
   }
 

--- a/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
+++ b/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
@@ -68,7 +68,7 @@ class PodInstancesTable extends React.Component {
     });
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { checkedItems } = this.state;
     const prevInstances = this.props.instances;
     const nextInstances = nextProps.instances;

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
@@ -52,7 +52,7 @@ class ServiceConfiguration extends mixin(StoreMixin) {
     });
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const { service } = this.props;
     const versionID = service.getVersion();
 

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfigurationContainer.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfigurationContainer.js
@@ -8,13 +8,13 @@ import Service from "../../structs/Service";
 import ServiceConfiguration from "./ServiceConfiguration";
 
 class ServiceConfigurationContainer extends React.Component {
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const { service } = this.props;
 
     DCOSStore.fetchServiceVersions(service.getId());
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { service: nextService } = nextProps;
     const { service } = this.props;
 

--- a/plugins/services/src/js/containers/service-connection/SDKServiceConnectionEndpointList.js
+++ b/plugins/services/src/js/containers/service-connection/SDKServiceConnectionEndpointList.js
@@ -50,7 +50,7 @@ class SDKServiceConnectionEndpointList extends React.Component {
     SDKEndpointActions.fetchEndpoints(service.getId());
   }
 
-  componentWillReceiveProps() {
+  UNSAFE_componentWillReceiveProps() {
     const { service } = this.props;
     const { servicePreviousState } = this.state;
     const serviceStatus = service.getStatus();

--- a/plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js
+++ b/plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js
@@ -33,7 +33,7 @@ class ServiceDebugContainer extends React.Component {
     });
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     MarathonStore.setShouldEmbedLastUnusedOffers(true);
   }
 

--- a/plugins/services/src/js/containers/service-detail/ServiceDetail.js
+++ b/plugins/services/src/js/containers/service-detail/ServiceDetail.js
@@ -58,13 +58,13 @@ class ServiceDetail extends mixin(TabsMixin) {
     });
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     super.componentWillMount(...arguments);
     this.updateCurrentTab();
     this.checkForVolumes();
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     super.componentWillReceiveProps(...arguments);
     this.updateCurrentTab(nextProps);
     this.checkForVolumes();

--- a/plugins/services/src/js/containers/services/ServicesContainer.js
+++ b/plugins/services/src/js/containers/services/ServicesContainer.js
@@ -202,11 +202,11 @@ class ServicesContainer extends React.Component {
     }
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.propsToState(this.props);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.propsToState(nextProps);
   }
 

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -171,7 +171,7 @@ class ServicesTable extends React.Component {
     CompositeState.enable();
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.regionRenderer = regionRendererFactory(nextProps.masterRegionName);
 
     this.setState(

--- a/plugins/services/src/js/containers/tasks/TasksContainer.js
+++ b/plugins/services/src/js/containers/tasks/TasksContainer.js
@@ -51,7 +51,7 @@ class TasksContainer extends React.Component {
     });
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.propsToState(this.props);
   }
 
@@ -61,7 +61,7 @@ class TasksContainer extends React.Component {
     this.dispatcher = AppDispatcher.register(this.handleServerAction);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.propsToState(nextProps);
   }
 

--- a/plugins/services/src/js/containers/tasks/TasksView.js
+++ b/plugins/services/src/js/containers/tasks/TasksView.js
@@ -50,12 +50,12 @@ class TasksView extends mixin(SaveStateMixin) {
     }, this);
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.saveState_key = `tasksView#${this.props.itemID}`;
     super.componentWillMount();
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const prevCheckedItems = this.state.checkedItems;
     const checkedItems = {};
 

--- a/plugins/services/src/js/pages/ServicesPage.tsx
+++ b/plugins/services/src/js/pages/ServicesPage.tsx
@@ -30,7 +30,7 @@ class ServicesPage extends mixin(StoreMixin, TabsMixin) {
     this.state = this.getInitialState();
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.store_listeners = [
       { name: "notification", events: ["change"], suppressUpdate: true }
     ];

--- a/plugins/services/src/js/pages/task-details/TaskDetail.js
+++ b/plugins/services/src/js/pages/task-details/TaskDetail.js
@@ -82,7 +82,7 @@ class TaskDetail extends mixin(TabsMixin, StoreMixin) {
     this.onTaskDirectoryStoreNodeStateSuccess = this.onTaskDirectoryStoreSuccess;
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     super.componentWillMount(...arguments);
 
     const { routes } = this.props;
@@ -116,7 +116,7 @@ class TaskDetail extends mixin(TabsMixin, StoreMixin) {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     super.componentWillReceiveProps(...arguments);
     const { innerPath, taskID } = this.props.params;
     if (

--- a/plugins/services/src/js/pages/task-details/TaskLogsContainer.js
+++ b/plugins/services/src/js/pages/task-details/TaskLogsContainer.js
@@ -29,7 +29,7 @@ class TaskLogsContainer extends mixin(StoreMixin) {
     ];
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     // We already have a configuration, so stop loading. No need to fetch
     if (this.state.isLoading && ConfigStore.get("config") != null) {
       this.setState({ isLoading: false });

--- a/src/js/components/CollapsibleErrorMessage.js
+++ b/src/js/components/CollapsibleErrorMessage.js
@@ -51,7 +51,7 @@ class CollapsibleErrorMessage extends React.Component {
   /**
    * Set the default expanded state from the properties
    */
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.setState({
       expanded: this.props.expanded
     });

--- a/src/js/components/DSLFormDropdownPanel.js
+++ b/src/js/components/DSLFormDropdownPanel.js
@@ -42,7 +42,7 @@ class DSLFormDropdownPanel extends React.Component {
    *
    * @override
    */
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (
       this.props.expression !== nextProps.expression ||
       (!this.props.isVisible && nextProps.isVisible)

--- a/src/js/components/DSLInputField.js
+++ b/src/js/components/DSLInputField.js
@@ -59,7 +59,7 @@ class DSLInputField extends React.Component {
    *
    * @override
    */
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { expression } = nextProps;
 
     if (expression !== this.state.expression) {

--- a/src/js/components/ExpandingTable.js
+++ b/src/js/components/ExpandingTable.js
@@ -27,7 +27,7 @@ class ExpandingTable extends React.Component {
     this.state = initialState;
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     // Check for new rows and expand them if expandRowsByDefault is true.
     if (nextProps.expandRowsByDefault) {
       let shouldSetState = false;

--- a/src/js/components/Image.js
+++ b/src/js/components/Image.js
@@ -18,7 +18,7 @@ class Image extends React.Component {
     });
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { src, fallbackSrc } = this.props;
     let newSrc;
     if (src !== nextProps.src) {

--- a/src/js/components/JSONEditor.js
+++ b/src/js/components/JSONEditor.js
@@ -86,7 +86,7 @@ class JSONEditor extends React.Component {
 
     //
     // The following properties are part of the `internal`, non-react state
-    // and is synchronized with the react through `componentWillReceiveProps`
+    // and is synchronized with the react through `UNSAFE_componentWillReceiveProps`
     //
     this.externalErrors = (this.props.errors || []).slice();
     this.jsonError = null;
@@ -113,7 +113,7 @@ class JSONEditor extends React.Component {
   /**
    * @override
    */
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     // Synchronize error updates
     if (!isEqual(this.externalErrors, nextProps.errors)) {
       this.externalErrors = (nextProps.errors || []).slice();

--- a/src/js/components/Modals.js
+++ b/src/js/components/Modals.js
@@ -45,7 +45,7 @@ var Modals = createReactClass({
     };
   },
 
-  componentWillReceiveProps(props) {
+  UNSAFE_componentWillReceiveProps(props) {
     this.setState({
       modalErrorMsg: props.modalErrorMsg,
       showErrorModal: props.showErrorModal

--- a/src/js/components/Page.js
+++ b/src/js/components/Page.js
@@ -80,7 +80,7 @@ const Page = createReactClass({
     title: PropTypes.oneOfType([PropTypes.object, PropTypes.string])
   },
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.store_listeners = [
       {
         name: "sidebar",

--- a/src/js/components/PlacementConstraintsSchemaField.js
+++ b/src/js/components/PlacementConstraintsSchemaField.js
@@ -57,7 +57,7 @@ export default class PlacementConstraintsSchemaField extends Component {
     this.handleBatchChange = this.handleBatchChange.bind(this);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.fieldProps.formData !== this.props.fieldProps.formData) {
       this.setState({
         batch: this.generateBatchFromInput(nextProps)

--- a/src/js/components/SchemaForm.js
+++ b/src/js/components/SchemaForm.js
@@ -42,7 +42,7 @@ class SchemaForm extends mixin(StoreMixin) {
     this.isValidated = true;
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     super.componentWillMount(...arguments);
 
     if (this.props.definition) {

--- a/src/js/components/Sidebar.js
+++ b/src/js/components/Sidebar.js
@@ -52,7 +52,7 @@ class Sidebar extends React.Component {
     });
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const pathnameSegments = this.props.location.pathname.split("/");
 
     // If the user loaded the UI from a route other than `/`, we want to display

--- a/src/js/components/TabForm.js
+++ b/src/js/components/TabForm.js
@@ -31,7 +31,7 @@ class TabForm extends React.Component {
     this.triggerSubmit = function() {};
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.model = {};
     this.submitMap = {};
 

--- a/src/js/components/__tests__/JSONEditor-test.js
+++ b/src/js/components/__tests__/JSONEditor-test.js
@@ -54,7 +54,7 @@ describe("JSONEditor", function() {
       const nextState = instance.state;
 
       instance.handleChange(JSON.stringify(updatedValue));
-      instance.componentWillReceiveProps(nextProps);
+      instance.UNSAFE_componentWillReceiveProps(nextProps);
 
       expect(instance.shouldComponentUpdate(nextProps, nextState)).toBe(true);
     });
@@ -151,7 +151,7 @@ describe("JSONEditor", function() {
         // Run all pending timers to reset internal `isTyping` state
         jest.runOnlyPendingTimers();
 
-        instance.componentWillReceiveProps({
+        instance.UNSAFE_componentWillReceiveProps({
           value: JSON.parse(initialJSONText)
         });
       });

--- a/src/js/components/charts/AnimationCircle.js
+++ b/src/js/components/charts/AnimationCircle.js
@@ -36,7 +36,7 @@ var AnimationCircle = createReactClass({
     );
   },
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const node = ReactDOM.findDOMNode(this);
 
     // Handle first position to not animate into position

--- a/src/js/components/charts/Chart.js
+++ b/src/js/components/charts/Chart.js
@@ -22,7 +22,7 @@ var Chart = createReactClass({
     };
   },
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.store_listeners = [
       {
         name: "sidebar",

--- a/src/js/components/charts/DialChart.js
+++ b/src/js/components/charts/DialChart.js
@@ -30,7 +30,7 @@ var DialChart = createReactClass({
     };
   },
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     var value = this.props.value;
     var data = Object.assign(
       {

--- a/src/js/components/charts/TimeSeriesArea.js
+++ b/src/js/components/charts/TimeSeriesArea.js
@@ -26,7 +26,7 @@ var TimeSeriesArea = createReactClass({
       .attr("transform", "translate(" + props.position + ")");
   },
 
-  componentWillReceiveProps(props) {
+  UNSAFE_componentWillReceiveProps(props) {
     d3.select(ReactDOM.findDOMNode(this))
       .interrupt()
       .attr("transform", null)

--- a/src/js/components/charts/TimeSeriesChart.js
+++ b/src/js/components/charts/TimeSeriesChart.js
@@ -57,7 +57,7 @@ const TimeSeriesChart = createReactClass({
     };
   },
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.clipPathID = `clip-${Util.uniqueID()}`;
     this.maskID = `mask-${Util.uniqueID()}`;
   },

--- a/src/js/components/modals/ActionsModal.js
+++ b/src/js/components/modals/ActionsModal.js
@@ -37,7 +37,7 @@ class ActionsModal extends mixin(StoreMixin) {
     });
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.setState({
       requestsRemaining: this.props.selectedItems.length
     });

--- a/src/js/components/modals/ImageViewerModal.js
+++ b/src/js/components/modals/ImageViewerModal.js
@@ -29,7 +29,7 @@ class ImageViewerModal extends React.Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { props } = this;
     if (props.open && !nextProps.open) {
       // Closes

--- a/src/js/components/modals/LanguagePreferenceFormModal.js
+++ b/src/js/components/modals/LanguagePreferenceFormModal.js
@@ -19,7 +19,7 @@ export class LanguagePreferenceFormModalComponent extends React.Component {
     this.handleLanguagePrefSubmit = this.handleLanguagePrefSubmit.bind(this);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { isOpen } = nextProps;
     if (isOpen !== this.state.isOpen) {
       this.setState({ isOpen });

--- a/src/js/mixins/SaveStateMixin.js
+++ b/src/js/mixins/SaveStateMixin.js
@@ -3,7 +3,7 @@ import UserSettingsStore from "../stores/UserSettingsStore";
 import { SAVED_STATE_KEY } from "../constants/UserSettings";
 
 const SaveStateMixin = {
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const key = this.saveState_key;
     if (!key) {
       return;

--- a/src/js/mixins/TabsMixin.js
+++ b/src/js/mixins/TabsMixin.js
@@ -28,7 +28,7 @@ import NotificationStore from "../stores/NotificationStore";
  *       currentTab: 'defined-route-1'
  *     }
  *   }
- *   componentWillMount() {
+ *   UNSAFE_componentWillMount() {
  *     // The keys to this object must be defined routes
  *     this.tabs_tabs = {
  *      'defined-route-1': 'Tab Title 1',

--- a/src/js/mixins/__tests__/SaveStateMixin-test.js
+++ b/src/js/mixins/__tests__/SaveStateMixin-test.js
@@ -17,7 +17,7 @@ describe("SaveStateMixin", function() {
     thisInstance.constructor.displayName = "FakeInstance";
   });
 
-  describe("#componentWillMount", function() {
+  describe("#UNSAFE_componentWillMount", function() {
     beforeEach(function() {
       thisPrevGetKey = UserSettingsStore.getKey;
       UserSettingsStore.getKey = function() {
@@ -34,7 +34,7 @@ describe("SaveStateMixin", function() {
     });
 
     it("sets the previous state", function() {
-      thisInstance.componentWillMount();
+      thisInstance.UNSAFE_componentWillMount();
       expect(thisInstance.setState).toHaveBeenCalledWith({ open: false });
     });
   });

--- a/src/js/pages/DashboardPage.js
+++ b/src/js/pages/DashboardPage.js
@@ -105,7 +105,7 @@ var DashboardPage = createReactClass({
     };
   },
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.store_listeners = [
       { name: "dcos", events: ["change"], suppressUpdate: true },
       { name: "summary", events: ["success", "error"], suppressUpdate: true },

--- a/src/js/pages/Index.js
+++ b/src/js/pages/Index.js
@@ -44,7 +44,7 @@ var Index = createReactClass({
     };
   },
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     MetadataStore.init();
     SidebarStore.init();
     MesosStateStore.addChangeListener(

--- a/src/js/pages/NetworkPage.js
+++ b/src/js/pages/NetworkPage.js
@@ -42,7 +42,7 @@ class NetworkPage extends mixin(TabsMixin) {
     this.state = {};
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     super.componentWillMount(...arguments);
 
     const networkPageReady = Hooks.applyFilter(

--- a/src/js/pages/catalog/PackageDetailTab.js
+++ b/src/js/pages/catalog/PackageDetailTab.js
@@ -155,7 +155,7 @@ class PackageDetailTab extends mixin(StoreMixin) {
     DCOSStore.removeChangeListener(DCOS_CHANGE, this.onStoreChange);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     super.componentWillReceiveProps(...arguments);
 
     this.retrievePackageInfo(

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.js
@@ -84,12 +84,12 @@ class VirtualNetworkDetail extends mixin(StoreMixin, TabsMixin) {
     });
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     super.componentWillMount(...arguments);
     this.updateCurrentTab();
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     super.componentWillReceiveProps(...arguments);
     this.updateCurrentTab(nextProps);
   }

--- a/src/js/pages/system/OrganizationTab.js
+++ b/src/js/pages/system/OrganizationTab.js
@@ -100,12 +100,12 @@ class OrganizationTab extends mixin(StoreMixin) {
     this.selectedIDSet = {};
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     super.componentWillMount();
     this.resetTablewideCheckboxTabulations();
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     super.componentWillReceiveProps(...arguments);
 
     if (nextProps.items.length !== this.props.items.length) {

--- a/src/js/stores/MesosSummaryFetchers.tsx
+++ b/src/js/stores/MesosSummaryFetchers.tsx
@@ -41,7 +41,7 @@ export function withNode<P extends object>(
       });
     }
 
-    componentWillMount() {
+    UNSAFE_componentWillMount() {
       MesosSummaryStore.addChangeListener(
         MESOS_SUMMARY_CHANGE,
         this.receiveNewSummary


### PR DESCRIPTION
## Testing
1. Verify that all instances of "componentWillMount" and "componentWillReceiveProps" have been renamed to "UNSAFE_componentWillMount" and "UNSAFE_componentWillReceiveProps".
2. (Optional) Smoke test the UI to see that everything works
3. (Optional) Check to see that we have less console warnings.

## Trade-offs
I didn't rename `super.componentWillMount`. I don't think that we should.

## Dependencies
None.

## Screenshots
None.
