### PR TITLE
chore: convert module.exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -225,7 +225,7 @@
     "test:system:local": "PLUGINS_PATH=\"${npm_config_externalplugins}\" ./scripts/run-system-tests -hnds",
     "test:validate": "PLUGINS_PATH=\"${npm_config_externalplugins}\" ./scripts/validate-tests",
     "test:watch": "npm test -- --watch",
-    "test": "./scripts/lingui-compile && NODE_PATH=node_modules jest --config=jest.config.js --no-cache",
+    "test": "./scripts/lingui-compile && jest --config=jest.config.js --no-cache",
     "util:env:validate": "node ./scripts/validate-engine-versions.js",
     "util:lingui:extract": "./scripts/lingui-extract",
     "util:lingui:compile": "./scripts/lingui-compile",

--- a/plugins/banner/SDK.js
+++ b/plugins/banner/SDK.js
@@ -1,6 +1,6 @@
 let SDK;
 
-module.exports = {
+export default {
   getSDK() {
     return SDK;
   },

--- a/plugins/banner/__tests__/BannerPlugin-test.js
+++ b/plugins/banner/__tests__/BannerPlugin-test.js
@@ -3,9 +3,9 @@ import { shallow } from "enzyme";
 const PluginTestUtils = require("PluginTestUtils");
 
 const SDK = PluginTestUtils.getSDK("banner", { enabled: true });
-require("../SDK").setSDK(SDK);
+require("../SDK").default.setSDK(SDK);
 
-const BannerPlugin = require("../hooks");
+const BannerPlugin = require("../hooks").default;
 
 var defaultConfiguration = BannerPlugin.configuration;
 

--- a/plugins/banner/hooks.js
+++ b/plugins/banner/hooks.js
@@ -3,10 +3,11 @@ import React from "react";
 import { Icon } from "@dcos/ui-kit";
 import { SystemIcons } from "@dcos/ui-kit/dist/packages/icons/dist/system-icons-enum";
 import { iconSizeXs } from "@dcos/ui-kit/dist/packages/design-tokens/build/js/designTokens";
+import MySDK from "./SDK";
 
-const SDK = require("./SDK").getSDK();
+const SDK = MySDK.getSDK();
 
-module.exports = {
+export default {
   configuration: {
     backgroundColor: "#1E232F",
     foregroundColor: "#FFFFFF",

--- a/plugins/banner/index.js
+++ b/plugins/banner/index.js
@@ -3,7 +3,7 @@ import SDK from "./SDK";
 export default PluginSDK => {
   SDK.setSDK(PluginSDK);
 
-  const PluginHooks = require("./hooks");
+  const PluginHooks = require("./hooks").default;
   // Set plugin's hooks
   PluginHooks.initialize();
 };

--- a/plugins/example/hooks.js
+++ b/plugins/example/hooks.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   initialize() {
     // Hooks.addFilter etc.
   }

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -4,7 +4,7 @@ import oauth from "./oauth/index";
 import intercom from "./intercom/index";
 import uiUpdate from "./ui-update/index";
 
-module.exports = {
+export default {
   banner,
   tracking,
   oauth,

--- a/plugins/intercom/SDK.js
+++ b/plugins/intercom/SDK.js
@@ -1,6 +1,6 @@
 let SDK;
 
-module.exports = {
+export default {
   getSDK() {
     return SDK;
   },

--- a/plugins/intercom/__tests__/IntercomPlugin-test.js
+++ b/plugins/intercom/__tests__/IntercomPlugin-test.js
@@ -17,9 +17,9 @@ jest.mock("#SRC/js/stores/AuthStore", () => mockAuthStore);
 const PluginTestUtils = require("PluginTestUtils");
 
 const SDK = PluginTestUtils.getSDK("intercom", { enabled: true });
-require("../SDK").setSDK(SDK);
+require("../SDK").default.setSDK(SDK);
 
-const IntercomHooks = require("../hooks");
+const IntercomHooks = require("../hooks").default;
 
 describe("IntercomHooks", () => {
   describe("Listeners", () => {

--- a/plugins/intercom/hooks.js
+++ b/plugins/intercom/hooks.js
@@ -5,12 +5,13 @@ import AuthStore from "#SRC/js/stores/AuthStore";
 
 import { INTERCOM_CHANGE } from "./constants/EventTypes";
 import IntercomStore from "./stores/IntercomStore";
+import MySDK from "./SDK";
 
-const SDK = require("./SDK").getSDK();
+const SDK = MySDK.getSDK();
 
 const INTERCOM_LOAD_TIMEOUT = 500;
 
-module.exports = {
+export default {
   filters: ["pluginsLoadedCheck"],
   actions: ["pluginsConfigured", "userLoginSuccess", "userLogoutSuccess"],
 

--- a/plugins/intercom/index.js
+++ b/plugins/intercom/index.js
@@ -3,7 +3,7 @@ import SDK from "./SDK";
 export default PluginSDK => {
   SDK.setSDK(PluginSDK);
 
-  const PluginHooks = require("./hooks");
+  const PluginHooks = require("./hooks").default;
 
   PluginHooks.initialize(PluginSDK.config);
 };

--- a/plugins/oauth/SDK.js
+++ b/plugins/oauth/SDK.js
@@ -1,6 +1,6 @@
 let SDK;
 
-module.exports = {
+export default {
   getSDK() {
     return SDK;
   },

--- a/plugins/oauth/components/LoginPage.js
+++ b/plugins/oauth/components/LoginPage.js
@@ -7,8 +7,9 @@ import { Modal } from "reactjs-components";
 import AuthStore from "#SRC/js/stores/AuthStore";
 import MetadataStore from "#SRC/js/stores/MetadataStore";
 import StoreMixin from "#SRC/js/mixins/StoreMixin";
+import MySDK from "../SDK";
 
-const SDK = require("../SDK").getSDK();
+const SDK = MySDK.getSDK();
 
 const METHODS_TO_BIND = ["handleModalClose", "onMessageReceived"];
 

--- a/plugins/oauth/hooks.js
+++ b/plugins/oauth/hooks.js
@@ -14,15 +14,16 @@ import StoreMixin from "#SRC/js/mixins/StoreMixin";
 
 import AuthenticatedUserAccountDropdown from "./components/AuthenticatedUserAccountDropdown";
 import LoginPage from "./components/LoginPage";
+import MySDK from "./SDK";
 
-const SDK = require("./SDK").getSDK();
+const SDK = MySDK.getSDK();
 
 let configResponseCallback = null;
 const defaultOrganizationRoute = {
   routes: []
 };
 
-module.exports = Object.assign({}, StoreMixin, {
+export default Object.assign({}, StoreMixin, {
   actions: [
     "AJAXRequestError",
     "userLoginSuccess",

--- a/plugins/oauth/index.js
+++ b/plugins/oauth/index.js
@@ -3,7 +3,7 @@ import SDK from "./SDK";
 export default PluginSDK => {
   SDK.setSDK(PluginSDK);
 
-  const PluginHooks = require("./hooks");
+  const PluginHooks = require("./hooks").default;
 
   // Set plugin's hooks
   PluginHooks.initialize();

--- a/plugins/services/index.js
+++ b/plugins/services/index.js
@@ -1,7 +1,0 @@
-import ServiceConfigBaseSectionDisplay from "./src/js/service-configuration/ServiceConfigBaseSectionDisplay";
-import ServiceConfigDisplayUtil from "./src/js/utils/ServiceConfigDisplayUtil";
-
-module.exports = {
-  ServiceConfigBaseSectionDisplay,
-  ServiceConfigDisplayUtil
-};

--- a/plugins/tracking/SDK.js
+++ b/plugins/tracking/SDK.js
@@ -1,6 +1,6 @@
 let SDK;
 
-module.exports = {
+export default {
   getSDK() {
     return SDK;
   },

--- a/plugins/tracking/__tests__/TrackingPlugin-test.js
+++ b/plugins/tracking/__tests__/TrackingPlugin-test.js
@@ -10,9 +10,9 @@ jest.setMock("react-router", {
 const PluginTestUtils = require("PluginTestUtils");
 
 const SDK = PluginTestUtils.getSDK("tracking", { enabled: true });
-require("../SDK").setSDK(SDK);
+require("../SDK").default.setSDK(SDK);
 
-const TrackingHooks = require("../hooks");
+const TrackingHooks = require("../hooks").default;
 
 describe("TrackingHooks", () => {
   describe("Listeners", () => {

--- a/plugins/tracking/actions/Actions.js
+++ b/plugins/tracking/actions/Actions.js
@@ -6,9 +6,9 @@ import RouterUtil from "#SRC/js/utils/RouterUtil";
 import Config from "#SRC/js/config/Config";
 import Util from "#SRC/js/utils/Util";
 
-const SDK = require("../SDK").getSDK();
+const SDK = require("../SDK").default.getSDK();
 
-var Actions = {
+const Actions = {
   previousFakePageLog: "",
 
   dcosMetadata: null,
@@ -256,4 +256,4 @@ var Actions = {
   }
 };
 
-module.exports = Actions;
+export default Actions;

--- a/plugins/tracking/actions/__tests__/Actions-test.js
+++ b/plugins/tracking/actions/__tests__/Actions-test.js
@@ -9,8 +9,8 @@ jest.setMock("react-router", {
 const PluginTestUtils = require("PluginTestUtils");
 
 const SDK = PluginTestUtils.getSDK("tracking", { enabled: true });
-require("../../SDK").setSDK(SDK);
-const Actions = require("../Actions");
+require("../../SDK").default.setSDK(SDK);
+const Actions = require("../Actions").default;
 
 global.analytics = {
   initialized: true,

--- a/plugins/tracking/hooks.js
+++ b/plugins/tracking/hooks.js
@@ -11,11 +11,11 @@ import Actions from "./actions/Actions";
 
 const ANALYTICS_LOAD_TIMEOUT = 2000;
 
-const SDK = require("./SDK").getSDK();
+const SDK = require("./SDK").default.getSDK();
 
 const segmentScript = `!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error('Segment snippet included twice.');else{analytics.invoked=!0;analytics.methods=['trackSubmit','trackClick','trackLink','trackForm','pageview','identify','group','track','ready','alias','page','once','off','on'];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement('script');e.type="text/javascript";e.async=!0;e.src=('https:'===document.location.protocol?'https://':'http://')+'cdn.segment.com/analytics.js/v1/'+t+'/analytics.min.js';var n=document.getElementsByTagName('script')[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="3.0.1";analytics.load("${Config.analyticsKey}");}}();`;
 
-module.exports = {
+export default {
   filters: [
     "pluginsLoadedCheck",
     "userFormModalFooter",

--- a/plugins/tracking/index.js
+++ b/plugins/tracking/index.js
@@ -3,8 +3,8 @@ import SDK from "./SDK";
 export default PluginSDK => {
   SDK.setSDK(PluginSDK);
 
-  const PluginHooks = require("./hooks");
-  const TrackingActions = require("./actions/Actions");
+  const PluginHooks = require("./hooks").default;
+  const TrackingActions = require("./actions/Actions").default;
   // Set plugin's hooks
   PluginHooks.initialize(PluginSDK.config);
 

--- a/plugins/ui-update/SDK.js
+++ b/plugins/ui-update/SDK.js
@@ -1,6 +1,6 @@
 let SDK;
 
-module.exports = {
+export default {
   getSDK() {
     return SDK;
   },

--- a/plugins/ui-update/hooks.js
+++ b/plugins/ui-update/hooks.js
@@ -4,11 +4,11 @@ import container from "#SRC/js/container";
 
 import UIDetails from "./components/UIDetails";
 import { loadNotifications, UIUpdateNotificationsType } from "./notifications";
-import { getSDK } from "./SDK";
+import MySDK from "./SDK";
 
-const SDK = getSDK();
+const SDK = MySDK.getSDK();
 
-module.exports = {
+export default {
   actions: ["userLoginSuccess", "userLogoutSuccess", "redirectToLogin"],
   notifications: {
     updated: null,

--- a/plugins/ui-update/index.js
+++ b/plugins/ui-update/index.js
@@ -3,7 +3,7 @@ import SDK from "./SDK";
 export default PluginSDK => {
   SDK.setSDK(PluginSDK);
 
-  const PluginHooks = require("./hooks");
+  const PluginHooks = require("./hooks").default;
 
   // Set plugin's hooks
   PluginHooks.initialize();

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -70,7 +70,7 @@ fi
 if [ -n "${staged_javascript_files}" ]
 then
   header "Test staged JavaScript files.."
-  npm run test --silent -- --findRelatedTests \
+  npm run test -- --findRelatedTests \
     ${staged_javascript_files} || exit $?
   info "Javascript Tests passed"
 fi

--- a/src/js/components/modals/ModalHeading.js
+++ b/src/js/components/modals/ModalHeading.js
@@ -24,4 +24,4 @@ ModalHeading.propTypes = {
   level: PropTypes.oneOf([1, 2, 3, 4, 5, 6])
 };
 
-module.exports = ModalHeading;
+export default ModalHeading;

--- a/src/js/events/__tests__/MesosSummaryActions-test.js
+++ b/src/js/events/__tests__/MesosSummaryActions-test.js
@@ -2,30 +2,8 @@ import AppDispatcher from "../AppDispatcher";
 import MesosSummaryActions from "../MesosSummaryActions";
 import TimeScales from "../../constants/TimeScales";
 
-const Hooks = require("PluginSDK").Hooks;
-
-jest.setMock("react-router", {
-  hashHistory: {
-    location: { pathname: "/foo" },
-    listen() {}
-  }
-});
-
-const PluginTestUtils = require("PluginTestUtils");
 const RequestUtil = require("mesosphere-shared-reactjs").RequestUtil;
-
-PluginTestUtils.loadPluginsByName({
-  tracking: { enabled: true }
-});
 const Config = require("#SRC/js/config/Config").default;
-
-global.analytics = {
-  initialized: true,
-  track() {},
-  log() {}
-};
-
-Hooks.addFilter("hasCapability", () => true);
 
 describe("Mesos State Actions", () => {
   beforeEach(() => {

--- a/src/js/plugin-bridge/Loader.js
+++ b/src/js/plugin-bridge/Loader.js
@@ -3,7 +3,7 @@ let externalPluginsList;
 
 // Try loading the list of plugins.
 try {
-  pluginsList = require("#PLUGINS/index");
+  pluginsList = require("#PLUGINS/index").default;
 } catch (err) {
   // No plugins
   pluginsList = {};


### PR DESCRIPTION
also NODE_PATH is not needed anymore as plugins-ee now is within the
dcos-ui/-path.

also making jest noisy in the precommit-hook again to better see errors.

