### PR TITLE
DCOS_OSS-5510: use getRootGroupName not getRole

### DIFF
--- a/plugins/services/src/js/columns/QuotaOverviewLimitColumn.tsx
+++ b/plugins/services/src/js/columns/QuotaOverviewLimitColumn.tsx
@@ -119,8 +119,7 @@ export function getLimitInfoForService(
     return getLimitInfoForPod(item);
   }
 
-  const groupName =
-    item instanceof ServiceTree ? item.getRootGroupName() : item.getRole();
+  const groupName = item.getRootGroupName();
   const stats = item.getQuotaRoleStats(groupName);
 
   return {


### PR DESCRIPTION
- Closes DCOS_OSS-5510

## Testing

1. Create a group with "Use Legacy Role"
2. Assign quota to group
3. Create service inside group
4. navigate to group's quota page
5. verify service quota limit status displays "Not Enforced"

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
