### PR TITLE
🚨1.14 blocker: account for non-marathon tasks when checking quota

### DIFF
--- a/plugins/services/src/js/columns/QuotaOverviewLimitColumn.tsx
+++ b/plugins/services/src/js/columns/QuotaOverviewLimitColumn.tsx
@@ -56,8 +56,8 @@ function renderLimitLabel(limitInfo: LimitInfo) {
           >
             <Plural
               value={limitInfo.servicesNotLimited}
-              one="# service or task has no quota limit."
-              other="# services or tasks have no quota limit."
+              one="# service has no quota limit."
+              other="# services have no quota limit."
             />
           </Tooltip>
         </div>

--- a/plugins/services/src/js/columns/QuotaOverviewLimitColumn.tsx
+++ b/plugins/services/src/js/columns/QuotaOverviewLimitColumn.tsx
@@ -13,6 +13,9 @@ import {
   QuotaLimitStatuses
 } from "#PLUGINS/services/src/js/types/ServiceGroup";
 
+// @ts-ignore
+import MesosStateStore from "#SRC/js/stores/MesosStateStore";
+
 import { getQuotaLimit } from "../utils/QuotaUtil";
 
 import ServiceTree from "../structs/ServiceTree";
@@ -53,8 +56,8 @@ function renderLimitLabel(limitInfo: LimitInfo) {
           >
             <Plural
               value={limitInfo.servicesNotLimited}
-              one="# service has no quota limit."
-              other="# services have no quota limit."
+              one="# service or task has no quota limit."
+              other="# services or tasks have no quota limit."
             />
           </Tooltip>
         </div>
@@ -120,14 +123,17 @@ export function getLimitInfoForService(
   }
 
   const groupName = item.getRootGroupName();
-  const stats = item.getQuotaRoleStats(groupName);
+  const stats = item.getQuotaRoleStats(
+    groupName,
+    MesosStateStore.getTasksByService.bind(MesosStateStore)
+  );
 
   return {
     limitText: getQuotaLimit({
       count: stats.count,
-      groupRoleCount: stats.groupRolesCount
+      groupRoleCount: stats.groupRoleCount
     }),
-    servicesNotLimited: stats.count - stats.groupRolesCount
+    servicesNotLimited: stats.count - stats.groupRoleCount
   };
 }
 

--- a/plugins/services/src/js/components/ServicesQuotaOverviewDetail.tsx
+++ b/plugins/services/src/js/components/ServicesQuotaOverviewDetail.tsx
@@ -21,6 +21,9 @@ import Units from "#SRC/js/utils/Units";
 import ProgressBar from "#SRC/js/components/ProgressBar";
 import * as ResourcesUtil from "#SRC/js/utils/ResourcesUtil";
 
+// @ts-ignore
+import MesosStateStore from "#SRC/js/stores/MesosStateStore";
+
 import { ServiceGroup, QuotaResources } from "../types/ServiceGroup";
 import * as QuotaUtil from "../utils/QuotaUtil";
 import ServiceTree from "../structs/ServiceTree";
@@ -208,7 +211,7 @@ const ServicesQuotaOverviewDetail = componentFromStream<
           }
         }
       `,
-      { id: getRootGroupId(id) }
+      { id: getRootGroupId(id), mesosStateStore: MesosStateStore }
     );
 
   const group$ = id$.pipe(

--- a/plugins/services/src/js/components/modals/ServiceRootGroupModal/index.tsx
+++ b/plugins/services/src/js/components/modals/ServiceRootGroupModal/index.tsx
@@ -33,6 +33,9 @@ import FieldError from "#SRC/js/components/form/FieldError";
 import InfoTooltipIcon from "#SRC/js/components/form/InfoTooltipIcon";
 import Loader from "#SRC/js/components/Loader";
 
+// @ts-ignore
+import MesosStateStore from "#SRC/js/stores/MesosStateStore";
+
 import { formatQuotaID } from "#PLUGINS/services/src/js/utils/QuotaUtil";
 import {
   GroupFormData,
@@ -97,7 +100,7 @@ function getGroup(id: string) {
         }
       }
     `,
