### PR TITLE
enable xterm for ee

### DIFF
--- a/scripts/utils/test
+++ b/scripts/utils/test
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEBUG_DIRECTIVE_PATTERN="(f(it|describe)|(it|describe|test|context)\.only)\("
+DEBUG_DIRECTIVE_PATTERN="((it|describe|test|context)\.only)\("
 
 # Example: find_debug_directives ./test src/js/components/__tests__/Component-test.js
 find_debug_directives(){
@@ -25,4 +25,3 @@ find_files_with_debug_directives(){
 
   grep -E -l --recursive ${DEBUG_DIRECTIVE_PATTERN} "$@"
 }
-


### PR DESCRIPTION
we want to call `xterm.fit()` for the debug terminal. unfortunately this thing
here complains about `fit` being a debug-directive.

this is rather a quickfix making use of the fact the jest does not even have
`fit` or `fdescribe` but goes with `.only`


see https://github.com/mesosphere/dcos-ui-plugins-private/pull/914
