### PR TITLE
fix(stores): revert "refactor: use unmountWhen to express listenAlway"

### DIFF
--- a/plugins/intercom/stores/IntercomStore.js
+++ b/plugins/intercom/stores/IntercomStore.js
@@ -30,7 +30,8 @@ class IntercomStore extends GetSetBaseStore {
       events: {
         intercomChange: INTERCOM_CHANGE
       },
-      unmountWhen: () => false
+      unmountWhen: () => true,
+      listenAlways: true
     });
 
     METHODS_TO_BIND.forEach(method => {

--- a/plugins/nodes/src/js/pages/nodes/NodesTaskDetailPage.js
+++ b/plugins/nodes/src/js/pages/nodes/NodesTaskDetailPage.js
@@ -18,7 +18,13 @@ class NodesTaskDetailPage extends mixin(StoreMixin) {
   constructor(...args) {
     super(...args);
 
-    this.store_listeners = [{ name: "summary", events: ["success"] }];
+    this.store_listeners = [
+      {
+        name: "summary",
+        events: ["success"],
+        listenAlways: false
+      }
+    ];
   }
 
   render() {

--- a/plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.js
+++ b/plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.js
@@ -30,8 +30,17 @@ class NodesGridContainer extends mixin(StoreMixin) {
       serviceColors: {}
     };
     this.store_listeners = [
-      { events: ["success"], name: "nodeHealth", suppressUpdate: true },
-      { events: ["success", "error"], name: "state", suppressUpdate: true }
+      {
+        events: ["success"],
+        listenAlways: false,
+        name: "nodeHealth",
+        suppressUpdate: true
+      },
+      {
+        events: ["success", "error"],
+        name: "state",
+        suppressUpdate: true
+      }
     ];
     METHODS_TO_BIND.forEach(method => {
       this[method] = this[method].bind(this);

--- a/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
+++ b/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
@@ -31,7 +31,12 @@ class NodesTableContainer extends mixin(StoreMixin) {
     };
 
     this.store_listeners = [
-      { events: ["success"], name: "nodeHealth", suppressUpdate: true },
+      {
+        events: ["success"],
+        listenAlways: false,
+        name: "nodeHealth",
+        suppressUpdate: true
+      },
       { name: "state", events: ["success"], suppressUpdate: true }
     ];
 

--- a/plugins/nodes/src/js/stores/NodeHealthStore.js
+++ b/plugins/nodes/src/js/stores/NodeHealthStore.js
@@ -74,7 +74,10 @@ class NodeHealthStore extends GetSetBaseStore {
         unitSuccess: HEALTH_NODE_UNIT_SUCCESS,
         unitError: HEALTH_NODE_UNIT_ERROR
       },
-      unmountWhen: () => false
+      unmountWhen() {
+        return true;
+      },
+      listenAlways: true
     });
 
     AppDispatcher.register(payload => {

--- a/plugins/services/src/js/components/DeploymentStatusIndicator.js
+++ b/plugins/services/src/js/components/DeploymentStatusIndicator.js
@@ -23,7 +23,11 @@ class DeploymentStatusIndicator extends mixin(StoreMixin) {
     super(...args);
 
     this.store_listeners = [
-      { name: "dcos", events: ["change"], unmountWhen: () => false }
+      {
+        name: "dcos",
+        events: ["change"],
+        listenAlways: true
+      }
     ];
 
     this.state = {

--- a/plugins/services/src/js/pages/task-details/TaskDetail.js
+++ b/plugins/services/src/js/pages/task-details/TaskDetail.js
@@ -59,9 +59,9 @@ class TaskDetail extends mixin(TabsMixin, StoreMixin) {
     };
 
     this.store_listeners = [
-      { name: "marathon", events: ["appsSuccess"] },
-      { name: "state", events: ["success"] },
-      { name: "summary", events: ["success"] },
+      { name: "marathon", events: ["appsSuccess"], listenAlways: false },
+      { name: "state", events: ["success"], listenAlways: false },
+      { name: "summary", events: ["success"], listenAlways: false },
       {
         name: "taskDirectory",
         events: ["error", "success", "nodeStateError", "nodeStateSuccess"],

--- a/plugins/services/src/js/pages/task-details/TaskLogsContainer.js
+++ b/plugins/services/src/js/pages/task-details/TaskLogsContainer.js
@@ -20,7 +20,13 @@ class TaskLogsContainer extends mixin(StoreMixin) {
       isLoading: true
     };
 
-    this.store_listeners = [{ name: "config", events: ["success", "error"] }];
+    this.store_listeners = [
+      {
+        name: "config",
+        events: ["success", "error"],
+        listenAlways: false
+      }
+    ];
   }
 
   UNSAFE_componentWillMount() {

--- a/plugins/services/src/js/stores/MarathonStore.js
+++ b/plugins/services/src/js/stores/MarathonStore.js
@@ -166,7 +166,14 @@ class MarathonStore extends GetSetBaseStore {
         taskKillSuccess: MARATHON_TASK_KILL_SUCCESS,
         taskKillError: MARATHON_TASK_KILL_ERROR
       },
-      unmountWhen: () => false
+      unmountWhen(store, event) {
+        if (event === "appsSuccess") {
+          return store.hasProcessedApps();
+        }
+
+        return true;
+      },
+      listenAlways: true
     });
 
     AppDispatcher.register(payload => {

--- a/plugins/services/src/js/stores/MesosLogStore.js
+++ b/plugins/services/src/js/stores/MesosLogStore.js
@@ -41,7 +41,10 @@ class MesosLogStore extends BaseStore {
         offsetSuccess: MESOS_INITIALIZE_LOG_CHANGE,
         offsetError: MESOS_INITIALIZE_LOG_REQUEST_ERROR
       },
-      unmountWhen: () => false,
+      unmountWhen() {
+        return true;
+      },
+      listenAlways: true,
       suppressUpdate: true
     });
 

--- a/plugins/services/src/js/stores/SDKEndpointStore.js
+++ b/plugins/services/src/js/stores/SDKEndpointStore.js
@@ -26,7 +26,7 @@ class SDKEndpointStore extends GetSetBaseStore {
     PluginSDK.addStoreConfig({
       store: this,
       storeID: this.storeID,
-      unmountWhen: () => false
+      listenAlways: true
     });
 
     AppDispatcher.register(payload => {

--- a/plugins/services/src/js/stores/TaskDirectoryStore.js
+++ b/plugins/services/src/js/stores/TaskDirectoryStore.js
@@ -58,7 +58,10 @@ class TaskDirectoryStore extends GetSetBaseStore {
         nodeStateError: REQUEST_NODE_STATE_ERROR,
         nodeStateSuccess: REQUEST_NODE_STATE_SUCCESS
       },
-      unmountWhen: () => false
+      unmountWhen() {
+        return true;
+      },
+      listenAlways: true
     });
 
     AppDispatcher.register(payload => {

--- a/src/js/components/ClusterHeader.js
+++ b/src/js/components/ClusterHeader.js
@@ -23,8 +23,8 @@ export default class ClusterHeader extends mixin(StoreMixin) {
     super(...args);
 
     this.store_listeners = [
-      { name: "metadata", events: ["success"] },
-      { name: "summary", events: ["success"] }
+      { name: "metadata", events: ["success"], listenAlways: false },
+      { name: "summary", events: ["success"], listenAlways: false }
     ];
   }
 

--- a/src/js/components/UserAccountDropdownTrigger.js
+++ b/src/js/components/UserAccountDropdownTrigger.js
@@ -7,7 +7,13 @@ export default class UserAccountDropdownTrigger extends mixin(StoreMixin) {
   constructor(...args) {
     super(...args);
 
-    this.store_listeners = [{ name: "metadata", events: ["success"] }];
+    this.store_listeners = [
+      {
+        name: "metadata",
+        events: ["success"],
+        listenAlways: false
+      }
+    ];
   }
 
   componentDidUpdate() {

--- a/src/js/mixins/StoreMixin.ts
+++ b/src/js/mixins/StoreMixin.ts
@@ -11,6 +11,7 @@ let ListenersDescription: Record<string, StoreConfig> = {
   //   unmountWhen: function () {
   //     return true;
   //   },
+  //   listenAlways: true,
   //   suppressUpdate: false
   // }
 };
@@ -166,10 +167,13 @@ export default {
     const args = Array.prototype.slice.call(arguments, 2);
     // See if we need to remove our change listener
     const listenerDetail = this.store_listeners[storeID];
-    // Remove change listener if the settings want to unmount after a certain
-    // condition is truthy
-    if (listenerDetail.unmountWhen(listenerDetail.store, event)) {
-      this.store_removeEventListenerForStoreID(storeID, event);
+    // Maybe remove listener
+    if (listenerDetail.unmountWhen && !listenerDetail.listenAlways) {
+      // Remove change listener if the settings want to unmount after a certain
+      // condition is truthy
+      if (listenerDetail.unmountWhen(listenerDetail.store, event)) {
+        this.store_removeEventListenerForStoreID(storeID, event);
+      }
     }
 
     // Call callback on component that implements mixin if it exists

--- a/src/js/plugin-bridge/PluginSDK.js
+++ b/src/js/plugin-bridge/PluginSDK.js
@@ -151,16 +151,18 @@ const getActionsAPI = SDK => ({
  * @return {Object}            - Created store
  */
 const addStoreConfig = definition => {
-  if (!definition.storeID) {
-    throw new Error("Must define a valid storeID to expose events");
+  if (definition) {
+    if (!definition.storeID) {
+      throw new Error("Must define a valid storeID to expose events");
+    }
+    if (definition.storeID in existingFluxStores) {
+      throw new Error(`Store with ID ${definition.storeID} already exists.`);
+    }
+    existingFluxStores[definition.storeID] = definition;
+    // Register events with StoreMixin. Only import this as needed
+    // because its presence will degrade test performance.
+    StoreMixin.store_configure(existingFluxStores);
   }
-  if (definition.storeID in existingFluxStores) {
-    throw new Error(`Store with ID ${definition.storeID} already exists.`);
-  }
-  existingFluxStores[definition.storeID] = definition;
-  // Register events with StoreMixin. Only import this as needed
-  // because its presence will degrade test performance.
-  StoreMixin.store_configure(existingFluxStores);
 
   return definition;
 };

--- a/src/js/stores/AuthStore.js
+++ b/src/js/stores/AuthStore.js
@@ -31,7 +31,10 @@ class AuthStore extends GetSetBaseStore {
         logoutSuccess: AUTH_USER_LOGOUT_SUCCESS,
         logoutError: AUTH_USER_LOGOUT_ERROR
       },
-      unmountWhen: () => false
+      unmountWhen() {
+        return true;
+      },
+      listenAlways: true
     });
 
     AppDispatcher.register(payload => {

--- a/src/js/stores/ConfigStore.js
+++ b/src/js/stores/ConfigStore.js
@@ -36,7 +36,8 @@ class ConfigStore extends GetSetBaseStore {
         ccidSuccess: CLUSTER_CCID_SUCCESS,
         ccidError: CLUSTER_CCID_ERROR
       },
-      unmountWhen: () => false
+      unmountWhen: () => true,
+      listenAlways: true
     });
 
     AppDispatcher.register(payload => {

--- a/src/js/stores/CosmosPackagesStore.js
+++ b/src/js/stores/CosmosPackagesStore.js
@@ -104,7 +104,10 @@ class CosmosPackagesStore extends GetSetBaseStore {
         serviceUpdateSuccess: COSMOS_SERVICE_UPDATE_SUCCESS,
         serviceUpdateError: COSMOS_SERVICE_UPDATE_ERROR
       },
-      unmountWhen: (store, event) => event === "availableSuccess"
+      unmountWhen(store, event) {
+        return event === "availableSuccess";
+      },
+      listenAlways: false
     });
 
     AppDispatcher.register(payload => {

--- a/src/js/stores/DCOSStore.js
+++ b/src/js/stores/DCOSStore.js
@@ -39,7 +39,10 @@ class DCOSStore extends EventEmitter {
       store: this,
       storeID: this.storeID,
       events: this.getEvents(),
-      unmountWhen: () => false
+      unmountWhen() {
+        return true;
+      },
+      listenAlways: true
     });
 
     METHODS_TO_BIND.forEach(method => {

--- a/src/js/stores/LanguageModalStore.js
+++ b/src/js/stores/LanguageModalStore.js
@@ -20,7 +20,8 @@ class LanguageModalStore extends GetSetBaseStore {
     PluginSDK.addStoreConfig({
       store: this,
       storeID: this.storeID,
-      unmountWhen: () => false
+      unmountWhen: () => true,
+      listenAlways: true
     });
 
     AppDispatcher.register(payload => {

--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -56,7 +56,12 @@ class MesosStateStore extends GetSetBaseStore {
         success: MESOS_STATE_CHANGE,
         error: MESOS_STATE_REQUEST_ERROR
       },
-      unmountWhen: () => false
+      unmountWhen(store, event) {
+        if (event === "success") {
+          return Object.keys(store.get("lastMesosState")).length;
+        }
+      },
+      listenAlways: true
     });
 
     METHODS_TO_BIND.forEach(method => {

--- a/src/js/stores/MesosSummaryStore.js
+++ b/src/js/stores/MesosSummaryStore.js
@@ -55,7 +55,14 @@ class MesosSummaryStore extends GetSetBaseStore {
       },
 
       // When to remove listener
-      unmountWhen: () => false
+      unmountWhen(store, event) {
+        if (event === "success") {
+          return store.get("statesProcessed");
+        }
+      },
+
+      // Set to true to keep listening until unmount
+      listenAlways: true
     });
 
     AppDispatcher.register(payload => {

--- a/src/js/stores/MetadataStore.js
+++ b/src/js/stores/MetadataStore.js
@@ -32,7 +32,8 @@ class MetadataStore extends GetSetBaseStore {
         dcosBuildInfoChange: DCOS_BUILD_INFO_CHANGE,
         dcosBuildInfoError: DCOS_BUILD_INFO_ERROR
       },
-      unmountWhen: () => false
+      unmountWhen: () => true,
+      listenAlways: true
     });
 
     AppDispatcher.register(payload => {

--- a/src/js/stores/NotificationStore.js
+++ b/src/js/stores/NotificationStore.js
@@ -17,7 +17,8 @@ class NotificationStore extends GetSetBaseStore {
       events: {
         change: NOTIFICATION_CHANGE
       },
-      unmountWhen: () => false
+      unmountWhen: () => true,
+      listenAlways: true
     });
   }
 

--- a/src/js/stores/SidebarStore.js
+++ b/src/js/stores/SidebarStore.js
@@ -36,7 +36,8 @@ class SidebarStore extends GetSetBaseStore {
       events: {
         widthChange: SIDEBAR_WIDTH_CHANGE
       },
-      unmountWhen: () => false
+      unmountWhen: () => true,
+      listenAlways: true
     });
 
     AppDispatcher.register(payload => {

--- a/src/js/stores/SystemLogStore.js
+++ b/src/js/stores/SystemLogStore.js
@@ -41,7 +41,8 @@ class SystemLogStore extends BaseStore {
         streamSuccess: SYSTEM_LOG_STREAM_TYPES_SUCCESS,
         streamError: SYSTEM_LOG_STREAM_TYPES_ERROR
       },
-      unmountWhen: () => false,
+      unmountWhen: () => true,
+      listenAlways: true,
       suppressUpdate: true
     });
 

--- a/src/js/stores/UnitHealthStore.js
+++ b/src/js/stores/UnitHealthStore.js
@@ -73,7 +73,10 @@ class UnitHealthStore extends GetSetBaseStore {
         nodeSuccess: HEALTH_UNIT_NODE_SUCCESS,
         nodeError: HEALTH_UNIT_NODE_ERROR
       },
-      unmountWhen: () => false
+      unmountWhen() {
+        return true;
+      },
+      listenAlways: true
     });
 
     AppDispatcher.register(payload => {

--- a/src/js/stores/UserStore.js
+++ b/src/js/stores/UserStore.js
@@ -33,7 +33,10 @@ class UserStore extends EventEmitter {
         deleteSuccess: USER_DELETE_SUCCESS,
         deleteError: USER_DELETE_ERROR
       },
-      unmountWhen: () => false
+      unmountWhen() {
+        return true;
+      },
+      listenAlways: true
     });
 
     AppDispatcher.register(payload => {

--- a/src/js/stores/UsersStore.js
+++ b/src/js/stores/UsersStore.js
@@ -26,7 +26,10 @@ class UsersStore extends GetSetBaseStore {
         success: USERS_CHANGE,
         error: USERS_REQUEST_ERROR
       },
-      unmountWhen: () => false
+      unmountWhen() {
+        return true;
+      },
+      listenAlways: true
     });
 
     AppDispatcher.register(payload => {

--- a/src/js/stores/VirtualNetworksStore.js
+++ b/src/js/stores/VirtualNetworksStore.js
@@ -30,7 +30,8 @@ class VirtualNetworksStore extends BaseStore {
         success: VIRTUAL_NETWORKS_CHANGE,
         error: VIRTUAL_NETWORKS_REQUEST_ERROR
       },
-      unmountWhen: () => false
+      unmountWhen: () => true,
+      listenAlways: true
     });
 
     // Handle app actions


### PR DESCRIPTION
This reverts commit 56b8a94b4b2741db40bafe1aeae901b06b2bd559.

flickering TaskDetail (most likely because it is the only component calling StoreMixin-internals directly - but let's be sure not to break stuff)

i overlooked that `listenAlways` is kind of inherited from the store that a listener subscribes to and that `listenAlways: false` is significant beyond `unmountWhen: () => true`.