### PR TITLE
DCOS-50331: TypeError: Cannot convert undefined or null to object

### DIFF
--- a/plugins/services/src/js/utils/VipLabelUtil.js
+++ b/plugins/services/src/js/utils/VipLabelUtil.js
@@ -29,6 +29,9 @@ const VipLabelUtil = {
   },
 
   findVip(labels = {}) {
+    if (typeof labels !== "object" || labels === null) {
+      return undefined;
+    }
     return Object.entries(labels).find(([key, _]) => key.match(/^(vip|VIP)/));
   },
 

--- a/plugins/services/src/js/utils/__tests__/VipLabelUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/VipLabelUtil-test.js
@@ -113,6 +113,10 @@ describe("VipLabelUtil", function() {
         })
       ).toEqual(undefined);
     });
+
+    it("does not crash when labels is null", function() {
+      expect(VipLabelUtil.findVip(null)).toEqual(undefined);
+    });
   });
 
   describe("#defaultVip", function() {


### PR DESCRIPTION
Add a non-object check and a null check
to the findVip function.

Closes https://jira.mesosphere.com/browse/DCOS-50331

## Testing
1. Go to services tab.
2. Open the create service modal.
3. Open the single container service form.
4. Go to the Networking tab.
5. Click "Add Service Endpoint".
6. Click "Enable Load Balanced Service Address" checkbox.
7. Manually change portDefinitions.labels to null in the JSON Editor.
8. Verify that no console error is shown.
9. Verify the same thing for pods.
10. Verify that the added test makes sense.

## Trade-offs
None.

## Dependencies
None.

## Screenshots
### Before
![Peek 2019-08-14 14-56](https://user-images.githubusercontent.com/40791275/63019380-cecd0480-bea3-11e9-95ce-96526f6828c0.gif)

### After
![Peek 2019-08-14 14-53](https://user-images.githubusercontent.com/40791275/63019220-63833280-bea3-11e9-95e8-9c843b5a1528.gif)

