### PR TITLE
DCOS-49193: fix blurry dialog modals on lo-res screens

### DIFF
--- a/src/styles/components/modal/styles.less
+++ b/src/styles/components/modal/styles.less
@@ -1,5 +1,23 @@
 & when (@modal-enabled) {
 
+  // using flexbox for centering fixes the blurry subpixel 
+  // rendering of dialog modals on low resolution screens
+  .modal-wrapper {
+    align-items: center;
+    bottom: 0;
+    display: flex;
+    justify-content: center;
+    left: 0;
+    right: 0;
+    top: 0;
+  }
+
+  // part of the flexbox centering fix
+  .modal-small {
+    position: unset !important;
+    transform: none !important;
+  }
+
   .modal {
     // We need the extra specificity here, so we have to nest.
     .modal-header,


### PR DESCRIPTION
## Testing
This only happens on low-resolution screens, so test this on an external monitor if you use a Macbook Pro or some other high-end machine.

1. Open up a dialog modal (for example: the "Repositories" modal under Settings > Package Repositories)
2. Confirm the text and text input borders aren't blurry
3. Click around to other dialog modals and confirm they don't look blurry either

## Trade-offs
The fix is a little hacky to avoid having to do a CNVS upgrade

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots
**Before**
![BlurryModal_before](https://user-images.githubusercontent.com/2313998/63358368-eb9c8880-c338-11e9-9d42-0c6cece1fa63.png)

**After**
![BlurryModal_after](https://user-images.githubusercontent.com/2313998/63358375-edfee280-c338-11e9-851c-c809b541a712.png)
