### PR TITLE
fix: don't error on pageNotFound

### DIFF
--- a/src/js/components/ClusterHeader.js
+++ b/src/js/components/ClusterHeader.js
@@ -16,6 +16,11 @@ import ClusterDropdown from "./ClusterDropdown";
 
 const METHODS_TO_BIND = ["handleItemSelect", "handleTextCopy"];
 
+MountService.MountService.registerComponent(
+  ClusterDropdown,
+  "Header:ClusterDropdown"
+);
+
 export default class ClusterHeader extends mixin(StoreMixin) {
   constructor() {
     super(...arguments);
@@ -40,18 +45,6 @@ export default class ClusterHeader extends mixin(StoreMixin) {
     METHODS_TO_BIND.forEach(method => {
       this[method] = this[method].bind(this);
     });
-
-    MountService.MountService.registerComponent(
-      ClusterDropdown,
-      "Header:ClusterDropdown"
-    );
-  }
-
-  componentWillUnmount() {
-    MountService.MountService.unregisterComponent(
-      ClusterDropdown,
-      "Header:ClusterDropdown"
-    );
   }
 
   getClusterName() {


### PR DESCRIPTION
problem: navigate `http://localhost:4200/#/dashboard123` and see the app crashing.

fix: not registering things multiple times on the MountService. it looks like this was the only place we chose to dynamically register a component and relied on the header only being instantiated once.

TODO: follow up with an integration test, making sure PageNotFound is correctly rendered when a page is not found...