### PR TITLE
refactor(dashboard): omit the use of custom state

### DIFF
--- a/src/js/pages/DashboardPage.jsx
+++ b/src/js/pages/DashboardPage.jsx
@@ -116,15 +116,19 @@ const DashboardPage = createReactClass({
       { name: "unitHealth", events: ["success", "error"], suppressUpdate: true }
     ];
 
-    this.mesosState = getMesosState();
+    this.setState({ mesosState: getMesosState() });
   },
 
   onSummaryStoreError() {
-    this.mesosState = { ...this.mesosState, ...getMesosState() };
+    this.setState({
+      mesosState: { ...this.state.mesosState, ...getMesosState() }
+    });
   },
 
   onSummaryStoreSuccess() {
-    this.mesosState = { ...this.mesosState, ...getMesosState() };
+    this.setState({
+      mesosState: { ...this.state.mesosState, ...getMesosState() }
+    });
   },
 
   onDcosStoreChange() {
@@ -219,7 +223,7 @@ const DashboardPage = createReactClass({
   render() {
     const columnClasses = "column-12 column-small-6 column-large-4";
     const resourceColors = ResourcesUtil.getResourceColors();
-    const data = this.mesosState;
+    const data = this.state.mesosState;
 
     return (
       <Page title="Dashboard">


### PR DESCRIPTION
This removes this.mesosState and puts it into the component state.


## Testing

Test the dashboard and ensure that it still works as expected.

## Trade-offs

N/A

## Dependencies

N/A

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->