### PR TITLE
refactor: remove some cruft from StoreMixin

### DIFF
--- a/src/js/mixins/StoreMixin.ts
+++ b/src/js/mixins/StoreMixin.ts
@@ -16,8 +16,8 @@ let ListenersDescription: Record<string, StoreConfig> = {
   // }
 };
 
-type Listener = "string" | StoreConfig;
-type StoreConfig = { name: string; events?: any };
+type Listener = StoreConfig;
+type StoreConfig = { name: string; events: any };
 
 export default {
   store_initializeListeners(storeListeners: Listener[]) {
@@ -27,34 +27,20 @@ export default {
     // Merges options for each store listener with
     // the ListenersDescription definition above
     storeListeners.forEach(listener => {
-      if (typeof listener === "string") {
-        if (!ListenersDescription[listener]) {
-          return;
-        }
-        // Use all defaults
-        storesListeners[listener] = { ...ListenersDescription[listener] };
-      } else {
-        const storeName = listener.name;
-        const events = listener.events;
+      const { events, name } = listener;
 
-        if (!ListenersDescription[storeName]) {
-          return;
-        }
-        // Populate events by key. For example, a component
-        // may only want to listen for 'success' events
-        if (events) {
-          listener.events = {};
-          events.forEach((event: any) => {
-            listener.events[event] =
-              ListenersDescription[storeName].events[event];
-          });
-        }
-
-        storesListeners[storeName] = {
-          ...ListenersDescription[storeName],
-          ...listener
-        };
+      if (!ListenersDescription[name]) {
+        return;
       }
+
+      // Populate events by key. For example, a component
+      // may only want to listen for 'success' events
+      listener.events = {};
+      events.forEach((event: any) => {
+        listener.events[event] = ListenersDescription[name].events[event];
+      });
+
+      storesListeners[name] = { ...ListenersDescription[name], ...listener };
     });
 
     // Default unmountWhen to unmount immediately when suppressUpdate is not


### PR DESCRIPTION
there's not a single Listener that's specified as a string - so let's remove
related functionality.

`events` seems to always be present - so there's no need to null-check.

the args-slice is limited by the amount of args we pass to onStoreChange - which
is two. so args would always be the empty array. let's get rid of that.