### PR TITLE
fix: "Allocated" min widths on services table

### DIFF
--- a/plugins/services/src/js/containers/services/ServicesTable.tsx
+++ b/plugins/services/src/js/containers/services/ServicesTable.tsx
@@ -480,12 +480,12 @@ class ServicesTable extends React.Component {
             minWidth={
               TableUtil.isColWidthCustom(columnWidthsStorageKey, "cpu")
                 ? undefined
-                : 70
+                : 135
             }
             maxWidth={
               TableUtil.isColWidthCustom(columnWidthsStorageKey, "cpu")
                 ? undefined
-                : 100
+                : 150
             }
             growToFill={
               !TableUtil.isColWidthCustom(columnWidthsStorageKey, "cpu")
@@ -515,12 +515,12 @@ class ServicesTable extends React.Component {
             minWidth={
               TableUtil.isColWidthCustom(columnWidthsStorageKey, "mem")
                 ? undefined
-                : 120
+                : 140
             }
             maxWidth={
               TableUtil.isColWidthCustom(columnWidthsStorageKey, "mem")
                 ? undefined
-                : 150
+                : 155
             }
             resizable={true}
             onResize={this.handleResize.bind(null, "mem")}
@@ -547,12 +547,12 @@ class ServicesTable extends React.Component {
             minWidth={
               TableUtil.isColWidthCustom(columnWidthsStorageKey, "disk")
                 ? undefined
-                : 100
+                : 140
             }
             maxWidth={
               TableUtil.isColWidthCustom(columnWidthsStorageKey, "disk")
                 ? undefined
-                : 120
+                : 150
             }
             resizable={true}
             onResize={this.handleResize.bind(null, "disk")}
@@ -579,12 +579,12 @@ class ServicesTable extends React.Component {
             minWidth={
               TableUtil.isColWidthCustom(columnWidthsStorageKey, "gpu")
                 ? undefined
-                : 50
+                : 135
             }
             maxWidth={
               TableUtil.isColWidthCustom(columnWidthsStorageKey, "gpu")
                 ? undefined
-                : 70
+                : 135
             }
             resizable={true}
             onResize={this.handleResize.bind(null, "gpu")}

--- a/tests/pages/services/GroupCreate-cy.js
+++ b/tests/pages/services/GroupCreate-cy.js
@@ -9,10 +9,13 @@ describe("Group Modals", () => {
     cy.get(".form-control-group-add-on")
       .eq(-1)
       .click(); // close filter window
-    cy.get(".ReactVirtualized__Grid")
-      .eq(-1) // bottom right grid
-      .scrollTo("right"); // scroll to the actions column
-    cy.get(".actions-dropdown").should("not.to.have.length", 0);
+
+    // scrolling right several times, as we (or react virtualized) seem to change the width of the table while scrolling as of today
+    for (const i of [1, 2, 3]) {
+      cy.get(".ReactVirtualized__Grid")
+        .eq(-1) // bottom right grid
+        .scrollTo("right", { duration: i * 200 }); // scroll to the actions column
+    }
     cy.get(".actions-dropdown")
       .eq(0)
       .click();

--- a/tests/pages/services/ServiceTable-cy.js
+++ b/tests/pages/services/ServiceTable-cy.js
@@ -10,9 +10,12 @@ describe("Service Table", () => {
     cy.get(".form-control-group-add-on")
       .eq(-1)
       .click(); // close filter window
-    cy.get(".ReactVirtualized__Grid")
-      .eq(-1) // bottom right grid
-      .scrollTo("right"); // scroll to the actions column
+    // scrolling right several times, as we (or react virtualized) seem to change the width of the table while scrolling as of today
+    for (const i of [1, 2, 3]) {
+      cy.get(".ReactVirtualized__Grid")
+        .eq(-1) // bottom right grid
+        .scrollTo("right", { duration: i * 200 }); // scroll to the actions column
+    }
     cy.get(".actions-dropdown").should("not.to.have.length", 0);
     cy.get(".actions-dropdown")
       .eq(0)


### PR DESCRIPTION
## Overview

Services table columns were being unfortunately truncated. I increased their min width

<details><summary>Before</summary>

<img width="1172" alt="Screen Shot 2019-08-30 at 3 08 19 PM" src="https://user-images.githubusercontent.com/174332/64051354-0c828c00-cb38-11e9-9b14-357d92d72943.png">
</details>

<details><summary>After</summary>
<img width="1148" alt="Screen Shot 2019-08-30 at 3 07 06 PM" src="https://user-images.githubusercontent.com/174332/64051390-2b811e00-cb38-11e9-92e7-9327373d0a90.png">
</details>


