### PR TITLE
DCOS-58031 show a warning for packages with known issues

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -872,6 +872,7 @@
   "This host port will be accessible as an environment variable called '$PORT{index}'. <0>More information</0>.": "",
   "This host port will be accessible as an environment variable called {environmentVariableName}. <0>More information</0>.": "",
   "This package can only be installed using the CLI. See the <0>documentation</0>.": "",
+  "This package is known to have issues when started with its default settings.": "",
   "This port will be used to load balance this service address internally": "",
   "This repository": "",
   "This service cannot run without the {dependency} package. Please run <0>{dependency} package</0> to enable this service.": "",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -872,6 +872,7 @@
   "This host port will be accessible as an environment variable called '$PORT{index}'. <0>More information</0>.": "此主机端口可以作为一个名为 '$PORT{index}' 的环境变量进行访问。<0>更多信息</0>.",
   "This host port will be accessible as an environment variable called {environmentVariableName}. <0>More information</0>.": "此主机端口可以作为一个名为 {environmentVariableName} 的环境变量进行访问。<0>更多信息</0>.",
   "This package can only be installed using the CLI. See the <0>documentation</0>.": "此包仅可使用 CLI 进行安装。查看 <0>文档</0>.",
+  "This package is known to have issues when started with its default settings.": "",
   "This port will be used to load balance this service address internally": "此端口将用于在内部负载均衡此服务地址",
   "This repository": "此存储库",
   "This service cannot run without the {dependency} package. Please run <0>{dependency} package</0> to enable this service.": "没有 {dependency} 包，此服务无法运行。请运行 <0>{dependency} 包，</0> 以启用此服务。",

