### PR TITLE
chore: speed up tsc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .idea/*
 !dist/
 dist/*
+__out/
 cypress/*
 results/
 build/

--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
     "test:system:local": "PLUGINS_PATH=\"${npm_config_externalplugins}\" ./scripts/run-system-tests -hnds",
     "test:validate": "PLUGINS_PATH=\"${npm_config_externalplugins}\" ./scripts/validate-tests",
     "test:watch": "npm test -- --watch",
-    "test": "./scripts/lingui-compile && jest --no-cache",
+    "test": "./scripts/lingui-compile && tsc > /dev/null; jest --no-cache",
     "typecheck": "jest typecheck",
     "updateTSSnapshots": "jest typecheck -u; jest tslint -u",
     "util:env:validate": "node ./scripts/validate-engine-versions.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,12 +6,15 @@
     "emitDecoratorMetadata": true,
     "esModuleInterop": true,
     "experimentalDecorators": true,
+    "incremental": true,
     "jsx": "preserve",
     "lib": ["es5", "es6", "esnext", "dom"],
     "listEmittedFiles": true,
     "module": "ESNext",
     "moduleResolution": "node",
-    "noEmit": true,
+
+    "noEmit": false,
+
     "noFallthroughCasesInSwitch": true,
 
     "noImplicitAny": false,
@@ -20,6 +23,9 @@
     "noImplicitThis": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+
+    "outDir": "__out",
+
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "sourceMap": true,


### PR DESCRIPTION
we enable the incremental-flag here.
because of the reasoning here
https://github.com/microsoft/TypeScript/issues/30661, we need to also need to
emit stuff. we'll have an __out-dir until there's a better option.

## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
