### PR TITLE
enable prefer-const in tslint as well

### DIFF
--- a/plugins/jobs/src/js/components/JobsFormModal.tsx
+++ b/plugins/jobs/src/js/components/JobsFormModal.tsx
@@ -392,7 +392,7 @@ class JobFormModal extends React.Component<
     const { isEdit } = this.props;
     const { scheduleFailure } = this.state;
 
-    let title =
+    const title =
       isEdit || scheduleFailure ? (
         <Trans render="span">Edit Job</Trans>
       ) : (
@@ -478,7 +478,7 @@ class JobFormModal extends React.Component<
   render() {
     const { isOpen, i18n } = this.props;
     const { isConfirmOpen } = this.state;
-    let useGemini = false;
+    const useGemini = false;
 
     return (
       <FullScreenModal

--- a/plugins/jobs/src/js/components/form/reducers/ContainerReducers.ts
+++ b/plugins/jobs/src/js/components/form/reducers/ContainerReducers.ts
@@ -66,7 +66,7 @@ export const dockerParamsReducers = {
   },
   [JobFormActionType.Set]: (value: string, state: JobSpec, path: string[]) => {
     const stateCopy = deepCopy(state);
-    let docker = stateCopy.job.run.docker;
+    const docker = stateCopy.job.run.docker;
     const [prop, i] = path;
     const index = parseFloat(i);
     if (

--- a/plugins/jobs/src/js/components/form/reducers/PlacementReducers.ts
+++ b/plugins/jobs/src/js/components/form/reducers/PlacementReducers.ts
@@ -38,7 +38,10 @@ export const placementReducers = {
   },
   [JobFormActionType.Set]: (value: string, state: JobSpec, path: string[]) => {
     const stateCopy = deepCopy(state);
-    let placement = findNestedPropertyInObject(stateCopy, "job.run.placement");
+    const placement = findNestedPropertyInObject(
+      stateCopy,
+      "job.run.placement"
+    );
     const [prop, i] = path;
     const index = parseFloat(i);
     if (

--- a/plugins/jobs/src/js/components/form/reducers/VolumesReducers.ts
+++ b/plugins/jobs/src/js/components/form/reducers/VolumesReducers.ts
@@ -28,7 +28,7 @@ export const volumesReducers = {
   },
   [JobFormActionType.Set]: (value: string, state: JobSpec, path: string[]) => {
     const stateCopy = deepCopy(state);
-    let volumes = stateCopy.job.run.volumes;
+    const volumes = stateCopy.job.run.volumes;
     const [prop, i] = path;
     const index = parseFloat(i);
     if (volumes && Array.isArray(volumes) && volumes.length >= index + 1) {

--- a/plugins/nodes/src/js/components/modals/DrainNodeModal.tsx
+++ b/plugins/nodes/src/js/components/modals/DrainNodeModal.tsx
@@ -26,7 +26,7 @@ const DEFAULT_DRAIN_OPTIONS: DrainOptions = {
 function DrainNodeModal(props: Props) {
   const { open, onClose, node } = props;
 
-  let [prevOpenState, setPrevOpenState] = useState<boolean | null>(null);
+  const [prevOpenState, setPrevOpenState] = useState<boolean | null>(null);
 
   const [drainOptions, setDrainOptions] = useState<DrainOptions>(
     DEFAULT_DRAIN_OPTIONS

--- a/plugins/services/src/js/components/modals/ServiceRootGroupModal/utils.tsx
+++ b/plugins/services/src/js/components/modals/ServiceRootGroupModal/utils.tsx
@@ -61,7 +61,7 @@ export function validateGroupFormData(
   data: GroupFormData,
   isEdit: boolean
 ): void | {} {
-  let errors: GroupFormErrors = {};
+  const errors: GroupFormErrors = {};
   const addFormError = (error: JSX.Element) => {
     if (!errors.form) {
       errors.form = [];
@@ -95,7 +95,7 @@ export function validateGroupFormData(
     }
     errors.quota[field] = error;
   };
-  for (let field of quotaFields) {
+  for (const field of quotaFields) {
     const value = (data.quota[field] + "").trim();
     if (ValidatorUtil.isEmpty(value)) {
       continue;

--- a/plugins/services/src/js/data/MesosClient.ts
+++ b/plugins/services/src/js/data/MesosClient.ts
@@ -32,7 +32,7 @@ function limitsFromQuotaFormData(
   quotaData: QuotaData
 ): Record<string, QuotaRequestValue> {
   const result: Record<string, QuotaRequestValue> = {};
-  for (let field of quotaFields) {
+  for (const field of quotaFields) {
     const value = (quotaData[field] + "").trim();
     if (!ValidatorUtil.isEmpty(value)) {
       result[field] = {

--- a/plugins/services/src/js/data/__tests__/extension-test.ts
+++ b/plugins/services/src/js/data/__tests__/extension-test.ts
@@ -24,7 +24,7 @@ export function createTestContainer(
 
 describe("DataLayer - Services Extension", () => {
   it("can load container module", () => {
-    let container = createTestContainer();
+    const container = createTestContainer();
 
     const dl = container.get<DataLayer>(DataLayerType);
     expect(dl).not.toBeNull();

--- a/plugins/services/src/js/utils/QuotaUtil.ts
+++ b/plugins/services/src/js/utils/QuotaUtil.ts
@@ -20,7 +20,7 @@ export function quotaHasLimit(
     quota.disk,
     quota.gpus
   ];
-  for (let metric of metrics) {
+  for (const metric of metrics) {
     if (metric && (metric.limit !== null && metric.limit !== undefined)) {
       return true;
     }
@@ -108,7 +108,7 @@ export function serviceTreeHasQuota(
   if (splitId.length < 2) {
     return false;
   }
-  let roleName = splitId[1];
+  const roleName = splitId[1];
   const role = roles.find(role => role.name === roleName);
   if (!role) {
     return false;

--- a/plugins/ui-update/components/InstalledVersion.tsx
+++ b/plugins/ui-update/components/InstalledVersion.tsx
@@ -22,7 +22,7 @@ function refreshPage() {
 }
 
 function renderRollbackAction(uiAction: UIAction): React.ReactNode {
-  let defaultContent = <Trans>Rollback</Trans>;
+  const defaultContent = <Trans>Rollback</Trans>;
   if (uiAction.type !== UIActionType.Reset) {
     return defaultContent;
   }

--- a/src/js/utils/crypto/index.ts
+++ b/src/js/utils/crypto/index.ts
@@ -4,7 +4,7 @@
 // the bundle: https://gist.github.com/jonleighton/958841
 function arrayBufferToBase64(buffer: ArrayBuffer): string {
   let binary = "";
-  let bytes = new Uint8Array(buffer);
+  const bytes = new Uint8Array(buffer);
   for (var i = 0; i < bytes.byteLength; i++) {
     binary += String.fromCharCode(bytes[i]);
   }

--- a/tslint.json
+++ b/tslint.json
@@ -5,6 +5,7 @@
     "interface-over-type-literal": false,
     "jsx-wrap-multiline": false,
     "no-submodule-imports": [false],
+    "prefer-const": true,
     "react-hooks-nesting": "error"
   }
 }


### PR DESCRIPTION
while reviewing i noticed that we have this enabled for eslint, but not for
tslint. i personally like that rule a lot because it reduces the mental overhead
necessary for me to understand code.

don't know if a public poll is necessary as somewhen it was already decided to use that for `.js`-files.