### PR TITLE
DCOS-62284 use packages' lastUpdated to show an according warning

### DIFF
--- a/plugins/services/src/js/utils/FrameworkUtil.ts
+++ b/plugins/services/src/js/utils/FrameworkUtil.ts
@@ -63,17 +63,9 @@ const FrameworkUtil = {
    * @returns {null | String | React.ReactNode} Null or string or an HTML element saying when was the last update of this package
    */
   getLastUpdated(cosmosPackage) {
-    try {
-      // This looks like magic, but we are only decoding the package configuration into a string,
-      // and then finding the PACKAGE_BUILD_TIME_STR property.
-      return DateUtil.msToUTCDay(
-        window
-          .atob(cosmosPackage.marathon.v2AppMustacheTemplate)
-          .match(/PACKAGE_BUILD_TIME_STR": "(.*)"/)[1]
-      );
-    } catch (_e) {
-      return null;
-    }
+    return cosmosPackage?.lastUpdated
+      ? DateUtil.msToUTCDay(new Date(cosmosPackage.lastUpdated * 1000))
+      : null;
   }
 };
 

--- a/src/js/__tests__/__snapshots__/typecheck-test.ts.snap
+++ b/src/js/__tests__/__snapshots__/typecheck-test.ts.snap
@@ -3757,8 +3757,6 @@ plugins/services/src/js/utils/DeclinedOffersUtil.ts: error TS2531: Object is pos
 plugins/services/src/js/utils/DeclinedOffersUtil.ts: error TS2531: Object is possibly 'null'.
 plugins/services/src/js/utils/DeclinedOffersUtil.ts: error TS2322: Type '\\"N/A\\"' is not assignable to type 'null'.
 plugins/services/src/js/utils/FrameworkUtil.ts: error TS2339: Property 'atob' does not exist on type 'Global'.
-plugins/services/src/js/utils/FrameworkUtil.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'number | Date'.
-plugins/services/src/js/utils/FrameworkUtil.ts: error TS2531: Object is possibly 'null'.
 plugins/services/src/js/utils/HostUtil.ts: error TS6133: 'match' is declared but its value is never read.
 plugins/services/src/js/utils/MarathonUtil.ts: error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
 plugins/services/src/js/utils/MarathonUtil.ts: error TS2769: No overload matches this call.

--- a/tests/_fixtures/cosmos/old-package-describe.json
+++ b/tests/_fixtures/cosmos/old-package-describe.json
@@ -1,546 +1,528 @@
 {
-    "package": {
-      "packagingVersion": "3.0",
-      "name": "marathon",
-      "version": "1.4.6",
-      "releaseVersion": 10,
-      "maintainer": "support@mesosphere.io",
-      "description": "A container orchestration platform for Mesos and DCOS. Documentation: https://docs.mesosphere.com/1.11/deploying-services/marathon-api/",
-      "tags": [
-        "init",
-        "long-running"
-      ],
-      "selected": true,
-      "scm": "https://github.com/mesosphere/marathon.git",
-      "framework": true,
-      "preInstallNotes": "We recommend a minimum of one node with at least 2 CPU shares and 1GB of RAM available for the Marathon DCOS Service. More information: https://mesosphere.github.io/marathon/",
-      "postInstallNotes": "Marathon DCOS Service has been successfully installed!\n\n\tDocumentation: https://mesosphere.github.io/marathon\n\tIssues: https://github.com/mesosphere/marathon/issues\n",
-      "postUninstallNotes": "The Marathon DCOS Service has been uninstalled and will no longer run.\nPlease follow the instructions at http://docs.mesosphere.com/services/marathon/#uninstall to clean up any persisted state",
-      "licenses": [
-        {
-          "name": "Apache License Version 2.0",
-          "url": "https://github.com/mesosphere/marathon/blob/master/LICENSE"
-        }
-      ],
-      "minDcosReleaseVersion": "1.9",
-      "marathon": {
-        "v2AppMustacheTemplate": "eyJQQUNLQUdFX0JVSUxEX1RJTUVfU1RSIjogIlRodSBKYW4gMjQgMjAxOSAwMDo0MTozOSArMDAwMCJ9"
-      },
-      "resource": {
-        "assets": {
-          "container": {
-            "docker": {
-              "image": "mesosphere/marathon:v1.4.6"
-            }
-          }
-        },
-        "images": {
-          "icon-small": "https://downloads.mesosphere.com/marathon/assets/icon-service-marathon-small.png",
-          "icon-medium": "https://downloads.mesosphere.com/marathon/assets/icon-service-marathon-medium.png",
-          "icon-large": "https://downloads.mesosphere.com/marathon/assets/icon-service-marathon-large.png",
-          "screenshots": [
-            "https://mesosphere.com/wp-content/themes/mesosphere/library/images/assets/marathon-0.6.0/mesosphere-marathon-app-list.png",
-            "https://beingasysadmin.files.wordpress.com/2014/06/marathon2.png",
-            "https://mesosphere.github.io/presentations/mug-ericsson-2014/assets/marathon-logo.jpg",
-            "https://mesosphere.com/wp-content/themes/mesosphere/library/images/assets/marathon-0.6.0/mesosphere-marathon-app-list.png",
-            "http://www.clker.com/cliparts/0/f/d/b/12917289761851255679earth-map-huge.jpg",
-            "https://mesosphere.github.io/presentations/mug-ericsson-2014/assets/marathon-logo.jpg",
-            "http://33.media.tumblr.com/9ff4e10667237a30d89f55f13fc5b45b/tumblr_inline_mksdnegnw31qz4rgp.gif"
-          ]
-        }
-      },
-      "config": {
-        "additionalProperties": false,
-        "description": "Marathon DCOS Service properties",
-        "properties": {
-          "service": {
-            "additionalProperties": false,
-            "description": "Marathon app configuration properties.",
-            "properties": {
-              "name": {
-                "description": "The name of this Marathon service inside DCOS base Marathon.\nIf not specified otherwise, this name will also be used for the framework name, dcos service name, zk path and mesos role.\nTo create a nested path, please specify a group.",
-                "type": "string",
-                "default": "marathon-user",
-                "pattern": "^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$"
-              },
-              "group": {
-                "description": "The group of this Marathon service inside DCOS base Marathon. If a group is defined, the id of this service will be group/name",
-                "type": "string",
-                "pattern": "^[/]?(([a-z0-9])([a-z0-9\\-]*[a-z0-9]))([/](([a-z0-9])([a-z0-9\\-]*[a-z0-9])))*$"
-              },
-              "region": {
-                "default": "",
-                "description": "Region picker",
-                "type": "string",
-                "media": {
-                  "type": "application/x-region+string"
-                }
-              },
-              "cpus": {
-                "default": 2,
-                "description": "CPU shares to allocate to each Marathon instance.",
-                "minimum": 0,
-                "type": "number"
-              },
-              "mem": {
-                "default": 1536,
-                "description": "Memory (MB) to allocate to each Marathon instance.",
-                "minimum": 512,
-                "type": "number"
-              },
-              "instances": {
-                "default": 1,
-                "description": "Number of Marathon instances to run.",
-                "minimum": 0,
-                "type": "integer"
-              },
-              "uris": {
-                "default": [
-  
-                ],
-                "description": "List of URIs that will be downloaded and made available in the current working directory of Marathon. For example this can be used to download a Java keystore file for SSL configuration.",
-                "items": {
-                  "pattern": "^[\\s]+",
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "custom_yml": {
-                "description": "Custom YAML to be appended to config.yml on each node. This field must be base64 encoded.",
-                "default": "ZGlzY292ZXJ5Og0KICAgIHplbjoNCiAgICAgICAgcGluZzoNCiAgICAgICAgICAgIG11bHRpY2FzdDoNCiAgICAgICAgICAgICAgICBlbmFibGVkOiBmYWxzZQ==",
-                "type": "string",
-                "media": {
-                  "type": "application/x-yaml"
-                }
-              },
-              "placement_constraints": {
-                "description": "Placement Constraints",
-                "media": {
-                  "type": "application/x-region-zone-constraints+json"
-                },
-                "type": "string",
-                "default": "[]"
-              }
-            },
-            "required": [
-              "cpus",
-              "mem",
-              "instances"
-            ],
-            "type": "object"
-          },
-          "jvm": {
-            "additionalProperties": false,
-            "description": "JVM configuration properties",
-            "properties": {
-              "heap-min": {
-                "default": 256,
-                "description": "Memory (MB) start size for the JVM heap. This number should be be less or equals than the heap-max.",
-                "minimum": 0,
-                "type": "integer"
-              },
-              "heap-max": {
-                "default": 768,
-                "description": "Memory (MB) max size for the JVM heap. This number should be less than the memory allocated to the Marathon instance (General rule: 50%).",
-                "minimum": 0,
-                "type": "integer"
-              },
-              "opts": {
-                "description": "Allows additional JVM_OPTS to be applied outside of the standard mx and ms.",
-                "type": "string"
-              }
-            },
-            "required": [
-              "heap-min",
-              "heap-max"
-            ],
-            "type": "object"
-          },
-          "marathon": {
-            "additionalProperties": true,
-            "description": "Marathon command line flags. These are the same flags that are passed through to Marathon when launching manually from the command line. See details here: https://mesosphere.github.io/marathon/docs/command-line-flags.html",
-            "properties": {
-              "access-control-allow-origin": {
-                "description": "The origin(s) to allow in Marathon. Not set by default. Example values are \"*\", or \"http://localhost:8888, http://domain.com\"",
-                "type": "string"
-              },
-              "artifact-store": {
-                "description": "URL to the artifact store. Supported store types hdfs, file. Example: hdfs://localhost:54310/path/to/store, file:///var/log/store",
-                "type": "string"
-              },
-              "checkpoint": {
-                "description": "Enabled: (Default) Enable checkpointing of tasks. Requires checkpointing enabled on slaves. Allows tasks to continue running during mesos-slave restarts and upgrades Disabled: Disable checkpointing of tasks.",
-                "type": "boolean",
-                "default": true
-              },
-              "decline-offer-duration": {
-                "description": "(Default: 120 seconds) The duration (milliseconds) for which to decline offers by default",
-                "type": "integer",
-                "default": 120000
-              },
-              "default-accepted-resource-roles": {
-                "description": "Default for the defaultAcceptedResourceRoles attribute of all app definitions as a comma-separated list of strings. This defaults to all roles for which this Marathon instance is configured to receive offers.",
-                "type": "string",
-                "default": "*"
-              },
-              "default-network-name": {
-                "description": "Network name, injected into applications' ipAddress{} specs that do not define their own networkName.",
-                "type": "string"
-              },
-              "disable-http": {
-                "description": "Disable listening for HTTP requests completely. HTTPS is unaffected.",
-                "type": "boolean",
-                "default": false
-              },
-              "enable-features": {
-                "description": "A comma-separated list of features. Available features are: secrets - Enable support for secrets in Marathon (experimental), external_volumes - Enable external volumes support in Marathon, vips - Enable networking VIPs UI, gpu_resources - Enable support for GPU in Marathon (experimental), task_killing - Enable the optional TASK_KILLING state, available in Mesos 0.28 and later",
-                "type": "string",
-                "default": "vips,task_killing"
-              },
-              "env-vars-prefix": {
-                "description": "Prefix to use for environment variables injected automatically into all started tasks.",
-                "type": "string"
-              },
-              "event-stream-max-outstanding-messages": {
-                "description": "The event stream buffers events, that are not already consumed by clients. This number defines the number of events that get buffered on the server side, before messages are dropped.",
-                "type": "integer",
-                "default": 50
-              },
-              "event-subscriber": {
-                "description": "The event subscription module to use. E.g. http_callback.",
-                "type": "string"
-              },
-              "executor": {
-                "description": "Executor to use when none is specified. If not defined the Mesos command executor is used by default.",
-                "type": "string",
-                "default": "//cmd"
-              },
-              "failover-timeout": {
-                "description": "(Default: 1 week) The failover_timeout for mesos in seconds.",
-                "type": "integer",
-                "default": 604800
-              },
-              "framework-name": {
-                "description": "(Default: service.name) Framework name to register with Mesos.",
-                "type": "string"
-              },
-              "ha": {
-                "description": "Enabled: (Default) Run Marathon in HA mode with leader election. Allows starting an arbitrary number of other Marathons but all need to be started in HA mode. This mode requires a running ZooKeeper Disabled: Run Marathon in single node mode.",
-                "type": "boolean",
-                "default": true
-              },
-              "hostname": {
-                "description": "The advertised hostname that is used for the communication with the Mesos master. The value is also stored in the persistent store so another standby host can redirect to the elected leader.",
-                "type": "string"
-              },
-              "http-address": {
-                "description": "The address to listen on for HTTP requests",
-                "type": "string"
-              },
-              "http-compression": {
-                "description": "Enabled: (Default) Enable http compression. Disabled: Disable http compression. ",
-                "type": "boolean",
-                "default": true
-              },
-              "http-credentials": {
-                "description": "Credentials for accessing the http service. If empty, anyone can access the HTTP endpoint. A username:password pair is expected where the username must not contain ':'. May also be specified with the `MESOSPHERE_HTTP_CREDENTIALS` environment variable. ",
-                "type": "string"
-              },
-              "http-endpoints": {
-                "description": "The URLs of the event endpoints added to the current list of subscribers on startup. You can manage this list during runtime by using the /v2/eventSubscriptions API endpoint.",
-                "type": "string"
-              },
-              "http-event-callback-slow-consumer-timeout": {
-                "description": "A http event callback consumer is considered slow, if the delivery takes longer than this timeout (ms)",
-                "type": "integer",
-                "default": 10000
-              },
-              "http-event-request-timeout": {
-                "description": "A http event request timeout (ms)",
-                "type": "integer",
-                "default": 10000
-              },
-              "http-max-concurrent-requests": {
-                "description": "The number of concurrent HTTP requests that are allowed before rejecting.",
-                "type": "integer"
-              },
-              "http-port": {
-                "description": "The port to listen on for HTTP requests",
-                "type": "integer"
-              },
-              "http-realm": {
-                "description": "The security realm (aka 'area') associated with the credentials",
-                "type": "string",
-                "default": "Mesosphere"
-              },
-              "https-address": {
-                "description": "The address to listen on for HTTPS requests.",
-                "type": "string"
-              },
-              "https-port": {
-                "description": "The port to listen on for HTTPS requests",
-                "type": "integer"
-              },
-              "launch-token-refresh-interval": {
-                "description": "The interval (ms) in which to refresh the launch tokens to --launch_token_count",
-                "type": "integer",
-                "default": 30000
-              },
-              "launch-tokens": {
-                "description": "Launch tokens per interval",
-                "type": "integer",
-                "default": 100
-              },
-              "leader-proxy-connection-timeout": {
-                "description": "Maximum time, in milliseconds, to wait for connecting to the current Marathon leader from another Marathon instance.",
-                "type": "integer",
-                "default": 5000
-              },
-              "leader-proxy-read-timeout": {
-                "description": "Maximum time, in milliseconds, for reading from the current Marathon leader.",
-                "type": "integer",
-                "default": 10000
-              },
-              "leader-proxy-ssl-ignore-hostname": {
-                "description": "Do not verify that the hostname of the Marathon leader matches the one in the SSL certificate when proxying API requests to the current leader.",
-                "type": "boolean",
-                "default": false
-              },
-              "local-port-max": {
-                "description": "Max port number to use when assigning globally unique service ports to apps.",
-                "type": "integer",
-                "default": 20000
-              },
-              "local-port-min": {
-                "description": "Min port number to use when assigning globally unique service ports to apps.",
-                "type": "integer",
-                "default": 10000
-              },
-              "logging-level": {
-                "description": "Set logging level to one of: off, error, warn, info, debug, trace, all",
-                "type": "string"
-              },
-              "logstash": {
-                "description": "Logs destination URI in format (udp|tcp|ssl)://<host>:<port>",
-                "type": "string"
-              },
-              "master": {
-                "description": "The URL of the Mesos master",
-                "type": "string",
-                "default": "zk://master.mesos:2181/mesos"
-              },
-              "max-apps": {
-                "description": "The maximum number of applications that may be created.",
-                "type": "integer"
-              },
-              "max-instances-per-offer": {
-                "description": "Max instances per offer. Do not start more than this number of app or pod instances on a single offer.",
-                "type": "integer"
-              },
-              "max-tasks-per-offer": {
-                "description": "(deprecated) Maximum tasks per offer. Do not start more than this number of tasks on a single offer.",
-                "type": "integer",
-                "default": 1
-              },
-              "mesos-authentication": {
-                "description": "Enabled: Will use framework authentication while registering with Mesos with principal and optional secret. Disabled: (Default) will not use framework authentication while registering with Mesos.",
-                "type": "boolean",
-                "default": false
-              },
-              "mesos-authentication-principal": {
-                "description": "(Default: service.name) Mesos Authentication Principal.",
-                "type": "string"
-              },
-              "mesos-authentication-secret": {
-                "description": "Mesos Authentication Secret.",
-                "type": "string"
-              },
-              "mesos-authentication-secret-file": {
-                "description": "Path to a file containing the Mesos Authentication Secret.",
-                "type": "string"
-              },
-              "mesos-leader-ui-url": {
-                "description": "The host and port (e.g. \"http://mesos_host:5050\") of the Mesos master.",
-                "type": "string",
-                "default": "/mesos"
-              },
-              "mesos-role": {
-                "description": "(Default: service.name) Mesos role for this framework. If set, Marathon receives resource offers for the specified role in addition to resources with the role designation '*'.",
-                "type": "string"
-              },
-              "mesos-user": {
-                "description": "Mesos user for this framework.",
-                "type": "string"
-              },
-              "metrics": {
-                "description": "Enabled: (Default) Expose the execution time of service method calls using code instrumentation via the metrics endpoint (/metrics). This might noticeably degrade performance but can help finding performance problems. Disabled: Disable exposing execution time of service method calls using code instrumentation via the metrics endpoing (/metrics). This does not turn off reporting of other metrics.",
-                "type": "boolean",
-                "default": true
-              },
-              "min-revive-offers-interval": {
-                "description": "Do not ask for all offers (also already seen ones) more often than this interval (ms).",
-                "type": "integer",
-                "default": 5000
-              },
-              "offer-matching-timeout": {
-                "description": "Offer matching timeout (ms). Stop trying to match additional tasks for this offer after this time.",
-                "type": "integer",
-                "default": 1000
-              },
-              "on-elected-prepare-timeout": {
-                "description": "The timeout for preparing the Marathon instance when elected as leader.",
-                "type": "integer",
-                "default": 180000
-              },
-              "plugin-conf": {
-                "description": "The plugin configuration file.",
-                "type": "string"
-              },
-              "plugin-dir": {
-                "description": "Path to a local directory containing plugin jars.",
-                "type": "string"
-              },
-              "reconciliation-initial-delay": {
-                "description": "This is the length of time, in milliseconds, before Marathon begins to periodically perform task reconciliation operations",
-                "type": "integer",
-                "default": 15000
-              },
-              "reconciliation-interval": {
-                "description": "This is the length of time, in milliseconds, between task reconciliation operations.",
-                "type": "integer",
-                "default": 600000
-              },
-              "reporter-datadog": {
-                "description": "URL to dogstatsd agent. e.g. udp://localhost:8125?prefix=marathon-test&tags=marathon&interval=10",
-                "type": "string"
-              },
-              "reporter-graphite": {
-                "description": "URL to graphite agent. e.g. tcp://localhost:2003?prefix=marathon-test&interval=10",
-                "type": "string"
-              },
-              "revive-offers-repetitions": {
-                "description": "Repeat every reviveOffer request this many times, delayed by the --min_revive_offers_interval.",
-                "type": "integer",
-                "default": 3
-              },
-              "save-tasks-to-launch-timeout": {
-                "description": "Timeout (ms) after matching an offer for saving all matched tasks that we are about to launch. When reaching the timeout, only the tasks that we could save within the timeout are also launched. All other task launches are temporarily rejected and retried later.",
-                "type": "integer",
-                "default": 3000
-              },
-              "scale-apps-initial-delay": {
-                "description": "This is the length of time, in milliseconds, before Marathon begins to periodically attempt to scale apps.",
-                "type": "integer",
-                "default": 15000
-              },
-              "scale-apps-interval": {
-                "description": "This is the length of time, in milliseconds, between task scale apps.",
-                "type": "integer",
-                "default": 300000
-              },
-              "sentry": {
-                "description": "URI for sentry, e.g. https://<public>:<private>@sentryserver/",
-                "type": "string"
-              },
-              "sentry-tags": {
-                "description": "Tags to post to sentry with, e.g: tag1:value1,tag2:value2",
-                "type": "string"
-              },
-              "ssl-keystore-password": {
-                "description": "Password for the keystore supplied with the `ssl_keystore_path` option. Required if `ssl_keystore_path` is supplied. May also be specified with the `MESOSPHERE_KEYSTORE_PASS` environment variable.",
-                "type": "string"
-              },
-              "ssl-keystore-path": {
-                "description": "Path to the SSL keystore. HTTPS (SSL) will be enabled if this option is supplied. Requires `--ssl_keystore_password`. May also be specified with the `MESOSPHERE_KEYSTORE_PATH` environment variable.",
-                "type": "string"
-              },
-              "store-cache": {
-                "description": "Enabled: (Default) Enable an in-memory cache for the storage layer. Disabled: Disable the in-memory cache for the storage layer. ",
-                "type": "boolean",
-                "default": true
-              },
-              "task-launch-confirm-timeout": {
-                "description": "Time, in milliseconds, to wait for a task to enter the TASK_STAGING state before killing it.",
-                "type": "integer",
-                "default": 300000
-              },
-              "task-launch-timeout": {
-                "description": "Time, in milliseconds, to wait for a task to enter the TASK_RUNNING state before killing it.",
-                "type": "integer",
-                "default": 300000
-              },
-              "task-lost-expunge-initial-delay": {
-                "description": "This is the length of time, in milliseconds, before Marathon begins to periodically perform task expunge gc operations",
-                "type": "integer",
-                "default": 300000
-              },
-              "task-lost-expunge-interval": {
-                "description": "This is the length of time in milliseconds, for lost task gc operations.",
-                "type": "integer",
-                "default": 30000
-              },
-              "task-reservation-timeout": {
-                "description": "Time, in milliseconds, to wait for a new reservation to be acknowledged via a received offer before deleting it.",
-                "type": "integer",
-                "default": 20000
-              },
-              "tracing": {
-                "description": "Enabled: Enable trace logging of service method calls. Disabled: (Default) Disable trace logging of service method calls.",
-                "type": "boolean",
-                "default": false
-              },
-              "webui-url": {
-                "description": "The HTTP(S) url of the web ui, defaulting to the advertised hostname.",
-                "type": "string"
-              },
-              "zk": {
-                "description": "ZooKeeper URL for storing state. Format: zk://host1:port1,host2:port2,.../path",
-                "type": "string"
-              },
-              "zk-compression": {
-                "description": "Enabled: (Default) Enable compression of zk nodes, if the size of the node is bigger than the configured threshold. Disabled: Disable compression of zk nodes",
-                "type": "boolean",
-                "default": true
-              },
-              "zk-compression-threshold": {
-                "description": "(Default: 64 KB) Threshold in bytes, when compression is applied to the ZooKeeper node.",
-                "type": "integer",
-                "default": 65536
-              },
-              "zk-max-node-size": {
-                "description": "(Default: 1 MiB) Maximum allowed ZooKeeper node size (in bytes).",
-                "type": "integer",
-                "default": 1024000
-              },
-              "zk-max-versions": {
-                "description": "Limit the number of versions, stored for one entity.",
-                "type": "integer",
-                "default": 50
-              },
-              "zk-session-timeout": {
-                "description": "The timeout for ZooKeeper sessions in milliseconds",
-                "type": "integer",
-                "default": 10000
-              },
-              "zk-timeout": {
-                "description": "The timeout for ZooKeeper operations in milliseconds.",
-                "type": "integer",
-                "default": 10000
-              }
-            },
-            "required": [
-              "master"
-            ],
-            "type": "object"
-          }
-        },
-        "required": [
-          "service",
-          "jvm",
-          "marathon"
-        ],
-        "type": "object"
+  "package": {
+    "packagingVersion": "3.0",
+    "name": "marathon",
+    "version": "1.4.6",
+    "releaseVersion": 10,
+    "maintainer": "support@mesosphere.io",
+    "description": "A container orchestration platform for Mesos and DCOS. Documentation: https://docs.mesosphere.com/1.11/deploying-services/marathon-api/",
+    "tags": ["init", "long-running"],
+    "selected": true,
+    "scm": "https://github.com/mesosphere/marathon.git",
+    "framework": true,
+    "preInstallNotes": "We recommend a minimum of one node with at least 2 CPU shares and 1GB of RAM available for the Marathon DCOS Service. More information: https://mesosphere.github.io/marathon/",
+    "postInstallNotes": "Marathon DCOS Service has been successfully installed!\n\n\tDocumentation: https://mesosphere.github.io/marathon\n\tIssues: https://github.com/mesosphere/marathon/issues\n",
+    "postUninstallNotes": "The Marathon DCOS Service has been uninstalled and will no longer run.\nPlease follow the instructions at http://docs.mesosphere.com/services/marathon/#uninstall to clean up any persisted state",
+    "lastUpdated": 1577120873,
+    "licenses": [
+      {
+        "name": "Apache License Version 2.0",
+        "url": "https://github.com/mesosphere/marathon/blob/master/LICENSE"
       }
+    ],
+    "minDcosReleaseVersion": "1.9",
+    "marathon": {
+      "v2AppMustacheTemplate": "eyJQQUNLQUdFX0JVSUxEX1RJTUVfU1RSIjogIlRodSBKYW4gMjQgMjAxOSAwMDo0MTozOSArMDAwMCJ9"
+    },
+    "resource": {
+      "assets": {
+        "container": {
+          "docker": {
+            "image": "mesosphere/marathon:v1.4.6"
+          }
+        }
+      },
+      "images": {
+        "icon-small": "https://downloads.mesosphere.com/marathon/assets/icon-service-marathon-small.png",
+        "icon-medium": "https://downloads.mesosphere.com/marathon/assets/icon-service-marathon-medium.png",
+        "icon-large": "https://downloads.mesosphere.com/marathon/assets/icon-service-marathon-large.png",
+        "screenshots": [
+          "https://mesosphere.com/wp-content/themes/mesosphere/library/images/assets/marathon-0.6.0/mesosphere-marathon-app-list.png",
+          "https://beingasysadmin.files.wordpress.com/2014/06/marathon2.png",
+          "https://mesosphere.github.io/presentations/mug-ericsson-2014/assets/marathon-logo.jpg",
+          "https://mesosphere.com/wp-content/themes/mesosphere/library/images/assets/marathon-0.6.0/mesosphere-marathon-app-list.png",
+          "http://www.clker.com/cliparts/0/f/d/b/12917289761851255679earth-map-huge.jpg",
+          "https://mesosphere.github.io/presentations/mug-ericsson-2014/assets/marathon-logo.jpg",
+          "http://33.media.tumblr.com/9ff4e10667237a30d89f55f13fc5b45b/tumblr_inline_mksdnegnw31qz4rgp.gif"
+        ]
+      }
+    },
+    "config": {
+      "additionalProperties": false,
+      "description": "Marathon DCOS Service properties",
+      "properties": {
+        "service": {
+          "additionalProperties": false,
+          "description": "Marathon app configuration properties.",
+          "properties": {
+            "name": {
+              "description": "The name of this Marathon service inside DCOS base Marathon.\nIf not specified otherwise, this name will also be used for the framework name, dcos service name, zk path and mesos role.\nTo create a nested path, please specify a group.",
+              "type": "string",
+              "default": "marathon-user",
+              "pattern": "^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$"
+            },
+            "group": {
+              "description": "The group of this Marathon service inside DCOS base Marathon. If a group is defined, the id of this service will be group/name",
+              "type": "string",
+              "pattern": "^[/]?(([a-z0-9])([a-z0-9\\-]*[a-z0-9]))([/](([a-z0-9])([a-z0-9\\-]*[a-z0-9])))*$"
+            },
+            "region": {
+              "default": "",
+              "description": "Region picker",
+              "type": "string",
+              "media": {
+                "type": "application/x-region+string"
+              }
+            },
+            "cpus": {
+              "default": 2,
+              "description": "CPU shares to allocate to each Marathon instance.",
+              "minimum": 0,
+              "type": "number"
+            },
+            "mem": {
+              "default": 1536,
+              "description": "Memory (MB) to allocate to each Marathon instance.",
+              "minimum": 512,
+              "type": "number"
+            },
+            "instances": {
+              "default": 1,
+              "description": "Number of Marathon instances to run.",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uris": {
+              "default": [],
+              "description": "List of URIs that will be downloaded and made available in the current working directory of Marathon. For example this can be used to download a Java keystore file for SSL configuration.",
+              "items": {
+                "pattern": "^[\\s]+",
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "custom_yml": {
+              "description": "Custom YAML to be appended to config.yml on each node. This field must be base64 encoded.",
+              "default": "ZGlzY292ZXJ5Og0KICAgIHplbjoNCiAgICAgICAgcGluZzoNCiAgICAgICAgICAgIG11bHRpY2FzdDoNCiAgICAgICAgICAgICAgICBlbmFibGVkOiBmYWxzZQ==",
+              "type": "string",
+              "media": {
+                "type": "application/x-yaml"
+              }
+            },
+            "placement_constraints": {
+              "description": "Placement Constraints",
+              "media": {
+                "type": "application/x-region-zone-constraints+json"
+              },
+              "type": "string",
+              "default": "[]"
+            }
+          },
+          "required": ["cpus", "mem", "instances"],
+          "type": "object"
+        },
+        "jvm": {
+          "additionalProperties": false,
+          "description": "JVM configuration properties",
+          "properties": {
+            "heap-min": {
+              "default": 256,
+              "description": "Memory (MB) start size for the JVM heap. This number should be be less or equals than the heap-max.",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "heap-max": {
+              "default": 768,
+              "description": "Memory (MB) max size for the JVM heap. This number should be less than the memory allocated to the Marathon instance (General rule: 50%).",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "opts": {
+              "description": "Allows additional JVM_OPTS to be applied outside of the standard mx and ms.",
+              "type": "string"
+            }
+          },
+          "required": ["heap-min", "heap-max"],
+          "type": "object"
+        },
+        "marathon": {
+          "additionalProperties": true,
+          "description": "Marathon command line flags. These are the same flags that are passed through to Marathon when launching manually from the command line. See details here: https://mesosphere.github.io/marathon/docs/command-line-flags.html",
+          "properties": {
+            "access-control-allow-origin": {
+              "description": "The origin(s) to allow in Marathon. Not set by default. Example values are \"*\", or \"http://localhost:8888, http://domain.com\"",
+              "type": "string"
+            },
+            "artifact-store": {
+              "description": "URL to the artifact store. Supported store types hdfs, file. Example: hdfs://localhost:54310/path/to/store, file:///var/log/store",
+              "type": "string"
+            },
+            "checkpoint": {
+              "description": "Enabled: (Default) Enable checkpointing of tasks. Requires checkpointing enabled on slaves. Allows tasks to continue running during mesos-slave restarts and upgrades Disabled: Disable checkpointing of tasks.",
+              "type": "boolean",
+              "default": true
+            },
+            "decline-offer-duration": {
+              "description": "(Default: 120 seconds) The duration (milliseconds) for which to decline offers by default",
+              "type": "integer",
+              "default": 120000
+            },
+            "default-accepted-resource-roles": {
+              "description": "Default for the defaultAcceptedResourceRoles attribute of all app definitions as a comma-separated list of strings. This defaults to all roles for which this Marathon instance is configured to receive offers.",
+              "type": "string",
+              "default": "*"
+            },
+            "default-network-name": {
+              "description": "Network name, injected into applications' ipAddress{} specs that do not define their own networkName.",
+              "type": "string"
+            },
+            "disable-http": {
+              "description": "Disable listening for HTTP requests completely. HTTPS is unaffected.",
+              "type": "boolean",
+              "default": false
+            },
+            "enable-features": {
+              "description": "A comma-separated list of features. Available features are: secrets - Enable support for secrets in Marathon (experimental), external_volumes - Enable external volumes support in Marathon, vips - Enable networking VIPs UI, gpu_resources - Enable support for GPU in Marathon (experimental), task_killing - Enable the optional TASK_KILLING state, available in Mesos 0.28 and later",
+              "type": "string",
+              "default": "vips,task_killing"
+            },
+            "env-vars-prefix": {
+              "description": "Prefix to use for environment variables injected automatically into all started tasks.",
+              "type": "string"
+            },
+            "event-stream-max-outstanding-messages": {
+              "description": "The event stream buffers events, that are not already consumed by clients. This number defines the number of events that get buffered on the server side, before messages are dropped.",
+              "type": "integer",
+              "default": 50
+            },
+            "event-subscriber": {
+              "description": "The event subscription module to use. E.g. http_callback.",
+              "type": "string"
+            },
+            "executor": {
+              "description": "Executor to use when none is specified. If not defined the Mesos command executor is used by default.",
+              "type": "string",
+              "default": "//cmd"
+            },
+            "failover-timeout": {
+              "description": "(Default: 1 week) The failover_timeout for mesos in seconds.",
+              "type": "integer",
+              "default": 604800
+            },
+            "framework-name": {
+              "description": "(Default: service.name) Framework name to register with Mesos.",
+              "type": "string"
+            },
+            "ha": {
+              "description": "Enabled: (Default) Run Marathon in HA mode with leader election. Allows starting an arbitrary number of other Marathons but all need to be started in HA mode. This mode requires a running ZooKeeper Disabled: Run Marathon in single node mode.",
+              "type": "boolean",
+              "default": true
+            },
+            "hostname": {
+              "description": "The advertised hostname that is used for the communication with the Mesos master. The value is also stored in the persistent store so another standby host can redirect to the elected leader.",
+              "type": "string"
+            },
+            "http-address": {
+              "description": "The address to listen on for HTTP requests",
+              "type": "string"
+            },
+            "http-compression": {
+              "description": "Enabled: (Default) Enable http compression. Disabled: Disable http compression. ",
+              "type": "boolean",
+              "default": true
+            },
+            "http-credentials": {
+              "description": "Credentials for accessing the http service. If empty, anyone can access the HTTP endpoint. A username:password pair is expected where the username must not contain ':'. May also be specified with the `MESOSPHERE_HTTP_CREDENTIALS` environment variable. ",
+              "type": "string"
+            },
+            "http-endpoints": {
+              "description": "The URLs of the event endpoints added to the current list of subscribers on startup. You can manage this list during runtime by using the /v2/eventSubscriptions API endpoint.",
+              "type": "string"
+            },
+            "http-event-callback-slow-consumer-timeout": {
+              "description": "A http event callback consumer is considered slow, if the delivery takes longer than this timeout (ms)",
+              "type": "integer",
+              "default": 10000
+            },
+            "http-event-request-timeout": {
+              "description": "A http event request timeout (ms)",
+              "type": "integer",
+              "default": 10000
+            },
+            "http-max-concurrent-requests": {
+              "description": "The number of concurrent HTTP requests that are allowed before rejecting.",
+              "type": "integer"
+            },
+            "http-port": {
+              "description": "The port to listen on for HTTP requests",
+              "type": "integer"
+            },
+            "http-realm": {
+              "description": "The security realm (aka 'area') associated with the credentials",
+              "type": "string",
+              "default": "Mesosphere"
+            },
+            "https-address": {
+              "description": "The address to listen on for HTTPS requests.",
+              "type": "string"
+            },
+            "https-port": {
+              "description": "The port to listen on for HTTPS requests",
+              "type": "integer"
+            },
+            "launch-token-refresh-interval": {
+              "description": "The interval (ms) in which to refresh the launch tokens to --launch_token_count",
+              "type": "integer",
+              "default": 30000
+            },
+            "launch-tokens": {
+              "description": "Launch tokens per interval",
+              "type": "integer",
+              "default": 100
+            },
+            "leader-proxy-connection-timeout": {
+              "description": "Maximum time, in milliseconds, to wait for connecting to the current Marathon leader from another Marathon instance.",
+              "type": "integer",
+              "default": 5000
+            },
+            "leader-proxy-read-timeout": {
+              "description": "Maximum time, in milliseconds, for reading from the current Marathon leader.",
+              "type": "integer",
+              "default": 10000
+            },
+            "leader-proxy-ssl-ignore-hostname": {
+              "description": "Do not verify that the hostname of the Marathon leader matches the one in the SSL certificate when proxying API requests to the current leader.",
+              "type": "boolean",
+              "default": false
+            },
+            "local-port-max": {
+              "description": "Max port number to use when assigning globally unique service ports to apps.",
+              "type": "integer",
+              "default": 20000
+            },
+            "local-port-min": {
+              "description": "Min port number to use when assigning globally unique service ports to apps.",
+              "type": "integer",
+              "default": 10000
+            },
+            "logging-level": {
+              "description": "Set logging level to one of: off, error, warn, info, debug, trace, all",
+              "type": "string"
+            },
+            "logstash": {
+              "description": "Logs destination URI in format (udp|tcp|ssl)://<host>:<port>",
+              "type": "string"
+            },
+            "master": {
+              "description": "The URL of the Mesos master",
+              "type": "string",
+              "default": "zk://master.mesos:2181/mesos"
+            },
+            "max-apps": {
+              "description": "The maximum number of applications that may be created.",
+              "type": "integer"
+            },
+            "max-instances-per-offer": {
+              "description": "Max instances per offer. Do not start more than this number of app or pod instances on a single offer.",
+              "type": "integer"
+            },
+            "max-tasks-per-offer": {
+              "description": "(deprecated) Maximum tasks per offer. Do not start more than this number of tasks on a single offer.",
+              "type": "integer",
+              "default": 1
+            },
+            "mesos-authentication": {
+              "description": "Enabled: Will use framework authentication while registering with Mesos with principal and optional secret. Disabled: (Default) will not use framework authentication while registering with Mesos.",
+              "type": "boolean",
+              "default": false
+            },
+            "mesos-authentication-principal": {
+              "description": "(Default: service.name) Mesos Authentication Principal.",
+              "type": "string"
+            },
+            "mesos-authentication-secret": {
+              "description": "Mesos Authentication Secret.",
+              "type": "string"
+            },
+            "mesos-authentication-secret-file": {
+              "description": "Path to a file containing the Mesos Authentication Secret.",
+              "type": "string"
+            },
+            "mesos-leader-ui-url": {
+              "description": "The host and port (e.g. \"http://mesos_host:5050\") of the Mesos master.",
+              "type": "string",
+              "default": "/mesos"
+            },
+            "mesos-role": {
+              "description": "(Default: service.name) Mesos role for this framework. If set, Marathon receives resource offers for the specified role in addition to resources with the role designation '*'.",
+              "type": "string"
+            },
+            "mesos-user": {
+              "description": "Mesos user for this framework.",
+              "type": "string"
+            },
+            "metrics": {
+              "description": "Enabled: (Default) Expose the execution time of service method calls using code instrumentation via the metrics endpoint (/metrics). This might noticeably degrade performance but can help finding performance problems. Disabled: Disable exposing execution time of service method calls using code instrumentation via the metrics endpoing (/metrics). This does not turn off reporting of other metrics.",
+              "type": "boolean",
+              "default": true
+            },
+            "min-revive-offers-interval": {
+              "description": "Do not ask for all offers (also already seen ones) more often than this interval (ms).",
+              "type": "integer",
+              "default": 5000
+            },
+            "offer-matching-timeout": {
+              "description": "Offer matching timeout (ms). Stop trying to match additional tasks for this offer after this time.",
+              "type": "integer",
+              "default": 1000
+            },
+            "on-elected-prepare-timeout": {
+              "description": "The timeout for preparing the Marathon instance when elected as leader.",
+              "type": "integer",
+              "default": 180000
+            },
+            "plugin-conf": {
+              "description": "The plugin configuration file.",
+              "type": "string"
+            },
+            "plugin-dir": {
+              "description": "Path to a local directory containing plugin jars.",
+              "type": "string"
+            },
+            "reconciliation-initial-delay": {
+              "description": "This is the length of time, in milliseconds, before Marathon begins to periodically perform task reconciliation operations",
+              "type": "integer",
+              "default": 15000
+            },
+            "reconciliation-interval": {
+              "description": "This is the length of time, in milliseconds, between task reconciliation operations.",
+              "type": "integer",
+              "default": 600000
+            },
+            "reporter-datadog": {
+              "description": "URL to dogstatsd agent. e.g. udp://localhost:8125?prefix=marathon-test&tags=marathon&interval=10",
+              "type": "string"
+            },
+            "reporter-graphite": {
+              "description": "URL to graphite agent. e.g. tcp://localhost:2003?prefix=marathon-test&interval=10",
+              "type": "string"
+            },
+            "revive-offers-repetitions": {
+              "description": "Repeat every reviveOffer request this many times, delayed by the --min_revive_offers_interval.",
+              "type": "integer",
+              "default": 3
+            },
+            "save-tasks-to-launch-timeout": {
+              "description": "Timeout (ms) after matching an offer for saving all matched tasks that we are about to launch. When reaching the timeout, only the tasks that we could save within the timeout are also launched. All other task launches are temporarily rejected and retried later.",
+              "type": "integer",
+              "default": 3000
+            },
+            "scale-apps-initial-delay": {
+              "description": "This is the length of time, in milliseconds, before Marathon begins to periodically attempt to scale apps.",
+              "type": "integer",
+              "default": 15000
+            },
+            "scale-apps-interval": {
+              "description": "This is the length of time, in milliseconds, between task scale apps.",
+              "type": "integer",
+              "default": 300000
+            },
+            "sentry": {
+              "description": "URI for sentry, e.g. https://<public>:<private>@sentryserver/",
+              "type": "string"
+            },
+            "sentry-tags": {
+              "description": "Tags to post to sentry with, e.g: tag1:value1,tag2:value2",
+              "type": "string"
+            },
+            "ssl-keystore-password": {
+              "description": "Password for the keystore supplied with the `ssl_keystore_path` option. Required if `ssl_keystore_path` is supplied. May also be specified with the `MESOSPHERE_KEYSTORE_PASS` environment variable.",
+              "type": "string"
+            },
+            "ssl-keystore-path": {
+              "description": "Path to the SSL keystore. HTTPS (SSL) will be enabled if this option is supplied. Requires `--ssl_keystore_password`. May also be specified with the `MESOSPHERE_KEYSTORE_PATH` environment variable.",
+              "type": "string"
+            },
+            "store-cache": {
+              "description": "Enabled: (Default) Enable an in-memory cache for the storage layer. Disabled: Disable the in-memory cache for the storage layer. ",
+              "type": "boolean",
+              "default": true
+            },
+            "task-launch-confirm-timeout": {
+              "description": "Time, in milliseconds, to wait for a task to enter the TASK_STAGING state before killing it.",
+              "type": "integer",
+              "default": 300000
+            },
+            "task-launch-timeout": {
+              "description": "Time, in milliseconds, to wait for a task to enter the TASK_RUNNING state before killing it.",
+              "type": "integer",
+              "default": 300000
+            },
+            "task-lost-expunge-initial-delay": {
+              "description": "This is the length of time, in milliseconds, before Marathon begins to periodically perform task expunge gc operations",
+              "type": "integer",
+              "default": 300000
+            },
+            "task-lost-expunge-interval": {
+              "description": "This is the length of time in milliseconds, for lost task gc operations.",
+              "type": "integer",
+              "default": 30000
+            },
+            "task-reservation-timeout": {
+              "description": "Time, in milliseconds, to wait for a new reservation to be acknowledged via a received offer before deleting it.",
+              "type": "integer",
+              "default": 20000
+            },
+            "tracing": {
+              "description": "Enabled: Enable trace logging of service method calls. Disabled: (Default) Disable trace logging of service method calls.",
+              "type": "boolean",
+              "default": false
+            },
+            "webui-url": {
+              "description": "The HTTP(S) url of the web ui, defaulting to the advertised hostname.",
+              "type": "string"
+            },
+            "zk": {
+              "description": "ZooKeeper URL for storing state. Format: zk://host1:port1,host2:port2,.../path",
+              "type": "string"
+            },
+            "zk-compression": {
+              "description": "Enabled: (Default) Enable compression of zk nodes, if the size of the node is bigger than the configured threshold. Disabled: Disable compression of zk nodes",
+              "type": "boolean",
+              "default": true
+            },
+            "zk-compression-threshold": {
+              "description": "(Default: 64 KB) Threshold in bytes, when compression is applied to the ZooKeeper node.",
+              "type": "integer",
+              "default": 65536
+            },
+            "zk-max-node-size": {
+              "description": "(Default: 1 MiB) Maximum allowed ZooKeeper node size (in bytes).",
+              "type": "integer",
+              "default": 1024000
+            },
+            "zk-max-versions": {
+              "description": "Limit the number of versions, stored for one entity.",
+              "type": "integer",
+              "default": 50
+            },
+            "zk-session-timeout": {
+              "description": "The timeout for ZooKeeper sessions in milliseconds",
+              "type": "integer",
+              "default": 10000
+            },
+            "zk-timeout": {
+              "description": "The timeout for ZooKeeper operations in milliseconds.",
+              "type": "integer",
+              "default": 10000
+            }
+          },
+          "required": ["master"],
+          "type": "object"
+        }
+      },
+      "required": ["service", "jvm", "marathon"],
+      "type": "object"
     }
   }
-  
+}

--- a/tests/_fixtures/cosmos/older-package-describe.json
+++ b/tests/_fixtures/cosmos/older-package-describe.json
@@ -1,546 +1,528 @@
 {
-    "package": {
-      "packagingVersion": "3.0",
-      "name": "marathon",
-      "version": "1.4.6",
-      "releaseVersion": 10,
-      "maintainer": "support@mesosphere.io",
-      "description": "A container orchestration platform for Mesos and DCOS. Documentation: https://docs.mesosphere.com/1.11/deploying-services/marathon-api/",
-      "tags": [
-        "init",
-        "long-running"
-      ],
-      "selected": true,
-      "scm": "https://github.com/mesosphere/marathon.git",
-      "framework": true,
-      "preInstallNotes": "We recommend a minimum of one node with at least 2 CPU shares and 1GB of RAM available for the Marathon DCOS Service. More information: https://mesosphere.github.io/marathon/",
-      "postInstallNotes": "Marathon DCOS Service has been successfully installed!\n\n\tDocumentation: https://mesosphere.github.io/marathon\n\tIssues: https://github.com/mesosphere/marathon/issues\n",
-      "postUninstallNotes": "The Marathon DCOS Service has been uninstalled and will no longer run.\nPlease follow the instructions at http://docs.mesosphere.com/services/marathon/#uninstall to clean up any persisted state",
-      "licenses": [
-        {
-          "name": "Apache License Version 2.0",
-          "url": "https://github.com/mesosphere/marathon/blob/master/LICENSE"
-        }
-      ],
-      "minDcosReleaseVersion": "1.9",
-      "marathon": {
-        "v2AppMustacheTemplate": "eyJQQUNLQUdFX0JVSUxEX1RJTUVfU1RSIjogIlRodSBKYW4gMjQgMjAxOCAwMDo0MTozOSArMDAwMCJ9"
-      },
-      "resource": {
-        "assets": {
-          "container": {
-            "docker": {
-              "image": "mesosphere/marathon:v1.4.6"
-            }
-          }
-        },
-        "images": {
-          "icon-small": "https://downloads.mesosphere.com/marathon/assets/icon-service-marathon-small.png",
-          "icon-medium": "https://downloads.mesosphere.com/marathon/assets/icon-service-marathon-medium.png",
-          "icon-large": "https://downloads.mesosphere.com/marathon/assets/icon-service-marathon-large.png",
-          "screenshots": [
-            "https://mesosphere.com/wp-content/themes/mesosphere/library/images/assets/marathon-0.6.0/mesosphere-marathon-app-list.png",
-            "https://beingasysadmin.files.wordpress.com/2014/06/marathon2.png",
-            "https://mesosphere.github.io/presentations/mug-ericsson-2014/assets/marathon-logo.jpg",
-            "https://mesosphere.com/wp-content/themes/mesosphere/library/images/assets/marathon-0.6.0/mesosphere-marathon-app-list.png",
-            "http://www.clker.com/cliparts/0/f/d/b/12917289761851255679earth-map-huge.jpg",
-            "https://mesosphere.github.io/presentations/mug-ericsson-2014/assets/marathon-logo.jpg",
-            "http://33.media.tumblr.com/9ff4e10667237a30d89f55f13fc5b45b/tumblr_inline_mksdnegnw31qz4rgp.gif"
-          ]
-        }
-      },
-      "config": {
-        "additionalProperties": false,
-        "description": "Marathon DCOS Service properties",
-        "properties": {
-          "service": {
-            "additionalProperties": false,
-            "description": "Marathon app configuration properties.",
-            "properties": {
-              "name": {
-                "description": "The name of this Marathon service inside DCOS base Marathon.\nIf not specified otherwise, this name will also be used for the framework name, dcos service name, zk path and mesos role.\nTo create a nested path, please specify a group.",
-                "type": "string",
-                "default": "marathon-user",
-                "pattern": "^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$"
-              },
-              "group": {
-                "description": "The group of this Marathon service inside DCOS base Marathon. If a group is defined, the id of this service will be group/name",
-                "type": "string",
-                "pattern": "^[/]?(([a-z0-9])([a-z0-9\\-]*[a-z0-9]))([/](([a-z0-9])([a-z0-9\\-]*[a-z0-9])))*$"
-              },
-              "region": {
-                "default": "",
-                "description": "Region picker",
-                "type": "string",
-                "media": {
-                  "type": "application/x-region+string"
-                }
-              },
-              "cpus": {
-                "default": 2,
-                "description": "CPU shares to allocate to each Marathon instance.",
-                "minimum": 0,
-                "type": "number"
-              },
-              "mem": {
-                "default": 1536,
-                "description": "Memory (MB) to allocate to each Marathon instance.",
-                "minimum": 512,
-                "type": "number"
-              },
-              "instances": {
-                "default": 1,
-                "description": "Number of Marathon instances to run.",
-                "minimum": 0,
-                "type": "integer"
-              },
-              "uris": {
-                "default": [
-  
-                ],
-                "description": "List of URIs that will be downloaded and made available in the current working directory of Marathon. For example this can be used to download a Java keystore file for SSL configuration.",
-                "items": {
-                  "pattern": "^[\\s]+",
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "custom_yml": {
-                "description": "Custom YAML to be appended to config.yml on each node. This field must be base64 encoded.",
-                "default": "ZGlzY292ZXJ5Og0KICAgIHplbjoNCiAgICAgICAgcGluZzoNCiAgICAgICAgICAgIG11bHRpY2FzdDoNCiAgICAgICAgICAgICAgICBlbmFibGVkOiBmYWxzZQ==",
-                "type": "string",
-                "media": {
-                  "type": "application/x-yaml"
-                }
-              },
-              "placement_constraints": {
-                "description": "Placement Constraints",
-                "media": {
-                  "type": "application/x-region-zone-constraints+json"
-                },
-                "type": "string",
-                "default": "[]"
-              }
-            },
-            "required": [
-              "cpus",
-              "mem",
-              "instances"
-            ],
-            "type": "object"
-          },
-          "jvm": {
-            "additionalProperties": false,
-            "description": "JVM configuration properties",
-            "properties": {
-              "heap-min": {
-                "default": 256,
-                "description": "Memory (MB) start size for the JVM heap. This number should be be less or equals than the heap-max.",
-                "minimum": 0,
-                "type": "integer"
-              },
-              "heap-max": {
-                "default": 768,
-                "description": "Memory (MB) max size for the JVM heap. This number should be less than the memory allocated to the Marathon instance (General rule: 50%).",
-                "minimum": 0,
-                "type": "integer"
-              },
-              "opts": {
-                "description": "Allows additional JVM_OPTS to be applied outside of the standard mx and ms.",
-                "type": "string"
-              }
-            },
-            "required": [
-              "heap-min",
-              "heap-max"
-            ],
-            "type": "object"
-          },
-          "marathon": {
-            "additionalProperties": true,
-            "description": "Marathon command line flags. These are the same flags that are passed through to Marathon when launching manually from the command line. See details here: https://mesosphere.github.io/marathon/docs/command-line-flags.html",
-            "properties": {
-              "access-control-allow-origin": {
-                "description": "The origin(s) to allow in Marathon. Not set by default. Example values are \"*\", or \"http://localhost:8888, http://domain.com\"",
-                "type": "string"
-              },
-              "artifact-store": {
-                "description": "URL to the artifact store. Supported store types hdfs, file. Example: hdfs://localhost:54310/path/to/store, file:///var/log/store",
-                "type": "string"
-              },
-              "checkpoint": {
-                "description": "Enabled: (Default) Enable checkpointing of tasks. Requires checkpointing enabled on slaves. Allows tasks to continue running during mesos-slave restarts and upgrades Disabled: Disable checkpointing of tasks.",
-                "type": "boolean",
-                "default": true
-              },
-              "decline-offer-duration": {
-                "description": "(Default: 120 seconds) The duration (milliseconds) for which to decline offers by default",
-                "type": "integer",
-                "default": 120000
-              },
-              "default-accepted-resource-roles": {
-                "description": "Default for the defaultAcceptedResourceRoles attribute of all app definitions as a comma-separated list of strings. This defaults to all roles for which this Marathon instance is configured to receive offers.",
-                "type": "string",
-                "default": "*"
-              },
-              "default-network-name": {
-                "description": "Network name, injected into applications' ipAddress{} specs that do not define their own networkName.",
-                "type": "string"
-              },
-              "disable-http": {
-                "description": "Disable listening for HTTP requests completely. HTTPS is unaffected.",
-                "type": "boolean",
-                "default": false
-              },
-              "enable-features": {
-                "description": "A comma-separated list of features. Available features are: secrets - Enable support for secrets in Marathon (experimental), external_volumes - Enable external volumes support in Marathon, vips - Enable networking VIPs UI, gpu_resources - Enable support for GPU in Marathon (experimental), task_killing - Enable the optional TASK_KILLING state, available in Mesos 0.28 and later",
-                "type": "string",
-                "default": "vips,task_killing"
-              },
-              "env-vars-prefix": {
-                "description": "Prefix to use for environment variables injected automatically into all started tasks.",
-                "type": "string"
-              },
-              "event-stream-max-outstanding-messages": {
-                "description": "The event stream buffers events, that are not already consumed by clients. This number defines the number of events that get buffered on the server side, before messages are dropped.",
-                "type": "integer",
-                "default": 50
-              },
-              "event-subscriber": {
-                "description": "The event subscription module to use. E.g. http_callback.",
-                "type": "string"
-              },
-              "executor": {
-                "description": "Executor to use when none is specified. If not defined the Mesos command executor is used by default.",
-                "type": "string",
-                "default": "//cmd"
-              },
-              "failover-timeout": {
-                "description": "(Default: 1 week) The failover_timeout for mesos in seconds.",
-                "type": "integer",
-                "default": 604800
-              },
-              "framework-name": {
-                "description": "(Default: service.name) Framework name to register with Mesos.",
-                "type": "string"
-              },
-              "ha": {
-                "description": "Enabled: (Default) Run Marathon in HA mode with leader election. Allows starting an arbitrary number of other Marathons but all need to be started in HA mode. This mode requires a running ZooKeeper Disabled: Run Marathon in single node mode.",
-                "type": "boolean",
-                "default": true
-              },
-              "hostname": {
-                "description": "The advertised hostname that is used for the communication with the Mesos master. The value is also stored in the persistent store so another standby host can redirect to the elected leader.",
-                "type": "string"
-              },
-              "http-address": {
-                "description": "The address to listen on for HTTP requests",
-                "type": "string"
-              },
-              "http-compression": {
-                "description": "Enabled: (Default) Enable http compression. Disabled: Disable http compression. ",
-                "type": "boolean",
-                "default": true
-              },
-              "http-credentials": {
-                "description": "Credentials for accessing the http service. If empty, anyone can access the HTTP endpoint. A username:password pair is expected where the username must not contain ':'. May also be specified with the `MESOSPHERE_HTTP_CREDENTIALS` environment variable. ",
-                "type": "string"
-              },
-              "http-endpoints": {
-                "description": "The URLs of the event endpoints added to the current list of subscribers on startup. You can manage this list during runtime by using the /v2/eventSubscriptions API endpoint.",
-                "type": "string"
-              },
-              "http-event-callback-slow-consumer-timeout": {
-                "description": "A http event callback consumer is considered slow, if the delivery takes longer than this timeout (ms)",
-                "type": "integer",
-                "default": 10000
-              },
-              "http-event-request-timeout": {
-                "description": "A http event request timeout (ms)",
-                "type": "integer",
-                "default": 10000
-              },
-              "http-max-concurrent-requests": {
-                "description": "The number of concurrent HTTP requests that are allowed before rejecting.",
-                "type": "integer"
-              },
-              "http-port": {
-                "description": "The port to listen on for HTTP requests",
-                "type": "integer"
-              },
-              "http-realm": {
-                "description": "The security realm (aka 'area') associated with the credentials",
-                "type": "string",
-                "default": "Mesosphere"
-              },
-              "https-address": {
-                "description": "The address to listen on for HTTPS requests.",
-                "type": "string"
-              },
-              "https-port": {
-                "description": "The port to listen on for HTTPS requests",
-                "type": "integer"
-              },
-              "launch-token-refresh-interval": {
-                "description": "The interval (ms) in which to refresh the launch tokens to --launch_token_count",
-                "type": "integer",
-                "default": 30000
-              },
-              "launch-tokens": {
-                "description": "Launch tokens per interval",
-                "type": "integer",
-                "default": 100
-              },
-              "leader-proxy-connection-timeout": {
-                "description": "Maximum time, in milliseconds, to wait for connecting to the current Marathon leader from another Marathon instance.",
-                "type": "integer",
-                "default": 5000
-              },
-              "leader-proxy-read-timeout": {
-                "description": "Maximum time, in milliseconds, for reading from the current Marathon leader.",
-                "type": "integer",
-                "default": 10000
-              },
-              "leader-proxy-ssl-ignore-hostname": {
-                "description": "Do not verify that the hostname of the Marathon leader matches the one in the SSL certificate when proxying API requests to the current leader.",
-                "type": "boolean",
-                "default": false
-              },
-              "local-port-max": {
-                "description": "Max port number to use when assigning globally unique service ports to apps.",
-                "type": "integer",
-                "default": 20000
-              },
-              "local-port-min": {
-                "description": "Min port number to use when assigning globally unique service ports to apps.",
-                "type": "integer",
-                "default": 10000
-              },
-              "logging-level": {
-                "description": "Set logging level to one of: off, error, warn, info, debug, trace, all",
-                "type": "string"
-              },
-              "logstash": {
-                "description": "Logs destination URI in format (udp|tcp|ssl)://<host>:<port>",
-                "type": "string"
-              },
-              "master": {
-                "description": "The URL of the Mesos master",
-                "type": "string",
-                "default": "zk://master.mesos:2181/mesos"
-              },
-              "max-apps": {
-                "description": "The maximum number of applications that may be created.",
-                "type": "integer"
-              },
-              "max-instances-per-offer": {
-                "description": "Max instances per offer. Do not start more than this number of app or pod instances on a single offer.",
-                "type": "integer"
-              },
-              "max-tasks-per-offer": {
-                "description": "(deprecated) Maximum tasks per offer. Do not start more than this number of tasks on a single offer.",
-                "type": "integer",
-                "default": 1
-              },
-              "mesos-authentication": {
-                "description": "Enabled: Will use framework authentication while registering with Mesos with principal and optional secret. Disabled: (Default) will not use framework authentication while registering with Mesos.",
-                "type": "boolean",
-                "default": false
-              },
-              "mesos-authentication-principal": {
-                "description": "(Default: service.name) Mesos Authentication Principal.",
-                "type": "string"
-              },
-              "mesos-authentication-secret": {
-                "description": "Mesos Authentication Secret.",
-                "type": "string"
-              },
-              "mesos-authentication-secret-file": {
-                "description": "Path to a file containing the Mesos Authentication Secret.",
-                "type": "string"
-              },
-              "mesos-leader-ui-url": {
-                "description": "The host and port (e.g. \"http://mesos_host:5050\") of the Mesos master.",
-                "type": "string",
-                "default": "/mesos"
-              },
-              "mesos-role": {
-                "description": "(Default: service.name) Mesos role for this framework. If set, Marathon receives resource offers for the specified role in addition to resources with the role designation '*'.",
-                "type": "string"
-              },
-              "mesos-user": {
-                "description": "Mesos user for this framework.",
-                "type": "string"
-              },
-              "metrics": {
-                "description": "Enabled: (Default) Expose the execution time of service method calls using code instrumentation via the metrics endpoint (/metrics). This might noticeably degrade performance but can help finding performance problems. Disabled: Disable exposing execution time of service method calls using code instrumentation via the metrics endpoing (/metrics). This does not turn off reporting of other metrics.",
-                "type": "boolean",
-                "default": true
-              },
-              "min-revive-offers-interval": {
-                "description": "Do not ask for all offers (also already seen ones) more often than this interval (ms).",
-                "type": "integer",
-                "default": 5000
-              },
-              "offer-matching-timeout": {
-                "description": "Offer matching timeout (ms). Stop trying to match additional tasks for this offer after this time.",
-                "type": "integer",
-                "default": 1000
-              },
-              "on-elected-prepare-timeout": {
-                "description": "The timeout for preparing the Marathon instance when elected as leader.",
-                "type": "integer",
-                "default": 180000
-              },
-              "plugin-conf": {
-                "description": "The plugin configuration file.",
-                "type": "string"
-              },
-              "plugin-dir": {
-                "description": "Path to a local directory containing plugin jars.",
-                "type": "string"
-              },
-              "reconciliation-initial-delay": {
-                "description": "This is the length of time, in milliseconds, before Marathon begins to periodically perform task reconciliation operations",
-                "type": "integer",
-                "default": 15000
-              },
-              "reconciliation-interval": {
-                "description": "This is the length of time, in milliseconds, between task reconciliation operations.",
-                "type": "integer",
-                "default": 600000
-              },
-              "reporter-datadog": {
-                "description": "URL to dogstatsd agent. e.g. udp://localhost:8125?prefix=marathon-test&tags=marathon&interval=10",
-                "type": "string"
-              },
-              "reporter-graphite": {
-                "description": "URL to graphite agent. e.g. tcp://localhost:2003?prefix=marathon-test&interval=10",
-                "type": "string"
-              },
-              "revive-offers-repetitions": {
-                "description": "Repeat every reviveOffer request this many times, delayed by the --min_revive_offers_interval.",
-                "type": "integer",
-                "default": 3
-              },
-              "save-tasks-to-launch-timeout": {
-                "description": "Timeout (ms) after matching an offer for saving all matched tasks that we are about to launch. When reaching the timeout, only the tasks that we could save within the timeout are also launched. All other task launches are temporarily rejected and retried later.",
-                "type": "integer",
-                "default": 3000
-              },
-              "scale-apps-initial-delay": {
-                "description": "This is the length of time, in milliseconds, before Marathon begins to periodically attempt to scale apps.",
-                "type": "integer",
-                "default": 15000
-              },
-              "scale-apps-interval": {
-                "description": "This is the length of time, in milliseconds, between task scale apps.",
-                "type": "integer",
-                "default": 300000
-              },
-              "sentry": {
-                "description": "URI for sentry, e.g. https://<public>:<private>@sentryserver/",
-                "type": "string"
-              },
-              "sentry-tags": {
-                "description": "Tags to post to sentry with, e.g: tag1:value1,tag2:value2",
-                "type": "string"
-              },
-              "ssl-keystore-password": {
-                "description": "Password for the keystore supplied with the `ssl_keystore_path` option. Required if `ssl_keystore_path` is supplied. May also be specified with the `MESOSPHERE_KEYSTORE_PASS` environment variable.",
-                "type": "string"
-              },
-              "ssl-keystore-path": {
-                "description": "Path to the SSL keystore. HTTPS (SSL) will be enabled if this option is supplied. Requires `--ssl_keystore_password`. May also be specified with the `MESOSPHERE_KEYSTORE_PATH` environment variable.",
-                "type": "string"
-              },
-              "store-cache": {
-                "description": "Enabled: (Default) Enable an in-memory cache for the storage layer. Disabled: Disable the in-memory cache for the storage layer. ",
-                "type": "boolean",
-                "default": true
-              },
-              "task-launch-confirm-timeout": {
-                "description": "Time, in milliseconds, to wait for a task to enter the TASK_STAGING state before killing it.",
-                "type": "integer",
-                "default": 300000
-              },
-              "task-launch-timeout": {
-                "description": "Time, in milliseconds, to wait for a task to enter the TASK_RUNNING state before killing it.",
-                "type": "integer",
-                "default": 300000
-              },
-              "task-lost-expunge-initial-delay": {
-                "description": "This is the length of time, in milliseconds, before Marathon begins to periodically perform task expunge gc operations",
-                "type": "integer",
-                "default": 300000
-              },
-              "task-lost-expunge-interval": {
-                "description": "This is the length of time in milliseconds, for lost task gc operations.",
-                "type": "integer",
-                "default": 30000
-              },
-              "task-reservation-timeout": {
-                "description": "Time, in milliseconds, to wait for a new reservation to be acknowledged via a received offer before deleting it.",
-                "type": "integer",
-                "default": 20000
-              },
-              "tracing": {
-                "description": "Enabled: Enable trace logging of service method calls. Disabled: (Default) Disable trace logging of service method calls.",
-                "type": "boolean",
-                "default": false
-              },
-              "webui-url": {
-                "description": "The HTTP(S) url of the web ui, defaulting to the advertised hostname.",
-                "type": "string"
-              },
-              "zk": {
-                "description": "ZooKeeper URL for storing state. Format: zk://host1:port1,host2:port2,.../path",
-                "type": "string"
-              },
-              "zk-compression": {
-                "description": "Enabled: (Default) Enable compression of zk nodes, if the size of the node is bigger than the configured threshold. Disabled: Disable compression of zk nodes",
-                "type": "boolean",
-                "default": true
-              },
-              "zk-compression-threshold": {
-                "description": "(Default: 64 KB) Threshold in bytes, when compression is applied to the ZooKeeper node.",
-                "type": "integer",
-                "default": 65536
-              },
-              "zk-max-node-size": {
-                "description": "(Default: 1 MiB) Maximum allowed ZooKeeper node size (in bytes).",
-                "type": "integer",
-                "default": 1024000
-              },
-              "zk-max-versions": {
-                "description": "Limit the number of versions, stored for one entity.",
-                "type": "integer",
-                "default": 50
-              },
-              "zk-session-timeout": {
-                "description": "The timeout for ZooKeeper sessions in milliseconds",
-                "type": "integer",
-                "default": 10000
-              },
-              "zk-timeout": {
-                "description": "The timeout for ZooKeeper operations in milliseconds.",
-                "type": "integer",
-                "default": 10000
-              }
-            },
-            "required": [
-              "master"
-            ],
-            "type": "object"
-          }
-        },
-        "required": [
-          "service",
-          "jvm",
-          "marathon"
-        ],
-        "type": "object"
+  "package": {
+    "packagingVersion": "3.0",
+    "name": "marathon",
+    "version": "1.4.6",
+    "releaseVersion": 10,
+    "maintainer": "support@mesosphere.io",
+    "description": "A container orchestration platform for Mesos and DCOS. Documentation: https://docs.mesosphere.com/1.11/deploying-services/marathon-api/",
+    "tags": ["init", "long-running"],
+    "selected": true,
+    "lastUpdated": 1514764800,
+    "scm": "https://github.com/mesosphere/marathon.git",
+    "framework": true,
+    "preInstallNotes": "We recommend a minimum of one node with at least 2 CPU shares and 1GB of RAM available for the Marathon DCOS Service. More information: https://mesosphere.github.io/marathon/",
+    "postInstallNotes": "Marathon DCOS Service has been successfully installed!\n\n\tDocumentation: https://mesosphere.github.io/marathon\n\tIssues: https://github.com/mesosphere/marathon/issues\n",
+    "postUninstallNotes": "The Marathon DCOS Service has been uninstalled and will no longer run.\nPlease follow the instructions at http://docs.mesosphere.com/services/marathon/#uninstall to clean up any persisted state",
+    "licenses": [
+      {
+        "name": "Apache License Version 2.0",
+        "url": "https://github.com/mesosphere/marathon/blob/master/LICENSE"
       }
+    ],
+    "minDcosReleaseVersion": "1.9",
+    "marathon": {
+      "v2AppMustacheTemplate": "eyJQQUNLQUdFX0JVSUxEX1RJTUVfU1RSIjogIlRodSBKYW4gMjQgMjAxOCAwMDo0MTozOSArMDAwMCJ9"
+    },
+    "resource": {
+      "assets": {
+        "container": {
+          "docker": {
+            "image": "mesosphere/marathon:v1.4.6"
+          }
+        }
+      },
+      "images": {
+        "icon-small": "https://downloads.mesosphere.com/marathon/assets/icon-service-marathon-small.png",
+        "icon-medium": "https://downloads.mesosphere.com/marathon/assets/icon-service-marathon-medium.png",
+        "icon-large": "https://downloads.mesosphere.com/marathon/assets/icon-service-marathon-large.png",
+        "screenshots": [
+          "https://mesosphere.com/wp-content/themes/mesosphere/library/images/assets/marathon-0.6.0/mesosphere-marathon-app-list.png",
+          "https://beingasysadmin.files.wordpress.com/2014/06/marathon2.png",
+          "https://mesosphere.github.io/presentations/mug-ericsson-2014/assets/marathon-logo.jpg",
+          "https://mesosphere.com/wp-content/themes/mesosphere/library/images/assets/marathon-0.6.0/mesosphere-marathon-app-list.png",
+          "http://www.clker.com/cliparts/0/f/d/b/12917289761851255679earth-map-huge.jpg",
+          "https://mesosphere.github.io/presentations/mug-ericsson-2014/assets/marathon-logo.jpg",
+          "http://33.media.tumblr.com/9ff4e10667237a30d89f55f13fc5b45b/tumblr_inline_mksdnegnw31qz4rgp.gif"
+        ]
+      }
+    },
+    "config": {
+      "additionalProperties": false,
+      "description": "Marathon DCOS Service properties",
+      "properties": {
+        "service": {
+          "additionalProperties": false,
+          "description": "Marathon app configuration properties.",
+          "properties": {
+            "name": {
+              "description": "The name of this Marathon service inside DCOS base Marathon.\nIf not specified otherwise, this name will also be used for the framework name, dcos service name, zk path and mesos role.\nTo create a nested path, please specify a group.",
+              "type": "string",
+              "default": "marathon-user",
+              "pattern": "^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$"
+            },
+            "group": {
+              "description": "The group of this Marathon service inside DCOS base Marathon. If a group is defined, the id of this service will be group/name",
+              "type": "string",
+              "pattern": "^[/]?(([a-z0-9])([a-z0-9\\-]*[a-z0-9]))([/](([a-z0-9])([a-z0-9\\-]*[a-z0-9])))*$"
+            },
+            "region": {
+              "default": "",
+              "description": "Region picker",
+              "type": "string",
+              "media": {
+                "type": "application/x-region+string"
+              }
+            },
+            "cpus": {
+              "default": 2,
+              "description": "CPU shares to allocate to each Marathon instance.",
+              "minimum": 0,
+              "type": "number"
+            },
+            "mem": {
+              "default": 1536,
+              "description": "Memory (MB) to allocate to each Marathon instance.",
+              "minimum": 512,
+              "type": "number"
+            },
+            "instances": {
+              "default": 1,
+              "description": "Number of Marathon instances to run.",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "uris": {
+              "default": [],
+              "description": "List of URIs that will be downloaded and made available in the current working directory of Marathon. For example this can be used to download a Java keystore file for SSL configuration.",
+              "items": {
+                "pattern": "^[\\s]+",
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "custom_yml": {
+              "description": "Custom YAML to be appended to config.yml on each node. This field must be base64 encoded.",
+              "default": "ZGlzY292ZXJ5Og0KICAgIHplbjoNCiAgICAgICAgcGluZzoNCiAgICAgICAgICAgIG11bHRpY2FzdDoNCiAgICAgICAgICAgICAgICBlbmFibGVkOiBmYWxzZQ==",
+              "type": "string",
+              "media": {
+                "type": "application/x-yaml"
+              }
+            },
+            "placement_constraints": {
+              "description": "Placement Constraints",
+              "media": {
+                "type": "application/x-region-zone-constraints+json"
+              },
+              "type": "string",
+              "default": "[]"
+            }
+          },
+          "required": ["cpus", "mem", "instances"],
+          "type": "object"
+        },
+        "jvm": {
+          "additionalProperties": false,
+          "description": "JVM configuration properties",
+          "properties": {
+            "heap-min": {
+              "default": 256,
+              "description": "Memory (MB) start size for the JVM heap. This number should be be less or equals than the heap-max.",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "heap-max": {
+              "default": 768,
+              "description": "Memory (MB) max size for the JVM heap. This number should be less than the memory allocated to the Marathon instance (General rule: 50%).",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "opts": {
+              "description": "Allows additional JVM_OPTS to be applied outside of the standard mx and ms.",
+              "type": "string"
+            }
+          },
+          "required": ["heap-min", "heap-max"],
+          "type": "object"
+        },
+        "marathon": {
+          "additionalProperties": true,
+          "description": "Marathon command line flags. These are the same flags that are passed through to Marathon when launching manually from the command line. See details here: https://mesosphere.github.io/marathon/docs/command-line-flags.html",
+          "properties": {
+            "access-control-allow-origin": {
+              "description": "The origin(s) to allow in Marathon. Not set by default. Example values are \"*\", or \"http://localhost:8888, http://domain.com\"",
+              "type": "string"
+            },
+            "artifact-store": {
+              "description": "URL to the artifact store. Supported store types hdfs, file. Example: hdfs://localhost:54310/path/to/store, file:///var/log/store",
+              "type": "string"
+            },
+            "checkpoint": {
+              "description": "Enabled: (Default) Enable checkpointing of tasks. Requires checkpointing enabled on slaves. Allows tasks to continue running during mesos-slave restarts and upgrades Disabled: Disable checkpointing of tasks.",
+              "type": "boolean",
+              "default": true
+            },
+            "decline-offer-duration": {
+              "description": "(Default: 120 seconds) The duration (milliseconds) for which to decline offers by default",
+              "type": "integer",
+              "default": 120000
+            },
+            "default-accepted-resource-roles": {
+              "description": "Default for the defaultAcceptedResourceRoles attribute of all app definitions as a comma-separated list of strings. This defaults to all roles for which this Marathon instance is configured to receive offers.",
+              "type": "string",
+              "default": "*"
+            },
+            "default-network-name": {
+              "description": "Network name, injected into applications' ipAddress{} specs that do not define their own networkName.",
+              "type": "string"
+            },
+            "disable-http": {
+              "description": "Disable listening for HTTP requests completely. HTTPS is unaffected.",
+              "type": "boolean",
+              "default": false
+            },
+            "enable-features": {
+              "description": "A comma-separated list of features. Available features are: secrets - Enable support for secrets in Marathon (experimental), external_volumes - Enable external volumes support in Marathon, vips - Enable networking VIPs UI, gpu_resources - Enable support for GPU in Marathon (experimental), task_killing - Enable the optional TASK_KILLING state, available in Mesos 0.28 and later",
+              "type": "string",
+              "default": "vips,task_killing"
+            },
+            "env-vars-prefix": {
+              "description": "Prefix to use for environment variables injected automatically into all started tasks.",
+              "type": "string"
+            },
+            "event-stream-max-outstanding-messages": {
+              "description": "The event stream buffers events, that are not already consumed by clients. This number defines the number of events that get buffered on the server side, before messages are dropped.",
+              "type": "integer",
+              "default": 50
+            },
+            "event-subscriber": {
+              "description": "The event subscription module to use. E.g. http_callback.",
+              "type": "string"
+            },
+            "executor": {
+              "description": "Executor to use when none is specified. If not defined the Mesos command executor is used by default.",
+              "type": "string",
+              "default": "//cmd"
+            },
+            "failover-timeout": {
+              "description": "(Default: 1 week) The failover_timeout for mesos in seconds.",
+              "type": "integer",
+              "default": 604800
+            },
+            "framework-name": {
+              "description": "(Default: service.name) Framework name to register with Mesos.",
+              "type": "string"
+            },
+            "ha": {
+              "description": "Enabled: (Default) Run Marathon in HA mode with leader election. Allows starting an arbitrary number of other Marathons but all need to be started in HA mode. This mode requires a running ZooKeeper Disabled: Run Marathon in single node mode.",
+              "type": "boolean",
+              "default": true
+            },
+            "hostname": {
+              "description": "The advertised hostname that is used for the communication with the Mesos master. The value is also stored in the persistent store so another standby host can redirect to the elected leader.",
+              "type": "string"
+            },
+            "http-address": {
+              "description": "The address to listen on for HTTP requests",
+              "type": "string"
+            },
+            "http-compression": {
+              "description": "Enabled: (Default) Enable http compression. Disabled: Disable http compression. ",
+              "type": "boolean",
+              "default": true
+            },
+            "http-credentials": {
+              "description": "Credentials for accessing the http service. If empty, anyone can access the HTTP endpoint. A username:password pair is expected where the username must not contain ':'. May also be specified with the `MESOSPHERE_HTTP_CREDENTIALS` environment variable. ",
+              "type": "string"
+            },
+            "http-endpoints": {
+              "description": "The URLs of the event endpoints added to the current list of subscribers on startup. You can manage this list during runtime by using the /v2/eventSubscriptions API endpoint.",
+              "type": "string"
+            },
+            "http-event-callback-slow-consumer-timeout": {
+              "description": "A http event callback consumer is considered slow, if the delivery takes longer than this timeout (ms)",
+              "type": "integer",
+              "default": 10000
+            },
+            "http-event-request-timeout": {
+              "description": "A http event request timeout (ms)",
+              "type": "integer",
+              "default": 10000
+            },
+            "http-max-concurrent-requests": {
+              "description": "The number of concurrent HTTP requests that are allowed before rejecting.",
+              "type": "integer"
+            },
+            "http-port": {
+              "description": "The port to listen on for HTTP requests",
+              "type": "integer"
+            },
+            "http-realm": {
+              "description": "The security realm (aka 'area') associated with the credentials",
+              "type": "string",
+              "default": "Mesosphere"
+            },
+            "https-address": {
+              "description": "The address to listen on for HTTPS requests.",
+              "type": "string"
+            },
+            "https-port": {
+              "description": "The port to listen on for HTTPS requests",
+              "type": "integer"
+            },
+            "launch-token-refresh-interval": {
+              "description": "The interval (ms) in which to refresh the launch tokens to --launch_token_count",
+              "type": "integer",
+              "default": 30000
+            },
+            "launch-tokens": {
+              "description": "Launch tokens per interval",
+              "type": "integer",
+              "default": 100
+            },
+            "leader-proxy-connection-timeout": {
+              "description": "Maximum time, in milliseconds, to wait for connecting to the current Marathon leader from another Marathon instance.",
+              "type": "integer",
+              "default": 5000
+            },
+            "leader-proxy-read-timeout": {
+              "description": "Maximum time, in milliseconds, for reading from the current Marathon leader.",
+              "type": "integer",
+              "default": 10000
+            },
+            "leader-proxy-ssl-ignore-hostname": {
+              "description": "Do not verify that the hostname of the Marathon leader matches the one in the SSL certificate when proxying API requests to the current leader.",
+              "type": "boolean",
+              "default": false
+            },
+            "local-port-max": {
+              "description": "Max port number to use when assigning globally unique service ports to apps.",
+              "type": "integer",
+              "default": 20000
+            },
+            "local-port-min": {
+              "description": "Min port number to use when assigning globally unique service ports to apps.",
+              "type": "integer",
+              "default": 10000
+            },
+            "logging-level": {
+              "description": "Set logging level to one of: off, error, warn, info, debug, trace, all",
+              "type": "string"
+            },
+            "logstash": {
+              "description": "Logs destination URI in format (udp|tcp|ssl)://<host>:<port>",
+              "type": "string"
+            },
+            "master": {
+              "description": "The URL of the Mesos master",
+              "type": "string",
+              "default": "zk://master.mesos:2181/mesos"
+            },
+            "max-apps": {
+              "description": "The maximum number of applications that may be created.",
+              "type": "integer"
+            },
+            "max-instances-per-offer": {
+              "description": "Max instances per offer. Do not start more than this number of app or pod instances on a single offer.",
+              "type": "integer"
+            },
+            "max-tasks-per-offer": {
+              "description": "(deprecated) Maximum tasks per offer. Do not start more than this number of tasks on a single offer.",
+              "type": "integer",
+              "default": 1
+            },
+            "mesos-authentication": {
+              "description": "Enabled: Will use framework authentication while registering with Mesos with principal and optional secret. Disabled: (Default) will not use framework authentication while registering with Mesos.",
+              "type": "boolean",
+              "default": false
+            },
+            "mesos-authentication-principal": {
+              "description": "(Default: service.name) Mesos Authentication Principal.",
+              "type": "string"
+            },
+            "mesos-authentication-secret": {
+              "description": "Mesos Authentication Secret.",
+              "type": "string"
+            },
+            "mesos-authentication-secret-file": {
+              "description": "Path to a file containing the Mesos Authentication Secret.",
+              "type": "string"
+            },
+            "mesos-leader-ui-url": {
+              "description": "The host and port (e.g. \"http://mesos_host:5050\") of the Mesos master.",
+              "type": "string",
+              "default": "/mesos"
+            },
+            "mesos-role": {
+              "description": "(Default: service.name) Mesos role for this framework. If set, Marathon receives resource offers for the specified role in addition to resources with the role designation '*'.",
+              "type": "string"
+            },
+            "mesos-user": {
+              "description": "Mesos user for this framework.",
+              "type": "string"
+            },
+            "metrics": {
+              "description": "Enabled: (Default) Expose the execution time of service method calls using code instrumentation via the metrics endpoint (/metrics). This might noticeably degrade performance but can help finding performance problems. Disabled: Disable exposing execution time of service method calls using code instrumentation via the metrics endpoing (/metrics). This does not turn off reporting of other metrics.",
+              "type": "boolean",
+              "default": true
+            },
+            "min-revive-offers-interval": {
+              "description": "Do not ask for all offers (also already seen ones) more often than this interval (ms).",
+              "type": "integer",
+              "default": 5000
+            },
+            "offer-matching-timeout": {
+              "description": "Offer matching timeout (ms). Stop trying to match additional tasks for this offer after this time.",
+              "type": "integer",
+              "default": 1000
+            },
+            "on-elected-prepare-timeout": {
+              "description": "The timeout for preparing the Marathon instance when elected as leader.",
+              "type": "integer",
+              "default": 180000
+            },
+            "plugin-conf": {
+              "description": "The plugin configuration file.",
+              "type": "string"
+            },
+            "plugin-dir": {
+              "description": "Path to a local directory containing plugin jars.",
+              "type": "string"
+            },
+            "reconciliation-initial-delay": {
+              "description": "This is the length of time, in milliseconds, before Marathon begins to periodically perform task reconciliation operations",
+              "type": "integer",
+              "default": 15000
+            },
+            "reconciliation-interval": {
+              "description": "This is the length of time, in milliseconds, between task reconciliation operations.",
+              "type": "integer",
+              "default": 600000
+            },
+            "reporter-datadog": {
+              "description": "URL to dogstatsd agent. e.g. udp://localhost:8125?prefix=marathon-test&tags=marathon&interval=10",
+              "type": "string"
+            },
+            "reporter-graphite": {
+              "description": "URL to graphite agent. e.g. tcp://localhost:2003?prefix=marathon-test&interval=10",
+              "type": "string"
+            },
+            "revive-offers-repetitions": {
+              "description": "Repeat every reviveOffer request this many times, delayed by the --min_revive_offers_interval.",
+              "type": "integer",
+              "default": 3
+            },
+            "save-tasks-to-launch-timeout": {
+              "description": "Timeout (ms) after matching an offer for saving all matched tasks that we are about to launch. When reaching the timeout, only the tasks that we could save within the timeout are also launched. All other task launches are temporarily rejected and retried later.",
+              "type": "integer",
+              "default": 3000
+            },
+            "scale-apps-initial-delay": {
+              "description": "This is the length of time, in milliseconds, before Marathon begins to periodically attempt to scale apps.",
+              "type": "integer",
+              "default": 15000
+            },
+            "scale-apps-interval": {
+              "description": "This is the length of time, in milliseconds, between task scale apps.",
+              "type": "integer",
+              "default": 300000
+            },
+            "sentry": {
+              "description": "URI for sentry, e.g. https://<public>:<private>@sentryserver/",
+              "type": "string"
+            },
+            "sentry-tags": {
+              "description": "Tags to post to sentry with, e.g: tag1:value1,tag2:value2",
+              "type": "string"
+            },
+            "ssl-keystore-password": {
+              "description": "Password for the keystore supplied with the `ssl_keystore_path` option. Required if `ssl_keystore_path` is supplied. May also be specified with the `MESOSPHERE_KEYSTORE_PASS` environment variable.",
+              "type": "string"
+            },
+            "ssl-keystore-path": {
+              "description": "Path to the SSL keystore. HTTPS (SSL) will be enabled if this option is supplied. Requires `--ssl_keystore_password`. May also be specified with the `MESOSPHERE_KEYSTORE_PATH` environment variable.",
+              "type": "string"
+            },
+            "store-cache": {
+              "description": "Enabled: (Default) Enable an in-memory cache for the storage layer. Disabled: Disable the in-memory cache for the storage layer. ",
+              "type": "boolean",
+              "default": true
+            },
+            "task-launch-confirm-timeout": {
+              "description": "Time, in milliseconds, to wait for a task to enter the TASK_STAGING state before killing it.",
+              "type": "integer",
+              "default": 300000
+            },
+            "task-launch-timeout": {
+              "description": "Time, in milliseconds, to wait for a task to enter the TASK_RUNNING state before killing it.",
+              "type": "integer",
+              "default": 300000
+            },
+            "task-lost-expunge-initial-delay": {
+              "description": "This is the length of time, in milliseconds, before Marathon begins to periodically perform task expunge gc operations",
+              "type": "integer",
+              "default": 300000
+            },
+            "task-lost-expunge-interval": {
+              "description": "This is the length of time in milliseconds, for lost task gc operations.",
+              "type": "integer",
+              "default": 30000
+            },
+            "task-reservation-timeout": {
+              "description": "Time, in milliseconds, to wait for a new reservation to be acknowledged via a received offer before deleting it.",
+              "type": "integer",
+              "default": 20000
+            },
+            "tracing": {
+              "description": "Enabled: Enable trace logging of service method calls. Disabled: (Default) Disable trace logging of service method calls.",
+              "type": "boolean",
+              "default": false
+            },
+            "webui-url": {
+              "description": "The HTTP(S) url of the web ui, defaulting to the advertised hostname.",
+              "type": "string"
+            },
+            "zk": {
+              "description": "ZooKeeper URL for storing state. Format: zk://host1:port1,host2:port2,.../path",
+              "type": "string"
+            },
+            "zk-compression": {
+              "description": "Enabled: (Default) Enable compression of zk nodes, if the size of the node is bigger than the configured threshold. Disabled: Disable compression of zk nodes",
+              "type": "boolean",
+              "default": true
+            },
+            "zk-compression-threshold": {
+              "description": "(Default: 64 KB) Threshold in bytes, when compression is applied to the ZooKeeper node.",
+              "type": "integer",
+              "default": 65536
+            },
+            "zk-max-node-size": {
+              "description": "(Default: 1 MiB) Maximum allowed ZooKeeper node size (in bytes).",
+              "type": "integer",
+              "default": 1024000
+            },
+            "zk-max-versions": {
+              "description": "Limit the number of versions, stored for one entity.",
+              "type": "integer",
+              "default": 50
+            },
+            "zk-session-timeout": {
+              "description": "The timeout for ZooKeeper sessions in milliseconds",
+              "type": "integer",
+              "default": 10000
+            },
+            "zk-timeout": {
+              "description": "The timeout for ZooKeeper operations in milliseconds.",
+              "type": "integer",
+              "default": 10000
+            }
+          },
+          "required": ["master"],
+          "type": "object"
+        }
+      },
+      "required": ["service", "jvm", "marathon"],
+      "type": "object"
     }
   }
-  
+}


### PR DESCRIPTION
there's no need to crawl the mustache-template anymore as most packages now have
a `lastUpdated` set. (i'd prefer `lastUpdatedAt`)

this makes for way more packages showing that warning and also decouples the
frontend from SDK-internals (using a regex to parse a PACKAGE_BUILD_TIME_STR
out of a base64-encoded mustache template seemed suboptimal).

Closes DCOS-62284
