### PR TITLE
fix: show serviceTable when all data is already loaded

### DIFF
--- a/plugins/services/src/js/containers/services/ServicesContainer.js
+++ b/plugins/services/src/js/containers/services/ServicesContainer.js
@@ -193,6 +193,7 @@ class ServicesContainer extends React.Component {
         this.forceUpdate();
       }
     });
+    this.onStoreChange();
   }
 
   componentDidMount() {


### PR DESCRIPTION
context: https://github.com/dcos/dcos-ui/pull/4142 (refreshRate)

there's another race condition that prevents the serviceContainer from
rendering: all data is already loaded. in that case we don't get an
onStoreChange-event and will not update `isLoading` until some requests triggers
a rerender (after 60 seconds).

we now trigger the `onStoreChange` at least once in the constructor to ensure we
either have the data or will be notified once the DCOS_STORE is ready to go.

it would be awesome to have promises for that. it would be even more awesome to
remodel that for a simpler data flow in that the container takes the stuff to
render as a prop and thus rerenders automatically on change. we should not need
to fear for a loss in performance as the cell-renderers of the table memoize
AllTheThings:tm:.

## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
