### PR TITLE
DCOS-57645: feat(endpointstab): add weburl to endpoints tab

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -961,6 +961,8 @@
   "Warning": "",
   "Warning:": "",
   "We are unable to retrieve the version {0} versions. Please try again.": "",
+  "Web Enpoints": "",
+  "Web URL": "",
   "When you attempt to deploy a service, DC/OS waits for offers to match the resources your service requires. If the offer does not satisfy the requirement, it is declined and DC/OS retries. <0>Learn more</0>.": "",
   "Will not enforce quota on all services in the group.": "",
   "With Latest Config": "",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -961,7 +961,7 @@
   "Warning": "",
   "Warning:": "",
   "We are unable to retrieve the version {0} versions. Please try again.": "",
-  "Web Enpoints": "",
+  "Web Endpoints": "",
   "Web URL": "",
   "When you attempt to deploy a service, DC/OS waits for offers to match the resources your service requires. If the offer does not satisfy the requirement, it is declined and DC/OS retries. <0>Learn more</0>.": "",
   "Will not enforce quota on all services in the group.": "",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -961,6 +961,8 @@
   "Warning": "警告",
   "Warning:": "警告：",
   "We are unable to retrieve the version {0} versions. Please try again.": "我们无法检索版本中的版本 {0}。请重试。",
+  "Web Enpoints": "",
+  "Web URL": "",
   "When you attempt to deploy a service, DC/OS waits for offers to match the resources your service requires. If the offer does not satisfy the requirement, it is declined and DC/OS retries. <0>Learn more</0>.": "当您尝试部署服务时，DC/OS 等待 offer，以匹配您的服务所需的资源。如果 offer 不能满足要求，则会被拒绝，而 DC/OS 会进行重试。<0>了解更多</0>.",
   "Will not enforce quota on all services in the group.": "",
   "With Latest Config": "附带最新配置",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -961,7 +961,7 @@
   "Warning": "警告",
   "Warning:": "警告：",
   "We are unable to retrieve the version {0} versions. Please try again.": "我们无法检索版本中的版本 {0}。请重试。",
-  "Web Enpoints": "",
+  "Web Endpoints": "",
   "Web URL": "",
   "When you attempt to deploy a service, DC/OS waits for offers to match the resources your service requires. If the offer does not satisfy the requirement, it is declined and DC/OS retries. <0>Learn more</0>.": "当您尝试部署服务时，DC/OS 等待 offer，以匹配您的服务所需的资源。如果 offer 不能满足要求，则会被拒绝，而 DC/OS 会进行重试。<0>了解更多</0>.",
   "Will not enforce quota on all services in the group.": "",

--- a/plugins/services/src/js/containers/service-connection/ServiceConnectionEndpointList.js
+++ b/plugins/services/src/js/containers/service-connection/ServiceConnectionEndpointList.js
@@ -147,13 +147,7 @@ class ServiceConnectionEndpointList extends React.Component {
     });
   }
 
-  getEndpoints(service) {
-    const webUrl = service.getWebURL();
-
-    if (webUrl === "") {
-      return null;
-    }
-
+  getEndpoints(webUrl) {
     return (
       <ConfigurationMapSection>
         <ConfigurationMapHeading>
@@ -199,12 +193,13 @@ class ServiceConnectionEndpointList extends React.Component {
         />
       );
     }
+    const webUrl = service.getWebURL();
 
     return (
       <div className="container">
         <ConfigurationMap>
           {this.getPortDefinitions(endpoints, service)}
-          {this.getEndpoints(service)}
+          {webUrl ? this.getEndpoints(webUrl) : null}
         </ConfigurationMap>
       </div>
     );

--- a/plugins/services/src/js/containers/service-connection/ServiceConnectionEndpointList.js
+++ b/plugins/services/src/js/containers/service-connection/ServiceConnectionEndpointList.js
@@ -147,6 +147,30 @@ class ServiceConnectionEndpointList extends React.Component {
     });
   }
 
