### PR TITLE
fix(servicescontainer): change to getderivedstatefromprops

### DIFF
--- a/plugins/services/src/js/containers/services/ServicesContainer.js
+++ b/plugins/services/src/js/containers/services/ServicesContainer.js
@@ -144,11 +144,7 @@ class ServicesContainer extends React.Component {
     });
 
     // This is so we get notified when the serviceTree is ready in DCOSStore. Making this a promise would be nice.
-    DCOSStore.on(DCOS_CHANGE, () => {
-      if (this.state.isLoading) {
-        this.forceUpdate();
-      }
-    });
+    this.onStoreChange();
   }
 
   componentDidMount() {


### PR DESCRIPTION
This changes the lifeCycleMethod on the `ServicesContainer` from
`componentWillRecieveProps` to `getDerivedStateFromProps` which is more fitting.

## Testing

Select a very high refresh rate from the ui configurations, and visit the services page.

## Trade-offs

N/A

## Dependencies

N/A
