### PR TITLE
Update CLI URL in UI installation instructions

### DIFF
--- a/src/js/components/modals/CliInstallModal.js
+++ b/src/js/components/modals/CliInstallModal.js
@@ -69,8 +69,9 @@ class CliInstallModal extends React.Component {
 
     // Starting from DC/OS >=2.0, users can stick to the "latest" CLI.
     // However on DC/OS 1.x we must use the correct CLI for the given version of DC/OS.
-    let dcosVersion = MetadataStore.parsedVersion
-    cliVersion = dcosVersion.substring(0, 2) == '1.' ? `dcos-${dcosVersion}` : "latest";
+    const dcosVersion = MetadataStore.parsedVersion;
+    const cliVersion =
+      dcosVersion.substring(0, 2) === "1." ? `dcos-${dcosVersion}` : "latest";
 
     const downloadUrl = `https://downloads.dcos.io/cli/releases/binaries/dcos/${osTypes[selectedOS]}/x86-64/${cliVersion}/dcos`;
     if (selectedOS === "Windows") {

--- a/src/js/components/modals/CliInstallModal.js
+++ b/src/js/components/modals/CliInstallModal.js
@@ -67,7 +67,12 @@ class CliInstallModal extends React.Component {
     const clusterUrl = `${protocol}://${hostname}${port}`;
     const { selectedOS } = this.state;
 
-    const downloadUrl = `https://downloads.dcos.io/binaries/cli/${osTypes[selectedOS]}/x86-64/dcos-1.13/dcos`;
+    // Starting from DC/OS >=2.0, users can stick to the "latest" CLI.
+    // However on DC/OS 1.x we must use the correct CLI for the given version of DC/OS.
+    let dcosVersion = MetadataStore.parsedVersion
+    cliVersion = dcosVersion.substring(0, 2) == '1.' ? `dcos-${dcosVersion}` : "latest";
+
+    const downloadUrl = `https://downloads.dcos.io/cli/releases/binaries/dcos/${osTypes[selectedOS]}/x86-64/${cliVersion}/dcos`;
     if (selectedOS === "Windows") {
       return this.getWindowsInstallInstruction(clusterUrl, downloadUrl);
     }


### PR DESCRIPTION
Starting with DC/OS 2.0 we're confident that the CLI is now cluster-version agnostic.

As such we can stick to the `latest` tagged version.

https://jira.mesosphere.com/browse/DCOS-59799