+  getEndpoints(service) {
+    const webUrl = service.getWebURL();
+
+    if (webUrl === "") {
+      return null;
+    }
+
+    return (
+      <ConfigurationMapSection>
+        <ConfigurationMapHeading>
+          <Trans>Web Endpoints</Trans>
+        </ConfigurationMapHeading>
+        <ConfigurationMapRow>
+          <Trans render={<ConfigurationMapLabel />}>Web URL</Trans>
+          <ConfigurationMapValue>
+            <EndpointClipboardTrigger
+              command={webUrl[0] === "/" ? location.origin + webUrl : webUrl}
+            />
+          </ConfigurationMapValue>
+        </ConfigurationMapRow>
+      </ConfigurationMapSection>
+    );
+  }
+
   render() {
     const { service } = this.props;
     let endpoints = [];
@@ -180,6 +204,7 @@ class ServiceConnectionEndpointList extends React.Component {
       <div className="container">
         <ConfigurationMap>
           {this.getPortDefinitions(endpoints, service)}
+          {this.getEndpoints(service)}
         </ConfigurationMap>
       </div>
     );

--- a/plugins/services/src/js/structs/Service.js
+++ b/plugins/services/src/js/structs/Service.js
@@ -82,7 +82,7 @@ module.exports = class Service extends Item {
   }
 
   getWebURL() {
-    return getWebURL(this.getLabels(), Config.rootUrl) || "";
+    return getWebURL(this.getLabels(), Config.rootUrl);
   }
 
   getVersion() {

--- a/plugins/services/src/js/structs/Service.js
+++ b/plugins/services/src/js/structs/Service.js
@@ -82,7 +82,7 @@ module.exports = class Service extends Item {
   }
 
   getWebURL() {
-    return getWebURL(this.getLabels(), Config.rootUrl);
+    return getWebURL(this.getLabels(), Config.rootUrl) || "";
   }
 
   getVersion() {

--- a/tests/_fixtures/marathon-1-task/groups.json
+++ b/tests/_fixtures/marathon-1-task/groups.json
@@ -188,7 +188,8 @@
         "maximumOverCapacity": 1
       },
       "labels": {
-        "MARATHON_SINGLE_INSTANCE_APP": "true"
+        "MARATHON_SINGLE_INSTANCE_APP": "true",
+        "DCOS_SERVICE_WEB_PATH": "web-path"
       },
       "acceptedResourceRoles": null,
       "version": "2015-08-28T01:26:14.620Z",
@@ -202,6 +203,16 @@
       "tasksUnhealthy": 0,
       "deployments": [
 
+      ],
+      "portDefinitions": [
+        {
+          "labels": {
+            "VIP_0": "/new-service-1:126"
+          },
+          "name": "124",
+          "protocol": "tcp",
+          "port": 125
+        }
       ]
     }
   ],

--- a/tests/pages/services/ServiceDetail-cy.js
+++ b/tests/pages/services/ServiceDetail-cy.js
@@ -76,6 +76,77 @@ describe("Service Detail Page", function() {
         cy.hash().should("match", /services\/detail\/%2Fsleep\/debug.*/);
       });
 
