### PR TITLE
[GA BLOCKER] DCOS-58445: Replace the "plus icon" dropdown with two separate dropdowns

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+**/*.less
+locale/en/messages.json
+locale/zh/messages.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -735,7 +735,7 @@
     "@dcos/copychars": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@dcos/copychars/-/copychars-0.1.2.tgz",
-      "integrity": "sha512-lS8hkmBZHf9f7JTJfCBtJ8n/WGyl5471J4hkIyzUihHwQHAx2+nbTMH4d3EudGD1Zrdi8YyAADyrjSQ6tQy2Uw=="
+      "integrity": "sha1-wpx1n+btFAaJMktSfLTW+6txCQs="
     },
     "@dcos/data-service": {
       "version": "2.0.0",
@@ -834,9 +834,9 @@
       "integrity": "sha512-inJlb0Idr6frKKVJNweG4t3BUbrvfSPhtwTuMzjLIUjSjEzu+/bNmSb4FrZcSfOGW9KCsvWY2pP4HMaoKzu86g=="
     },
     "@dcos/ui-kit": {
-      "version": "3.33.0",
-      "resolved": "https://registry.npmjs.org/@dcos/ui-kit/-/ui-kit-3.33.0.tgz",
-      "integrity": "sha512-Adgycc67zj+NFZlW/TqaZ9AuTJl8Gvd9MBASGVfs2LNPsE8Drq/3t477csia5PWyOK1ADulbJoXfTaHLBqflDg==",
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/@dcos/ui-kit/-/ui-kit-3.39.0.tgz",
+      "integrity": "sha512-/nvH+dPhk0z7iyELJRt1D2srkSaIvvPiqNdFQbjZ+23LtrA3iAHSoi0zdS0Qh0QK+j+M+rCd9KsERjGjLhmNsw==",
       "requires": {
         "@types/chartist": "^0.9.46",
         "@types/react-tabs": "^2.3.1",
@@ -856,7 +856,8 @@
         "react-toggled": "1.2.7",
         "react-transition-group": "2.5.0",
         "react-virtualized": "9.20.1",
-        "relative-luminance": "2.0.1"
+        "relative-luminance": "2.0.1",
+        "shortid": "2.2.14"
       },
       "dependencies": {
         "immutable": {
@@ -4627,7 +4628,7 @@
     },
     "bl": {
       "version": "1.2.2",
-      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "dev": true,
       "requires": {
@@ -4753,7 +4754,6 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
-      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -10669,8 +10669,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -10691,14 +10690,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10713,20 +10710,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -10843,8 +10837,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -10856,7 +10849,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -10871,7 +10863,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -10879,14 +10870,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -10905,7 +10894,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -10986,8 +10974,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -10999,7 +10986,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -11085,8 +11071,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -11122,7 +11107,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -11142,7 +11126,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -11186,14 +11169,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -12182,8 +12163,7 @@
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "hoist-non-react-statics": {
       "version": "2.5.5",
@@ -12379,7 +12359,7 @@
     },
     "html-webpack-plugin": {
       "version": "3.2.0",
-      "resolved": "http://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
       "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
       "dev": true,
       "requires": {
@@ -12857,7 +12837,7 @@
       "dependencies": {
         "colors": {
           "version": "1.0.3",
-          "resolved": "http://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
           "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
           "dev": true
         }
@@ -21590,7 +21570,7 @@
         },
         "external-editor": {
           "version": "2.2.0",
-          "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
           "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
           "dev": true,
           "requires": {
@@ -21628,7 +21608,7 @@
         },
         "node-fetch": {
           "version": "1.6.3",
-          "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
           "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
           "dev": true,
           "requires": {
@@ -25102,13 +25082,6 @@
       "requires": {
         "classnames": "^2.2.5",
         "prop-types": "^15.6.0"
-      },
-      "dependencies": {
-        "classnames": {
-          "version": "2.2.6",
-          "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-          "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
-        }
       }
     },
     "react-emotion": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@dcos/http-service": "2.3.1",
     "@dcos/mesos-client": "1.0.0",
     "@dcos/tslint-config": "0.1.1",
-    "@dcos/ui-kit": "3.33.0",
+    "@dcos/ui-kit": "3.39.0",
     "@extension-kid/core": "0.2.4",
     "@lingui/react": "2.8.3",
     "array-sort": "1.0.0",

--- a/plugins/services/src/js/containers/services/ServicesQuotaView.tsx
+++ b/plugins/services/src/js/containers/services/ServicesQuotaView.tsx
@@ -2,11 +2,19 @@ import PropTypes from "prop-types";
 import React from "react";
 import { routerShape } from "react-router";
 import { i18nMark } from "@lingui/react";
+import { Trans } from "@lingui/macro";
+import {
+  DropdownMenu,
+  DropdownSection,
+  DropdownMenuItem,
+  PrimaryDropdownButton
+} from "@dcos/ui-kit";
+import { SystemIcons } from "@dcos/ui-kit/dist/packages/icons/dist/system-icons-enum";
 
 import Page, { Header } from "#SRC/js/components/Page";
-//@ts-ignore
+// @ts-ignore
 import DeploymentStatusIndicator from "../../components/DeploymentStatusIndicator";
-//@ts-ignore
+// @ts-ignore
 import ServiceBreadcrumbs from "../../components/ServiceBreadcrumbs";
 import ServicesQuotaOverview from "../../components/ServicesQuotaOverview";
 import ServicesQuotaOverviewDetail from "../../components/ServicesQuotaOverviewDetail";
@@ -58,53 +66,90 @@ class ServicesQuotaView extends React.Component<ServicesQuotaViewProps, {}> {
     const tabs = this.getTabs();
     const id: string = serviceTree.getId();
     const isRoot = serviceTree.isRoot();
-    const createService = () => {
-      isRoot
-        ? this.context.router.push("/services/overview/create")
-        : this.context.router.push(
-            "/services/overview/" +
-              encodeURIComponent(serviceTree.getId()) +
-              "/create"
-          );
-    };
+
     const content = isRoot ? (
       <ServicesQuotaOverview />
     ) : (
       <ServicesQuotaOverviewDetail serviceTree={serviceTree} id={id} />
     );
-    let createGroup;
-    if (isRoot) {
-      createGroup = () => {
-        this.context.router.push("/services/overview/create_group");
-      };
-    } else {
-      createGroup = modalHandlers.createGroup;
-    }
-    const editGroupAction = {
-      onItemSelect: () => {
-        this.context.router.push(
-          `/services/detail/${encodeURIComponent(serviceTree.getId())}/edit/`
-        );
-      },
-      label: i18nMark("Edit Group")
+    const onAddSelectRoot = (selectedItem: string) => {
+      switch (selectedItem) {
+        case "runService":
+          this.context.router.push("/services/overview/create");
+          break;
+        case "createGroup":
+          this.context.router.push("/services/overview/create_group");
+          break;
+        default:
+          break;
+      }
     };
+
+    const onAddSelectTree = (selectedItem: string) => {
+      switch (selectedItem) {
+        case "runService":
+          this.context.router.push(
+            "/services/overview/" +
+              encodeURIComponent(serviceTree.getId()) +
+              "/create"
+          );
+          break;
+        case "createGroup":
+          modalHandlers.createGroup();
+          break;
+        default:
+          break;
+      }
+    };
+
+    const onEditSelect = () => {
+      this.context.router.push(
+        `/services/detail/${encodeURIComponent(serviceTree.getId())}/edit/`
+      );
+    };
+
+    const actionMenu = (
+      <React.Fragment>
+        <DropdownMenu
+          trigger={
+            <PrimaryDropdownButton iconStart={SystemIcons.Plus}>
+              <Trans render="span">New</Trans>
+            </PrimaryDropdownButton>
+          }
+          onSelect={isRoot ? onAddSelectRoot : onAddSelectTree}
+        >
+          <DropdownSection>
+            <DropdownMenuItem key="runService" value="runService">
+              <Trans render="span">Run a Service</Trans>
+            </DropdownMenuItem>
+            <DropdownMenuItem key="createGroup" value="createGroup">
+              <Trans render="span">Create Group</Trans>
+            </DropdownMenuItem>
+          </DropdownSection>
+        </DropdownMenu>
+      </React.Fragment>
+    );
 
     return (
       <Page dontScroll={false} flushBottom={true}>
         <Header
           breadcrumbs={<ServiceBreadcrumbs serviceID={id} />}
-          addButton={[
-            {
-              onItemSelect: createService,
-              label: i18nMark("Run a Service")
-            },
-            {
-              onItemSelect: createGroup,
-              label: i18nMark("Create Group")
-            },
-            ...(serviceTree.isTopLevel() ? [editGroupAction] : [])
-          ]}
-          supplementalContent={<DeploymentStatusIndicator />}
+          supplementalContent={
+            <React.Fragment>
+              <DeploymentStatusIndicator />
+              {actionMenu}
+            </React.Fragment>
+          }
+          actions={
+            serviceTree.isTopLevel()
+              ? [
+                  {
+                    onItemSelect: onEditSelect,
+                    label: i18nMark("Edit Group")
+                  }
+                ]
+              : []
+          }
           tabs={tabs}
         />
         <div className="flex-item-grow-1 flex flex-direction-top-to-bottom">

--- a/src/styles/views/services/styles.less
+++ b/src/styles/views/services/styles.less
@@ -1,4 +1,7 @@
 & when (@services-view-enabled) {
+  button[data-cy="primaryDropdownButton"] {
+    color: #fff;
+  }
 
   .modal-service-delete-force {
     cursor: pointer;
@@ -17,13 +20,9 @@
   }
 
   .services-version-select {
-
     &-toggle {
-
       .services-version-select {
-
         &-icon {
-
           &-selected {
             display: none;
           }
@@ -32,15 +31,12 @@
     }
 
     &-menu {
-
       .badge-container {
         display: inline-flex;
       }
 
       .services-version-select {
-
         &-icon {
-
           &-selected {
             visibility: hidden;
           }
@@ -48,11 +44,8 @@
       }
 
       .is-selected {
-
         .services-version-select {
-
           &-icon {
-
             &-selected {
               visibility: visible;
             }
@@ -85,7 +78,6 @@
 }
 
 .filter-tasks-bar {
-
   .filter-bar,
   .filter-bar-left,
   .filter-bar-item {
@@ -98,9 +90,7 @@
 }
 
 @media (min-width: @layout-screen-medium-min-width) {
-
   .filter-tasks-bar {
-
     .filter-bar {
       height: 70px;
       position: relative;
@@ -116,11 +106,8 @@
 }
 
 & when (@services-view-enabled) and (@layout-screen-small-enabled) {
-
   @media (min-width: @layout-screen-small-min-width) {
-
     .services-version-select {
-
       &-icon {
         margin-right: @base-spacing-unit-screen-small * 1/4;
       }
@@ -129,11 +116,8 @@
 }
 
 & when (@services-view-enabled) and (@layout-screen-medium-enabled) {
-
   @media (min-width: @layout-screen-medium-min-width) {
-
     .services-version-select {
-
       &-icon {
         margin-right: @base-spacing-unit-screen-medium * 1/4;
       }
@@ -142,15 +126,12 @@
 }
 
 & when (@services-view-enabled) and (@layout-screen-large-enabled) {
-
   @media (min-width: @layout-screen-large-min-width) {
-
     .services-sidebar {
       max-width: @service-sidebar-width-screen-large;
     }
 
     .services-version-select {
-
       &-icon {
         margin-right: @base-spacing-unit-screen-large * 1/4;
       }
@@ -159,15 +140,12 @@
 }
 
 & when (@services-view-enabled) and (@layout-screen-jumbo-enabled) {
-
   @media (min-width: @layout-screen-jumbo-min-width) {
-
     .services-sidebar {
       max-width: @service-sidebar-width-screen-jumbo;
     }
 
     .services-version-select {
-
       &-icon {
         margin-right: @base-spacing-unit-screen-jumbo * 1/4;
       }

--- a/src/styles/views/services/styles.less
+++ b/src/styles/views/services/styles.less
@@ -1,5 +1,6 @@
 & when (@services-view-enabled) {
-  button[data-cy="primaryDropdownButton"] {
+
+  button[data-cy='primaryDropdownButton'] {
     color: #fff;
   }
 
@@ -20,9 +21,13 @@
   }
 
   .services-version-select {
+
     &-toggle {
+
       .services-version-select {
+
         &-icon {
+
           &-selected {
             display: none;
           }
@@ -31,12 +36,15 @@
     }
 
     &-menu {
+
       .badge-container {
         display: inline-flex;
       }
 
       .services-version-select {
+
         &-icon {
+
           &-selected {
             visibility: hidden;
           }
@@ -44,8 +52,11 @@
       }
 
       .is-selected {
+
         .services-version-select {
+
           &-icon {
+
             &-selected {
               visibility: visible;
             }
@@ -78,6 +89,7 @@
 }
 
 .filter-tasks-bar {
+
   .filter-bar,
   .filter-bar-left,
   .filter-bar-item {
@@ -90,7 +102,9 @@
 }
 
 @media (min-width: @layout-screen-medium-min-width) {
+
   .filter-tasks-bar {
+
     .filter-bar {
       height: 70px;
       position: relative;
@@ -106,8 +120,11 @@
 }
 
 & when (@services-view-enabled) and (@layout-screen-small-enabled) {
+
   @media (min-width: @layout-screen-small-min-width) {
+
     .services-version-select {
+
       &-icon {
         margin-right: @base-spacing-unit-screen-small * 1/4;
       }
@@ -116,8 +133,11 @@
 }
 
 & when (@services-view-enabled) and (@layout-screen-medium-enabled) {
+
   @media (min-width: @layout-screen-medium-min-width) {
+
     .services-version-select {
+
       &-icon {
         margin-right: @base-spacing-unit-screen-medium * 1/4;
       }
@@ -126,12 +146,15 @@
 }
 
 & when (@services-view-enabled) and (@layout-screen-large-enabled) {
+
   @media (min-width: @layout-screen-large-min-width) {
+
     .services-sidebar {
       max-width: @service-sidebar-width-screen-large;
     }
 
     .services-version-select {
+
       &-icon {
         margin-right: @base-spacing-unit-screen-large * 1/4;
       }
@@ -140,12 +163,15 @@
 }
 
 & when (@services-view-enabled) and (@layout-screen-jumbo-enabled) {
+
   @media (min-width: @layout-screen-jumbo-min-width) {
+
     .services-sidebar {
       max-width: @service-sidebar-width-screen-jumbo;
     }
 
     .services-version-select {
+
       &-icon {
         margin-right: @base-spacing-unit-screen-jumbo * 1/4;
       }

--- a/tests/pages/services/GroupCreate-cy.js
+++ b/tests/pages/services/GroupCreate-cy.js
@@ -24,7 +24,7 @@ describe("Group Modals", () => {
     return cy.get(".form-group").find('.form-control[name="' + id + '"]');
   }
 
-  context.skip("Fullscreen group modal", () => {
+  context("Fullscreen group modal", () => {
     beforeEach(() => {
       cy.configureCluster({
         mesos: "1-sdk-service",
@@ -33,10 +33,10 @@ describe("Group Modals", () => {
 
       cy.visitUrl({ url: "/services/overview" });
 
-      cy.get("button.button-narrow")
-        .eq(-1)
+      cy.get(".page-header-actions [data-cy='primaryDropdownButton']")
+        .contains("New")
         .click();
-      cy.get("li.is-selectable")
+      cy.get("[data-cy='PopoverListItem']")
         .contains("Create Group")
         .click();
     });
@@ -393,9 +393,7 @@ describe("Group Modals", () => {
         .contains("services")
         .click();
 
-      cy.get("button.button-narrow")
-        .eq(-1)
-        .click();
+      cy.get(".page-header-actions button.button-narrow").click();
       cy.get("li.is-selectable")
         .contains("Edit Group")
         .click();
@@ -404,12 +402,7 @@ describe("Group Modals", () => {
 
     it("does not have an edit action for root level", () => {
       cy.visitUrl({ url: "/services/overview" });
-      cy.get("button.button-narrow")
-        .eq(-1)
-        .click();
-      cy.get("li.is-selectable")
-        .contains("Edit Group")
-        .should("not.exist");
+      cy.get(".page-header-actions button.button-narrow").should("not.exist");
     });
 
     it("does not have an edit action for non-top-level groups", () => {
@@ -437,10 +430,10 @@ describe("Group Modals", () => {
 
       cy.visitUrl({ url: "/services/overview" });
 
-      cy.get("button.button-narrow")
-        .eq(-1)
+      cy.get(".page-header-actions [data-cy='primaryDropdownButton']")
+        .contains("New")
         .click();
-      cy.get("li.is-selectable")
+      cy.get("[data-cy='PopoverListItem']")
         .contains("Create Group")
         .click();
 
@@ -470,10 +463,10 @@ describe("Group Modals", () => {
 
       cy.visitUrl({ url: "/services/overview" });
 
-      cy.get("button.button-narrow")
-        .eq(-1)
+      cy.get(".page-header-actions [data-cy='primaryDropdownButton']")
+        .contains("New")
         .click();
-      cy.get("li.is-selectable")
+      cy.get("[data-cy='PopoverListItem']")
         .contains("Create Group")
         .click();
 
@@ -508,10 +501,10 @@ describe("Group Modals", () => {
 
       cy.visitUrl({ url: "/services/overview" });
 
-      cy.get("button.button-narrow")
-        .eq(-1)
+      cy.get(".page-header-actions [data-cy='primaryDropdownButton']")
+        .contains("New")
         .click();
-      cy.get("li.is-selectable")
+      cy.get("[data-cy='PopoverListItem']")
         .contains("Create Group")
         .click();
 
@@ -541,10 +534,10 @@ describe("Group Modals", () => {
 
       cy.visitUrl({ url: "/services/overview" });
 
-      cy.get("button.button-narrow")
-        .eq(-1)
+      cy.get(".page-header-actions [data-cy='primaryDropdownButton']")
+        .contains("New")
         .click();
-      cy.get("li.is-selectable")
+      cy.get("[data-cy='PopoverListItem']")
         .contains("Create Group")
         .click();
 
@@ -570,7 +563,7 @@ describe("Group Modals", () => {
     });
   });
 
-  context.skip("Group Edit", () => {
+  context("Group Edit", () => {
     it("closes modal on successful creation", () => {
       cy.configureCluster({
         mesos: "1-sdk-service",
@@ -602,6 +595,7 @@ describe("Group Modals", () => {
 
       cy.get(".modal-full-screen").should("not.exist");
     });
+
     it("shows force update if mesos returns overcommit error", () => {
       cy.configureCluster({
         mesos: "1-sdk-service",
@@ -640,7 +634,7 @@ describe("Group Modals", () => {
     });
   });
 
-  context.skip("Small group modal", () => {
+  context("Small group modal", () => {
     beforeEach(() => {
       cy.configureCluster({
         mesos: "1-sdk-service",
@@ -653,12 +647,13 @@ describe("Group Modals", () => {
         .click();
     });
     it("displays a small group modal for non-top-level groups", () => {
-      cy.get("button.button-narrow")
-        .eq(-1)
+      cy.get(".page-header-actions [data-cy='primaryDropdownButton']")
+        .contains("New")
         .click();
-      cy.get("li.is-selectable")
+      cy.get("[data-cy='PopoverListItem']")
         .contains("Create Group")
         .click();
+
       cy.get(".modal-small");
       cy.get(".modal-full-screen").should("not.exist");
     });

--- a/tests/pages/services/QuotaOverview-cy.js
+++ b/tests/pages/services/QuotaOverview-cy.js
@@ -27,18 +27,20 @@ describe("Quota Tab", function() {
     });
 
     it("Shows actions dropdown", function() {
-      cy.get(".button-narrow")
-        .eq(0)
+      cy.get(".page-header-actions [data-cy='primaryDropdownButton']")
+        .contains("New")
         .click();
-      cy.get("li.is-selectable").contains("Run a Service");
-      cy.get("li.is-selectable").contains("Create Group");
+
+      cy.get("[data-cy='PopoverListItem']").contains("Run a Service");
+      cy.get("[data-cy='PopoverListItem']").contains("Create Group");
     });
 
     it("Opens create service modal", function() {
-      cy.get(".button-narrow")
-        .eq(0)
+      cy.get(".page-header-actions [data-cy='primaryDropdownButton']")
+        .contains("New")
         .click();
-      cy.get("li.is-selectable")
+
+      cy.get("[data-cy='PopoverListItem']")
         .contains("Run a Service")
         .click();
       cy.get(".create-service-modal-service-picker-options");
@@ -46,10 +48,11 @@ describe("Quota Tab", function() {
     });
 
     it("Opens create group modal", function() {
-      cy.get(".button-narrow")
-        .eq(0)
+      cy.get(".page-header-actions [data-cy='primaryDropdownButton']")
+        .contains("New")
         .click();
-      cy.get("li.is-selectable")
+
+      cy.get("[data-cy='PopoverListItem']")
         .contains("Create Group")
         .click();
       cy.get(".create-service-modal-form-container");


### PR DESCRIPTION
Replacing `+` icon with suggested dropdowns for Service/Quota screens

## Testing

Please check empty states when group is empty
also top level group, 1 level, 2 levels deep

## Trade-offs

1. I had to leverage supplemental content and completely drop `addButton` prop on the header component
2. Overrode CNVS `button:hover` style in a nasty way 😅 

## Screenshots

### After

![Screenshot 2019-09-10 at 15 59 17](https://user-images.githubusercontent.com/186223/64620346-fb613700-d3e3-11e9-8f69-e79160a2e0ab.png)