--- a/src/js/__tests__/__snapshots__/tslint-test.ts.snap
+++ b/src/js/__tests__/__snapshots__/tslint-test.ts.snap
@@ -1261,18 +1261,21 @@ exports[`tslint snapshot should be up to date 1`] = `
 /src/js/pages/catalog/PackageDetailTab.tsx - Multiline JS expressions inside JSX are forbidden
 /src/js/pages/catalog/PackageDetailTab.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
 /src/js/pages/catalog/PackageDetailTab.tsx - require statement not part of an import statement
-/src/js/pages/catalog/PackageDetailTab.tsx - Multiline JSX elements must be wrapped in parentheses
-/src/js/pages/catalog/PackageDetailTab.tsx - Multiline JS expressions inside JSX are forbidden
-/src/js/pages/catalog/PackageDetailTab.tsx - Multiline JSX elements must be wrapped in parentheses
-/src/js/pages/catalog/PackageDetailTab.tsx - Multiline JS expressions inside JSX are forbidden
 /src/js/pages/catalog/PackageDetailTab.tsx - Multiline JS expressions inside JSX are forbidden
 /src/js/pages/catalog/PackageDetailTab.tsx - Multiline JSX elements must be wrapped in parentheses
 /src/js/pages/catalog/PackageDetailTab.tsx - Multiline JS expressions inside JSX are forbidden
 /src/js/pages/catalog/PackageDetailTab.tsx - Multiline JSX elements must be wrapped in parentheses
 /src/js/pages/catalog/PackageDetailTab.tsx - Multiline JS expressions inside JSX are forbidden
+/src/js/pages/catalog/PackageDetailTab.tsx - Multiline JSX elements must be wrapped in parentheses
+/src/js/pages/catalog/PackageDetailTab.tsx - Multiline JS expressions inside JSX are forbidden
+/src/js/pages/catalog/PackageDetailTab.tsx - Multiline JS expressions inside JSX are forbidden
+/src/js/pages/catalog/PackageDetailTab.tsx - Multiline JSX elements must be wrapped in parentheses
 /src/js/pages/catalog/PackageDetailTab.tsx - Multiline JS expressions inside JSX are forbidden
 /src/js/pages/catalog/PackageDetailTab.tsx - Multiline JS expressions inside JSX are forbidden
 /src/js/pages/catalog/PackageDetailTab.tsx - Multiline JS expressions inside JSX are forbidden
+/src/js/pages/catalog/PackageDetailTab.tsx - Multiline JS expressions inside JSX are forbidden
+/src/js/pages/catalog/PackageDetailTab.tsx - Multiline JS expressions inside JSX are forbidden
+/src/js/pages/catalog/PackageDetailTab.tsx - Multiline JSX elements must be wrapped in parentheses
 /src/js/pages/catalog/PackageDetailTab.tsx - Multiline JS expressions inside JSX are forbidden
 /src/js/pages/catalog/PackageDetailTab.tsx - Shadowed name: 'dependency'
 /src/js/pages/catalog/PackageDetailTab.tsx - Multiline JS expressions inside JSX are forbidden

--- a/src/js/__tests__/__snapshots__/typecheck-test.ts.snap
+++ b/src/js/__tests__/__snapshots__/typecheck-test.ts.snap
@@ -4471,28 +4471,30 @@ src/js/pages/catalog/DeployFrameworkConfiguration.tsx: error TS6133: 'version' i
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'location' does not exist on type 'Global'.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS7030: Not all code paths return a value.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
-src/js/pages/catalog/PackageDetailTab.tsx: error TS2307: Cannot find module '#PLUGINS/services/src/img/icon-service-default-large@2x.png'.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2605: JSX element type 'Badge' is not a constructor function for JSX elements.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2607: JSX element class does not support attributes because it does not have a 'props' property.
+src/js/pages/catalog/PackageDetailTab.tsx: error TS2307: Cannot find module '#PLUGINS/services/src/img/icon-service-default-large@2x.png'.
+src/js/pages/catalog/PackageDetailTab.tsx: error TS2531: Object is possibly 'null'.
+src/js/pages/catalog/PackageDetailTab.tsx: error TS2531: Object is possibly 'null'.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'key' does not exist on type 'never'.
-src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'value' does not exist on type 'never'.
-src/js/pages/catalog/PackageDetailTab.tsx: error TS2531: Object is possibly 'null'.
-src/js/pages/catalog/PackageDetailTab.tsx: error TS2531: Object is possibly 'null'.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2769: No overload matches this call.
+src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'value' does not exist on type 'never'.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2605: JSX element type 'ImageViewer' is not a constructor function for JSX elements.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2607: JSX element class does not support attributes because it does not have a 'props' property.
-src/js/pages/catalog/PackageDetailTab.tsx: error TS2322: Type '{ children: Element; key: number; title: string; }' is not assignable to type 'IntrinsicAttributes & Pick<InferProps<{ isCaret: Requireable<boolean>; isIcon: Requireable<boolean>; title: Validator<string>; }>, \\"title\\"> & Partial<...> & Partial<...>'.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'location' does not exist on type 'Global'.
-src/js/pages/catalog/PackageDetailTab.tsx: error TS2322: Type '{ children: false | Element; key: number; title: any; }' is not assignable to type 'IntrinsicAttributes & Pick<InferProps<{ isCaret: Requireable<boolean>; isIcon: Requireable<boolean>; title: Validator<string>; }>, \\"title\\"> & Partial<...> & Partial<...>'.
+src/js/pages/catalog/PackageDetailTab.tsx: error TS2322: Type '{ children: Element; key: number; title: string; }' is not assignable to type 'IntrinsicAttributes & Pick<InferProps<{ isCaret: Requireable<boolean>; isIcon: Requireable<boolean>; title: Validator<string>; }>, \\"title\\"> & Partial<...> & Partial<...>'.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2605: JSX element type 'Loader' is not a constructor function for JSX elements.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2322: Type '{ __html: any; } | null' is not assignable to type 'null'.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2531: Object is possibly 'null'.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2531: Object is possibly 'null'.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2322: Type '{ __html: any; } | null' is not assignable to type '{ __html: string; } | undefined'.
-src/js/pages/catalog/PackageDetailTab.tsx: error TS2322: Type '{ children: any; to: string; query: { version: any; }; key: number; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<LinkProps, any, any>> & Readonly<LinkProps> & Readonly<...>'.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2322: Type 'null' is not assignable to type '{ __html: string; } | undefined'.
+src/js/pages/catalog/PackageDetailTab.tsx: error TS2322: Type '{ children: false | Element; key: number; title: any; }' is not assignable to type 'IntrinsicAttributes & Pick<InferProps<{ isCaret: Requireable<boolean>; isIcon: Requireable<boolean>; title: Validator<string>; }>, \\"title\\"> & Partial<...> & Partial<...>'.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2605: JSX element type 'Image' is not a constructor function for JSX elements.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2607: JSX element class does not support attributes because it does not have a 'props' property.
+src/js/pages/catalog/PackageDetailTab.tsx: error TS2605: JSX element type 'Tooltip' is not a constructor function for JSX elements.
+src/js/pages/catalog/PackageDetailTab.tsx: error TS2607: JSX element class does not support attributes because it does not have a 'props' property.
+src/js/pages/catalog/PackageDetailTab.tsx: error TS2322: Type '{ children: any; to: string; query: { version: any; }; key: number; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<LinkProps, any, any>> & Readonly<LinkProps> & Readonly<...>'.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2605: JSX element type 'Loader' is not a constructor function for JSX elements.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2605: JSX element type 'Loader' is not a constructor function for JSX elements.
 src/js/pages/catalog/PackagesTab.tsx: error TS2605: JSX element type 'CosmosErrorMessage' is not a constructor function for JSX elements.

--- a/src/js/pages/catalog/PackageDetailTab.tsx
+++ b/src/js/pages/catalog/PackageDetailTab.tsx
@@ -5,11 +5,18 @@ import mixin from "reactjs-mixin";
 import { Link, routerShape } from "react-router";
 import * as React from "react";
 import { Dropdown, Tooltip, Modal, Confirm } from "reactjs-components";
-import { Badge, Icon, InfoBoxInline } from "@dcos/ui-kit";
+import {
+  Badge,
+  Box,
+  Icon,
+  InfoBoxInline,
+  Tooltip as UIKitTooltip
+} from "@dcos/ui-kit";
 import { SystemIcons } from "@dcos/ui-kit/dist/packages/icons/dist/system-icons-enum";
 import { ProductIcons } from "@dcos/ui-kit/dist/packages/icons/dist/product-icons-enum";
 import {
   green,
+  red,
   iconSizeL,
   iconSizeXs
 } from "@dcos/ui-kit/dist/packages/design-tokens/build/js/designTokens";
@@ -626,7 +633,27 @@ class PackageDetailTab extends mixin(StoreMixin) {
                   </div>
                   {!state.isLoadingSelectedVersion && (
                     <div className="media-object-item media-object-item-grow ">
-                      <h1 className="short flush-top flush-bottom">{name}</h1>
+                      <h1 className="short flush-top flush-bottom">
+                        {cosmosPackage.getHasKnownIssues() ? (
+                          <Box display="inline-block">
+                            <UIKitTooltip
+                              id="has-known-issues"
+                              preferredDirections={["top-left"]}
+                              trigger={
+                                <span>
+                                  <Icon color={red} shape={SystemIcons.Yield} />
+                                </span>
+                              }
+                            >
+                              <Trans render="span">
+                                This package is known to have issues when
+                                started with its default settings.
+                              </Trans>
+                            </UIKitTooltip>{" "}
+                          </Box>
+                        ) : null}
+                        {name}
+                      </h1>
                       <div className="flex flex-align-items-center">
                         <span className="package-version-label">
                           <Trans>Version</Trans>:

--- a/src/js/structs/UniversePackage.ts
+++ b/src/js/structs/UniversePackage.ts
@@ -25,6 +25,10 @@ class UniversePackage extends Item {
     );
   }
 
+  getHasKnownIssues() {
+    return this.get("hasKnownIssues");
+  }
+
   getName() {
     return this.get("name");
   }

--- a/tests/_fixtures/cosmos/community-package-describe.json
+++ b/tests/_fixtures/cosmos/community-package-describe.json
@@ -6,16 +6,14 @@
     "releaseVersion": 10,
     "maintainer": "support@mesosphere.io",
     "description": "A container orchestration platform for Mesos and DCOS. Documentation: https://docs.mesosphere.com/1.11/deploying-services/marathon-api/",
-    "tags": [
-      "init",
-      "long-running"
-    ],
+    "tags": ["init", "long-running"],
     "selected": false,
     "scm": "https://github.com/mesosphere/marathon.git",
     "framework": true,
     "preInstallNotes": "We recommend a minimum of one node with at least 2 CPU shares and 1GB of RAM available for the Marathon DCOS Service. More information: https://mesosphere.github.io/marathon/",
     "postInstallNotes": "Marathon DCOS Service has been successfully installed!\n\n\tDocumentation: https://mesosphere.github.io/marathon\n\tIssues: https://github.com/mesosphere/marathon/issues\n",
     "postUninstallNotes": "The Marathon DCOS Service has been uninstalled and will no longer run.\nPlease follow the instructions at http://docs.mesosphere.com/services/marathon/#uninstall to clean up any persisted state",
+    "hasKnownIssues": true,
     "licenses": [
       {
         "name": "Apache License Version 2.0",
@@ -95,9 +93,7 @@
               "type": "integer"
             },
             "uris": {
-              "default": [
-
-              ],
+              "default": [],
               "description": "List of URIs that will be downloaded and made available in the current working directory of Marathon. For example this can be used to download a Java keystore file for SSL configuration.",
               "items": {
                 "pattern": "^[\\s]+",
@@ -122,11 +118,7 @@
               "default": "[]"
             }
           },
-          "required": [
-            "cpus",
-            "mem",
-            "instances"
-          ],
+          "required": ["cpus", "mem", "instances"],
           "type": "object"
         },
         "jvm": {
@@ -150,10 +142,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "heap-min",
-            "heap-max"
-          ],
+          "required": ["heap-min", "heap-max"],
           "type": "object"
         },
         "marathon": {
@@ -528,17 +517,11 @@
               "default": 10000
             }
           },
-          "required": [
-            "master"
-          ],
+          "required": ["master"],
           "type": "object"
         }
       },
-      "required": [
-        "service",
-        "jvm",
-        "marathon"
-      ],
+      "required": ["service", "jvm", "marathon"],
       "type": "object"
     }
   }

--- a/tests/pages/catalog/packages/package/PackageTab-cy.js
+++ b/tests/pages/catalog/packages/package/PackageTab-cy.js
@@ -121,6 +121,11 @@ describe("Package Detail Tab", () => {
       cy.get(".modal-full-screen-header-title").contains("Edit Configuration");
     });
 
+    it("Does not shows a knownIssues-warning ", () => {
+      cy.get("h1").contains("marathon");
+      cy.get("[aria-describedby=has-known-issues]").should("not.exist");
+    });
+
     context("Unmet dependency", () => {
       beforeEach(() => {
         cy.configureCluster({
@@ -172,6 +177,9 @@ describe("Package Detail Tab", () => {
         cy.get(".modal-full-screen-header-title").contains(
           "Edit Configuration"
         );
+      });
+      it("Shows a warning in case the package is known to have issues", () => {
+        cy.get("[aria-describedby=has-known-issues]");
       });
     });
 


### PR DESCRIPTION
We now have an icon (with a tooltip) indicating that a package has known issues.

`/package/describe` will get new fields in the future to indicate that a package has issues. the implementation in this PR currently assumes that there will be a boolean flag `hasKnownIssues` and is blocked until DataServices decided on an exact implementation.

![dcos-ui 2019-08-28 12-41-20](https://user-images.githubusercontent.com/300861/63848928-2df54380-c991-11e9-9898-d573d8ffff8c.png)

Closes DCOS-58031