-    { id }
+    { id, mesosStateStore: MesosStateStore }
   );
 }
 

--- a/plugins/services/src/js/data/groups/__tests__/index-test.ts
+++ b/plugins/services/src/js/data/groups/__tests__/index-test.ts
@@ -28,6 +28,17 @@ function makeServiceTree(groupsResponse = {}): ServiceTree {
   return new ServiceTree(MarathonUtil.parseGroups(groupsResponse));
 }
 
+const getTasksByService = () => {
+  return [
+    {
+      id: "/fake_1",
+      isStartedByMarathon: true,
+      state: "TASK_RUNNING",
+      resources: { cpus: 0.2, mem: 300, gpus: 0, disk: 0 }
+    }
+  ];
+};
+
 describe("Services Data Layer - Groups", () => {
   let container: Container | null = null;
   let dl: DataLayer | null = null;
@@ -129,7 +140,11 @@ describe("Services Data Layer - Groups", () => {
             }
           }
         });
-        m.expect(dl.query(query, {}).pipe(take(1))).toBeObservable(expected$);
+        m.expect(
+          dl
+            .query(query, { mesosStateStore: { getTasksByService } })
+            .pipe(take(1))
+        ).toBeObservable(expected$);
       })
     );
 
@@ -262,7 +277,11 @@ describe("Services Data Layer - Groups", () => {
             }
           }
         });
-        m.expect(dl.query(query, {}).pipe(take(1))).toBeObservable(expected$);
+        m.expect(
+          dl
+            .query(query, { mesosStateStore: { getTasksByService } })
+            .pipe(take(1))
+        ).toBeObservable(expected$);
       })
     );
 
@@ -395,7 +414,11 @@ describe("Services Data Layer - Groups", () => {
             }
           }
         });
-        m.expect(dl.query(query, {}).pipe(take(1))).toBeObservable(expected$);
+        m.expect(
+          dl
+            .query(query, { mesosStateStore: { getTasksByService } })
+            .pipe(take(1))
+        ).toBeObservable(expected$);
       })
     );
   });
@@ -462,7 +485,11 @@ describe("Services Data Layer - Groups", () => {
             }
           }
         });
-        m.expect(dl.query(query, {}).pipe(take(1))).toBeObservable(expected$);
+        m.expect(
+          dl
+            .query(query, { mesosStateStore: { getTasksByService } })
+            .pipe(take(1))
+        ).toBeObservable(expected$);
       })
     );
 
@@ -486,7 +513,11 @@ describe("Services Data Layer - Groups", () => {
           undefined,
           "Group resolver arguments aren't valid for type ServiceGroupQueryArgs"
         );
-        m.expect(dl.query(query, null).pipe(take(1))).toBeObservable(expected$);
+        m.expect(
+          dl
+            .query(query, { mesosStateStore: { getTasksByService } })
+            .pipe(take(1))
+        ).toBeObservable(expected$);
       })
     );
   });

