### PR TITLE
Close stop job run modal

### DIFF
--- a/plugins/jobs/src/js/pages/JobRunHistoryTable.js
+++ b/plugins/jobs/src/js/pages/JobRunHistoryTable.js
@@ -67,7 +67,6 @@ class JobRunHistoryTable extends React.Component {
 
     this.state = {
       selectedID: null,
-      isStopRunModalShown: null,
       mesosStateStoreLoaded: false
     };
 
@@ -81,11 +80,11 @@ class JobRunHistoryTable extends React.Component {
   }
 
   handleItemSelect(id) {
-    this.setState({ isStopRunModalShown: true, selectedID: id });
+    this.setState({ selectedID: id });
   }
 
   handleStopJobRunModalClose() {
-    this.setState({ isStopRunModalShown: false });
+    this.setState({ selectedID: null });
   }
 
   getColumnHeading(prop, order, sortBy) {

--- a/tests/pages/jobs/JobDetails-cy.js
+++ b/tests/pages/jobs/JobDetails-cy.js
@@ -120,6 +120,17 @@ describe("Job Details", function() {
         "You are about to stop the job run with id"
       );
     });
+
+    it("Closes the stop job run modal", function() {
+      cy.get(".actions-dropdown").click();
+      cy.get(".dropdown-menu-items")
+        .contains("Stop")
+        .click();
+      cy.get(".button-primary-link")
+        .contains("Cancel")
+        .click();
+      cy.get(".modal-small").should("not.exist");
+    });
   });
 
   context("Configuration Tab", function() {


### PR DESCRIPTION
## Testing
1. Go to jobs tab.
2. Create a long-running job, for example:
```
{
  "id": "new-job-1",
  "run": {
    "cpus": 1,
    "mem": 128,
    "disk": 0,
    "gpus": 0,
    "cmd": "sleep 1000",
    "artifacts": [],
    "maxLaunchDelay": 3600,
    "restart": {
      "policy": "NEVER"
    },
    "ucr": {
      "image": {
        "id": "nginx",
        "kind": "docker",
        "forcePull": false
      },
      "privileged": false
    }
  },
  "schedules": []
}
```
3. Click it and start it at least once.
4. Open the stop job run modal from the actions dropdown.
5. Verify that the modal can be closed by either clicking on the "Cancel" button or outside the modal.

## Trade-offs
None.

## Dependencies
None.

## Screenshots
![Peek 2019-08-27 12-55](https://user-images.githubusercontent.com/40791275/63762176-0d62b600-c8cb-11e9-9d30-f35ce760b2bb.gif)

