### PR TITLE
chore: add a timestamp before each test run

### DIFF
--- a/scripts/utils/tests-functions
+++ b/scripts/utils/tests-functions
@@ -51,6 +51,7 @@ function executeCypress() {
 function runTestFile() {
   echo ""
   echo "==> Running Tests for ./${TESTS_FOLDER}/$RELATIVE_PATH"
+  date +"%T"
   local RUN=0
   local EXIT_CODE=1
   while [ $EXIT_CODE -ne 0 ] && [ $RUN -lt $RETRIES ]; do


### PR DESCRIPTION
...to get a feeling for what's taking out tests so long.