### PR TITLE
DCOS-57643: feat(servicetable): add endpoints link to action menu

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -937,6 +937,7 @@
   "Version": "",
   "View Cluster Configuration": "",
   "View Documentation": "",
+  "View Endpoints": "",
   "View Plans": "",
   "View Services": "",
   "View all {componentCount} {componentCountWord}": "",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -937,6 +937,7 @@
   "Version": "版本",
   "View Cluster Configuration": "查看集群配置",
   "View Documentation": "查看文档",
+  "View Endpoints": "",
   "View Plans": "",
   "View Services": "查看服务",
   "View all {componentCount} {componentCountWord}": "查看全部 {componentCount} {componentCountWord}",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4327,7 +4327,7 @@
     },
     "bl": {
       "version": "1.2.2",
-      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "dev": true,
       "requires": {
@@ -11888,7 +11888,7 @@
     },
     "html-webpack-plugin": {
       "version": "3.2.0",
-      "resolved": "http://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
       "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
       "dev": true,
       "requires": {
@@ -12365,7 +12365,7 @@
       "dependencies": {
         "colors": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "resolved": "http://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
           "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
           "dev": true
         }
@@ -20681,7 +20681,7 @@
         },
         "external-editor": {
           "version": "2.2.0",
-          "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
           "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
           "dev": true,
           "requires": {
@@ -20719,7 +20719,7 @@
         },
         "node-fetch": {
           "version": "1.6.3",
-          "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
           "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
           "dev": true,
           "requires": {
@@ -26460,7 +26460,7 @@
     },
     "speed-measure-webpack-plugin": {
       "version": "1.2.2",
-      "resolved": "http://registry.npmjs.org/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.2.2.tgz",
       "integrity": "sha512-OPssnUTAdOwl/ijqToLrYUi8xHxdC9SOVV9e2AxkOC02Hua7+Jkfh3tdFCZxiMbtlghHK5Eyz87kG/XNpeM77w==",
       "dev": true,
       "requires": {

--- a/plugins/services/src/js/columns/ServicesTableActionsColumn.tsx
+++ b/plugins/services/src/js/columns/ServicesTableActionsColumn.tsx
@@ -21,6 +21,7 @@ import ConfigStore from "#SRC/js/stores/ConfigStore";
 const DELETE = ServiceActionItem.DELETE;
 const EDIT = ServiceActionItem.EDIT;
 const VIEW_PLANS = ServiceActionItem.VIEW_PLANS;
+const VIEW_ENDPOINTS = ServiceActionItem.VIEW_ENDPOINTS;
 const MORE = ServiceActionItem.MORE;
 const OPEN = ServiceActionItem.OPEN;
 const RESTART = ServiceActionItem.RESTART;
@@ -56,6 +57,7 @@ function onActionsItemSelection(
   if (
     actionItem.id !== EDIT &&
     actionItem.id !== VIEW_PLANS &&
+    actionItem.id !== VIEW_ENDPOINTS &&
     actionItem.id !== DELETE &&
     (containsSDKService || isSDKService(service)) &&
     !Hooks.applyFilter(
@@ -126,6 +128,13 @@ export function actionsRendererFactory(
         <Icon shape={SystemIcons.EllipsisVertical} size={iconSizeXs} />
       )
     });
+
+    if (!isGroup) {
+      actions.push({
+        id: VIEW_ENDPOINTS,
+        html: <Trans render="span" id={ServiceActionLabels.view_endpoints} />
+      });
+    }
 
     if (hasWebUI(service)) {
       actions.push({

--- a/plugins/services/src/js/constants/ServiceActionItem.ts
+++ b/plugins/services/src/js/constants/ServiceActionItem.ts
@@ -12,5 +12,6 @@ export enum ServiceActionItem {
   MORE = "more",
   KILL_POD_INSTANCES = "kill_pod_instances",
   KILL_TASKS = "kill_tasks",
-  VIEW_PLANS = "view_plans"
+  VIEW_PLANS = "view_plans",
+  VIEW_ENDPOINTS = "view_endpoints"
 }

--- a/plugins/services/src/js/constants/ServiceActionLabels.ts
+++ b/plugins/services/src/js/constants/ServiceActionLabels.ts
@@ -11,6 +11,7 @@ interface ServiceActionLabelsInterface {
   reset_delayed: string;
   stop: string;
   view_plans: string;
+  view_endpoints: string;
 }
 
 const ServiceActionLabels: ServiceActionLabelsInterface = {
@@ -23,7 +24,8 @@ const ServiceActionLabels: ServiceActionLabelsInterface = {
   reset_delayed: i18nMark("Reset Delay"),
   scale_by: i18nMark("Scale By"),
   stop: i18nMark("Stop"),
-  view_plans: i18nMark("View Plans")
+  view_plans: i18nMark("View Plans"),
+  view_endpoints: i18nMark("View Endpoints")
 };
 
 export default ServiceActionLabels;

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -64,6 +64,7 @@ const SCALE = ServiceActionItem.SCALE;
 const STOP = ServiceActionItem.STOP;
 const RESET_DELAYED = ServiceActionItem.RESET_DELAYED;
 const VIEW_PLANS = ServiceActionItem.VIEW_PLANS;
+const VIEW_ENDPOINTS = ServiceActionItem.VIEW_ENDPOINTS;
 
 const METHODS_TO_BIND = [
   "handleServiceAction",
@@ -195,6 +196,11 @@ class ServicesTable extends React.Component {
       case VIEW_PLANS:
         router.push(
           `/services/detail/${encodeURIComponent(service.getId())}/plans/`
+        );
+        break;
+      case VIEW_ENDPOINTS:
+        router.push(
+          `/services/detail/${encodeURIComponent(service.getId())}/endpoints/`
         );
         break;
       case SCALE:


### PR DESCRIPTION
This adds a link to the endpoints tab to the action menu of sdk's pods and apps.

CLOSES DCOS-57643

## Testing

Visit the Service Table
Check if the action menu of a service(SDK, app or/and pod) is containing "View Endpoints"
Click the Action the Endpoints tab should be shown now.

## Trade-offs

N/A
## Dependencies

N/A

## Screenshots

![image](https://user-images.githubusercontent.com/156010/63164026-6575fe80-c027-11e9-8c90-4a0f5ca9ff77.png)