+      it("shows endpoints tab when clicked", function() {
+        cy.visitUrl({
+          url: "/services/detail/%2Fsleep"
+        });
+
+        cy.get(".menu-tabbed-item")
+          .contains("Endpoints")
+          .click();
+
+        cy.get("h1.configuration-map-heading")
+          .contains("124")
+          .should("exist");
+
+        cy.get(".configuration-map-label")
+          .contains("Protocol")
+          .should("exist");
+        cy.get(".configuration-map-label")
+          .contains("Protocol")
+          .next(".configuration-map-value")
+          .contains("tcp")
+          .should("exist");
+
+        cy.get(".configuration-map-label")
+          .contains("Container Port")
+          .should("exist");
+        cy.get(".configuration-map-label")
+          .contains("Container Port")
+          .next(".configuration-map-value")
+          .contains("—")
+          .should("exist");
+
+        cy.get(".configuration-map-label")
+          .contains("Host Port")
+          .should("exist");
+        cy.get(".configuration-map-label")
+          .contains("Host Port")
+          .next(".configuration-map-value")
+          .contains("Auto Assigned")
+          .should("exist");
+
+        cy.get(".configuration-map-label")
+          .contains("Service Port")
+          .should("exist");
+        cy.get(".configuration-map-label")
+          .contains("Service Port")
+          .next(".configuration-map-value")
+          .contains("—")
+          .should("exist");
+
+        cy.get(".configuration-map-label")
+          .contains("Load Balanced Address")
+          .should("exist");
+        cy.get(".configuration-map-label")
+          .contains("Load Balanced Address")
+          .next(".configuration-map-value")
+          .contains("new-service-1.marathon.l4lb.thisdcos.directory:126")
+          .should("exist");
+
+        cy.get("h1.configuration-map-heading")
+          .contains("Web Endpoints")
+          .should("exist");
+        cy.get(".configuration-map-label")
+          .contains("Web URL")
+          .should("exist");
+        cy.get(".configuration-map-label")
+          .contains("Web URL")
+          .next(".configuration-map-value")
+          .contains("http://localhost:4200/service/undefined/web-path")
+          .should("exist");
+      });
+
       it("shows volumes tab when clicked", function() {
         cy.visitUrl({
           url: "/services/detail/%2Fsleep"

--- a/tests/pages/services/ServiceDetail-cy.js
+++ b/tests/pages/services/ServiceDetail-cy.js
@@ -100,10 +100,6 @@ describe("Service Detail Page", function() {
           .and("contain", "Auto Assigned");
 
         cy.get(".table-row")
-          .should("contain", "Service Port")
-          .and("contain", "-");
-
-        cy.get(".table-row")
           .should("contain", "Load Balanced Address")
           .and("contain", "new-service-1.marathon.l4lb.thisdcos.directory:126");
 

--- a/tests/pages/services/ServiceDetail-cy.js
+++ b/tests/pages/services/ServiceDetail-cy.js
@@ -85,66 +85,33 @@ describe("Service Detail Page", function() {
           .contains("Endpoints")
           .click();
 
-        cy.get("h1.configuration-map-heading")
-          .contains("124")
-          .should("exist");
+        cy.get("h1.configuration-map-heading").contains("124");
 
-        cy.get(".configuration-map-label")
-          .contains("Protocol")
-          .should("exist");
-        cy.get(".configuration-map-label")
-          .contains("Protocol")
-          .next(".configuration-map-value")
-          .contains("tcp")
-          .should("exist");
+        cy.get(".table-row")
+          .should("contain", "Protocol")
+          .and("contain", "tcp");
 
-        cy.get(".configuration-map-label")
-          .contains("Container Port")
-          .should("exist");
-        cy.get(".configuration-map-label")
-          .contains("Container Port")
-          .next(".configuration-map-value")
-          .contains("—")
-          .should("exist");
+        cy.get(".table-row")
+          .should("contain", "Container Port")
+          .and("contain", "-");
 
-        cy.get(".configuration-map-label")
-          .contains("Host Port")
-          .should("exist");
-        cy.get(".configuration-map-label")
-          .contains("Host Port")
-          .next(".configuration-map-value")
-          .contains("Auto Assigned")
-          .should("exist");
+        cy.get(".table-row")
+          .should("contain", "Host Port")
+          .and("contain", "Auto Assigned");
 
-        cy.get(".configuration-map-label")
-          .contains("Service Port")
-          .should("exist");
-        cy.get(".configuration-map-label")
-          .contains("Service Port")
-          .next(".configuration-map-value")
-          .contains("—")
-          .should("exist");
+        cy.get(".table-row")
+          .should("contain", "Service Port")
+          .and("contain", "-");
 
-        cy.get(".configuration-map-label")
-          .contains("Load Balanced Address")
-          .should("exist");
-        cy.get(".configuration-map-label")
-          .contains("Load Balanced Address")
-          .next(".configuration-map-value")
-          .contains("new-service-1.marathon.l4lb.thisdcos.directory:126")
-          .should("exist");
+        cy.get(".table-row")
+          .should("contain", "Load Balanced Address")
+          .and("contain", "new-service-1.marathon.l4lb.thisdcos.directory:126");
 
-        cy.get("h1.configuration-map-heading")
-          .contains("Web Endpoints")
-          .should("exist");
-        cy.get(".configuration-map-label")
-          .contains("Web URL")
-          .should("exist");
-        cy.get(".configuration-map-label")
-          .contains("Web URL")
-          .next(".configuration-map-value")
-          .contains("http://localhost:4200/service/undefined/web-path")
-          .should("exist");
+        cy.get("h1.configuration-map-heading").contains("Web Endpoints");
+
+        cy.get(".table-row")
+          .should("contain", "Web URL")
+          .and("contain", "http://localhost:4200/service/undefined/web-path");
       });
 
       it("shows volumes tab when clicked", function() {


### PR DESCRIPTION
This adds the weburl from a service to the endpoints tab as a click to copy function

CLOSES DCOS-57645

## Testing

Start a  package with a frontend (marathon) for example.
visit the endpoints tab on the detail page and check if the url is present there.

## Trade-offs

N/A

## Dependencies

N/A

## Screenshots

![image](https://user-images.githubusercontent.com/156010/63169438-1fc13200-c037-11e9-87b2-0d685b999984.png)


