### PR TITLE
update setup-docs and remove obsolete helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,11 @@ DC/OS UI comes bundled with some internal plugins within the `/plugins` director
 # for dcos-ui-plugins-private
 npm config set externalplugins ./plugins-ee
 
-# to simplify development of external plugins and enable automated translation catalog extraction
-npm run util:env:link-externalplugins
-
 # for your own plugins
 npm config set externalplugins ../path/to/plugins
 ```
 
-Note that `dcos-ui-plugins-private` currently _must_ be set up at `./plugins-ee` for CI and all tooling to work. You also might want to copy its `Config.template.js` to `src/js/config/Config.dev.ts` to enable the enterprise edition.
+Note that `dcos-ui-plugins-private` currently _must_ be cloned to `./plugins-ee` for CI and all tooling to work. You also might want to copy its `Config.template.js` to `src/js/config/Config.dev.ts` to enable the enterprise edition.
 
 5.  Start the development server:
 

--- a/package.json
+++ b/package.json
@@ -227,8 +227,6 @@
     "test:validate": "PLUGINS_PATH=\"${npm_config_externalplugins}\" ./scripts/validate-tests",
     "test:watch": "npm test -- --watch",
     "test": "./scripts/lingui-compile && NODE_PATH=node_modules jest --config=jest.config.js --no-cache",
-    "util:env:link-externalplugins": "test -L ./plugins-ee || ln -s \"${npm_config_externalplugins}\" ./plugins-ee",
-    "util:env:unlink-externalplugins": "unlink plugins-ee",
     "util:env:validate": "node ./scripts/validate-engine-versions.js",
     "util:lingui:extract": "./scripts/lingui-extract",
     "util:lingui:compile": "./scripts/lingui-compile",


### PR DESCRIPTION
with directly cloning plugins-private to ./plugins-ee, we save a bit of
complexity and duplicated config-files. i see no apparent tradeoff (having worked for a couple weeks with this setup now).