--- a/plugins/services/src/js/structs/Service.d.ts
+++ b/plugins/services/src/js/structs/Service.d.ts
@@ -8,7 +8,10 @@ export default class Service extends Item {
   getName(): string;
   getRole(): string;
   getRootGroupName(): string;
-  getQuotaRoleStats(roleName: string | null = null): ServiceQuotaRolesStats;
+  getQuotaRoleStats(
+    roleName: string | null = null,
+    getMesosTasksByService: (service: Service) => any[]
+  ): ServiceQuotaRolesStats;
   getSpec(): any;
   getHealth(): string;
   getLabels(): object;

--- a/plugins/services/src/js/structs/Service.js
+++ b/plugins/services/src/js/structs/Service.js
@@ -145,20 +145,29 @@ module.exports = class Service extends Item {
     return this.getId().split("/")[1];
   }
 
-  getQuotaRoleStats(roleName) {
-    return (this.get("tasks") || []).reduce(
-      (roles, item) => {
+  getQuotaRoleStats(roleName, getMesosTasksByService) {
+    const mesosTasks = getMesosTasksByService(this);
+    const tasks = this.get("tasks");
+
+    return mesosTasks.reduce(
+      (roles, mesosTask) => {
+        const item = tasks.find(t => t.id === mesosTask.id);
         roles.count++;
+
+        if (!item) {
+          return roles;
+        }
+
         const itemRole = item.role;
         if (itemRole) {
           roles.rolesCount++;
           if (itemRole === roleName) {
-            roles.groupRolesCount++;
+            roles.groupRoleCount++;
           }
         }
         return roles;
       },
-      { count: 0, rolesCount: 0, groupRolesCount: 0 }
+      { count: 0, rolesCount: 0, groupRoleCount: 0 }
     );
   }
 

--- a/plugins/services/src/js/structs/ServiceTree.d.ts
+++ b/plugins/services/src/js/structs/ServiceTree.d.ts
@@ -46,7 +46,10 @@ declare class ServiceTree extends Tree<Service> {
   getFrameworks(): any;
   getVolumes(): any;
   getLabels(): any;
-  getQuotaRoleStats(roleName: string | null = null): ServiceQuotaRolesStats;
+  getQuotaRoleStats(
+    roleName: string | null = null,
+    getMesosTasksByService: (service: Service) => any[]
+  ): ServiceQuotaRolesStats;
   isRoot(): boolean;
   isTopLevel(): boolean;
 }

--- a/plugins/services/src/js/structs/__tests__/ServiceTree-test.js
+++ b/plugins/services/src/js/structs/__tests__/ServiceTree-test.js
@@ -1289,7 +1289,7 @@ describe("ServiceTree", function() {
       expect(thisInstance.getQuotaRoleStats()).toEqual({
         count: 1,
         rolesCount: 1,
-        groupRolesCount: 0
+        groupRoleCount: 0
       });
     });
 
@@ -1320,7 +1320,7 @@ describe("ServiceTree", function() {
       expect(thisInstance.getQuotaRoleStats()).toEqual({
         count: 4,
         rolesCount: 4,
-        groupRolesCount: 2
+        groupRoleCount: 2
       });
     });
   });

--- a/plugins/services/src/js/types/ServiceQuotaRolesStats.ts
+++ b/plugins/services/src/js/types/ServiceQuotaRolesStats.ts
@@ -1,5 +1,5 @@
 export interface ServiceQuotaRolesStats {
   count: number;
   rolesCount: number;
-  groupRolesCount: number;
+  groupRoleCount: number;
 }


### PR DESCRIPTION
Closes DCOS-59786

## Overview

I am not proud of this change. A bug was affecting the quota summary ("Applied", "Partially Applied", etc) where tasks started by services outside of Marathon were not subject to quota: https://jira.mesosphere.com/browse/DCOS-59786

To solve it, I needed to consult the mesos stream in order to locate tasks started by a service and count those against the quota stats. The UI was not really prepared for task-level stats, so I changed the tooltip for partially applied quotas to read "# services or tasks"

I had to make some awkward incursions into the stream. I added it to the graphql context in groups queries and awaited loading those pages that use them until the stream was received.  I drew the line at "getQuotaRoleStats" which consumes the stream by instead having it accept a function similar to MesosStateStore "getTasksByService" and passed it down.

The new pain is now in getQuotaRoleStats for Service and ServiceTree.

## Testing

I smoke tested this with different types of services but this should be re-tested very carefully, as it completely changes how we summarize quota enforcement.

I had to make several attempts at avoiding circular dependencies which took a lot of time. If I had more I would have added some unit tests.

Create a quota group and add services to it. confluent-kafka is a service that creates its own sdk tasks.

## Trade-offs

This adds some damage and to be frank this requirement needed to be incorporated in the initial design.

## Screenshots

![Screen Shot 2019-10-15 at 1 07 27 AM](https://user-images.githubusercontent.com/174332/66808344-4214e600-eee8-11e9-9c4f-e76a50d3dffb.png)
