### PR TITLE
backport: fix: don't let users wait `refreshRate` before rendering services

### DIFF
--- a/plugins/services/src/js/containers/services/ServicesContainer.js
+++ b/plugins/services/src/js/containers/services/ServicesContainer.js
@@ -142,6 +142,13 @@ class ServicesContainer extends React.Component {
     METHODS_TO_BIND.forEach(method => {
       this[method] = this[method].bind(this);
     });
+
+    // This is so we get notified when the serviceTree is ready in DCOSStore. Making this a promise would be nice.
+    DCOSStore.on(DCOS_CHANGE, () => {
+      if (this.state.isLoading) {
+        this.forceUpdate();
+      }
+    });
   }
 
   componentDidMount() {


### PR DESCRIPTION
## Testing


Go to ui Settings, 
Change the setting to something different then 2 seconds  ( bigger is better )
Reload the page.
Open network tab.
Open services page.
Check in the network tab that the endpoints are only requested at about the changed refresh rate setting.

You can also check this on various pages in the app.

If you select the 60 sec. setting make sure that the service page or any other page loads in a reasonable time and not only 60 sec. later.

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
