### PR TITLE
DCOS-61439 don't compute labels for ServiceTrees so often

### DIFF
--- a/plugins/services/src/js/columns/ServicesTableActionsColumn.tsx
+++ b/plugins/services/src/js/columns/ServicesTableActionsColumn.tsx
@@ -110,13 +110,14 @@ export function actionsRendererFactory(
   return (service: Service | Pod | ServiceTree) => {
     const isGroup = service instanceof ServiceTree;
     const isPod = service instanceof Pod;
-    const isSingleInstanceApp = service.getLabels()
-      .MARATHON_SINGLE_INSTANCE_APP;
+    const isSingleInstanceApp =
+      !isGroup && service.getLabels().MARATHON_SINGLE_INSTANCE_APP;
+
     const instancesCount = service.getInstancesCount();
     const scaleTextID = isGroup
       ? ServiceActionLabels.scale_by
       : ServiceActionLabels[SCALE];
-    const isSDK = isSDKService(service);
+    const isSDK = !isGroup && isSDKService(service);
 
     const actions = [];
 

--- a/plugins/services/src/js/components/modals/EditServiceModal.js
+++ b/plugins/services/src/js/components/modals/EditServiceModal.js
@@ -26,15 +26,15 @@ const EditServiceModal = props => {
     return null;
   }
 
+  if (service instanceof ServiceTree) {
+    return <ServiceRootGroupModal id={id} {...props} />;
+  }
+
   if (
     service.getLabels().DCOS_PACKAGE_DEFINITION != null ||
     service.getLabels().DCOS_PACKAGE_METADATA != null
   ) {
     return <EditFrameworkConfiguration {...props} />;
-  }
-
-  if (service instanceof ServiceTree) {
-    return <ServiceRootGroupModal id={id} {...props} />;
   }
 
   return <CreateServiceModal {...props} />;

--- a/plugins/services/src/js/components/modals/ServiceResumeModal.js
+++ b/plugins/services/src/js/components/modals/ServiceResumeModal.js
@@ -115,7 +115,10 @@ class ServiceResumeModal extends React.PureComponent {
       props: { service }
     } = this;
 
-    if (service.getLabels().MARATHON_SINGLE_INSTANCE_APP) {
+    if (
+      !(service instanceof ServiceTree) &&
+      service.getLabels().MARATHON_SINGLE_INSTANCE_APP
+    ) {
       return (
         <Trans render="p">
           This service is currently stopped. Do you want to resume this service?

--- a/plugins/services/src/js/structs/ServiceTree.js
+++ b/plugins/services/src/js/structs/ServiceTree.js
@@ -351,23 +351,11 @@ module.exports = class ServiceTree extends Tree {
   }
 
   getLabels() {
-    return this.reduceItems((serviceTreeLabels, item) => {
-      const labels = Object.entries(item.getLabels()).map(([key, value]) => ({
-        key,
-        value
-      }));
-
-      labels.forEach(({ key, value }) => {
-        if (
-          serviceTreeLabels.findIndex(
-            label => label.key === key && label.value === value
-          ) < 0
-        ) {
-          serviceTreeLabels = serviceTreeLabels.concat([{ key, value }]);
-        }
+    return this.list.reduce((acc, el) => {
+      Object.entries(el.labels || {}).forEach(([key, value]) => {
+        acc.push({ key, value });
       });
-
-      return serviceTreeLabels;
+      return acc;
     }, []);
   }
 

--- a/plugins/services/src/js/structs/__tests__/ServiceTree-test.js
+++ b/plugins/services/src/js/structs/__tests__/ServiceTree-test.js
@@ -1134,34 +1134,6 @@ describe("ServiceTree", () => {
       ]);
     });
 
-    it("filters out duplicate label key-value tuples", () => {
-      thisInstance.add(
-        new Framework({
-          id: "/metronome",
-          labels: {
-            label_one: "value_one"
-          }
-        })
-      );
-
-      thisInstance.add(
-        new Application({
-          id: "/sleeper",
-          labels: {
-            label_one: "value_one",
-            label_two: "value_one"
-          }
-        })
-      );
-
-      const labels = thisInstance.getLabels();
-      expect(labels.length).toEqual(2);
-      expect(labels).toEqual([
-        { key: "label_one", value: "value_one" },
-        { key: "label_two", value: "value_one" }
-      ]);
-    });
-
     it("returns an empty array if no labels are found", () => {
       thisInstance.add(
         new Framework({


### PR DESCRIPTION
# ⚠️ BACKPORT TO 1.13 AFTER MERGE ⚠️ 

Due to the way we handle `Application`, `Service`, `Pod`, `ServiceTree` el al.
in the ServiceTable we aggregate all labels under all ServiceTrees (or "Groups")
multiple times.

We know for sure now that on some installations we got a lot of really large
labels, which lets browsers run out of memory, thus we now pay attention not to
compute labels for `ServiceTree`s too often.

To test this fix you might want to put a debugger in the `ServiceTree`'s
`getLabels`-method to see it's not called during the rendering of the table.

# Testing

* be on master
* get the groups-response posted by Ben, put a `module.exports = ` in front and palce it at `tests/_fixtures/marathon-pods/groups.js`. 
* open the services tab and observe your browser crashing.
* check out this branch and see how your browser does not crash.

* grep for `getLabels()` and make sure that there's no other place than the `PackageDetailTab` using a ServiceTrees list of labels. Not that the `PackageDetailTab` also used to crash with the given groups-response which is why it was refactored to be more "low-level" (directly using `.items` and reducing by hand). please don't see this as a final solution but as a fix.

Closes DCOS-61439