### PR TITLE
chore: change some tslint-rules

### DIFF
--- a/plugins/catalog/src/js/repositories/RepositoriesAdd.tsx
+++ b/plugins/catalog/src/js/repositories/RepositoriesAdd.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { componentFromStream } from "@dcos/data-service";
 import { DataLayerType } from "@extension-kid/data-layer";
 import gql from "graphql-tag";
-import { Trans } from "@lingui/macro";
+import { Trans } from "@lingui/react";
 
 import { Subject, BehaviorSubject } from "rxjs";
 import {
@@ -20,19 +20,15 @@ import AddRepositoryFormModal from "./components/AddRepositoryFormModal";
 const dataLayer = container.get(DataLayerType);
 
 // Imported from the Cosmos Store
-const getErrorMessage = (response = {}) => {
+const getErrorMessage = (response = { description: null, message: null }) => {
   if (typeof response === "string") {
     return response;
   }
 
-  if (response) {
-    return (
-      response.description ||
-      response.message || <Trans render="span">An error has occurred.</Trans>
-    );
-  }
-
-  return <Trans render="span">An error has occurred.</Trans>;
+  return (
+    response.description ||
+    response.message || <Trans render="span" id="An error has occurred." />
+  );
 };
 
 const addPackageRepositoryMutation = gql`
@@ -83,22 +79,25 @@ const RepositoriesAdd = componentFromStream(props$ =>
     combineLatest(
       pendingRequest$,
       addRepository$.pipe(startWith({})),
-      (props, pendingRequest, result) => (
-        <AddRepositoryFormModal
-          pendingRequest={pendingRequest}
-          numberOfRepositories={props.numberOfRepositories}
-          open={props.open}
-          addRepository={value => {
-            pendingRequest$.next(true);
-            return addRepositoryEvent$.next({
-              complete: props.onClose,
-              ...value
-            });
-          }}
-          onClose={props.onClose}
-          errorMsg={result.error}
-        />
-      )
+      (props, pendingRequest, result) => {
+        const addRepository = value => {
+          pendingRequest$.next(true);
+          return addRepositoryEvent$.next({
+            complete: props.onClose,
+            ...value
+          });
+        };
+        return (
+          <AddRepositoryFormModal
+            pendingRequest={pendingRequest}
+            numberOfRepositories={props.numberOfRepositories}
+            open={props.open}
+            addRepository={addRepository}
+            onClose={props.onClose}
+            errorMsg={result.error}
+          />
+        );
+      }
     )
   )
 );

--- a/src/js/__tests__/__snapshots__/tslint-test.ts.snap
+++ b/src/js/__tests__/__snapshots__/tslint-test.ts.snap
@@ -8,16 +8,12 @@ exports[`tslint snapshot should be up to date 1`] = `
 /packages/@extension-kid/toast-notifications/ToastExtension.ts - Shadowed name: 'toasts'
 /packages/@extension-kid/toast-notifications/ToastExtension.ts - Shadowed name: 'toast'
 /packages/@extension-kid/toast-notifications/ToastExtension.ts - Shadowed name: 'toast'
-/packages/foundation-ui/src/mount/MountService.ts - Identifier 'components' is never reassigned; use 'const' instead of 'let'.
-/packages/foundation-ui/src/mount/MountService.ts - Identifier 'instance' is never reassigned; use 'const' instead of 'let'.
 /packages/foundation-ui/src/mount/__tests__/Mount-test.tsx - Missing \\"key\\" prop for element.
 /packages/foundation-ui/src/mount/__tests__/Mount-test.tsx - Missing \\"key\\" prop for element.
 /packages/foundation-ui/src/mount/__tests__/Mount-test.tsx - Missing \\"key\\" prop for element.
 /packages/foundation-ui/src/routing/__tests__/RoutingService-test.ts - require statement not part of an import statement
-/plugins/banner/__tests__/BannerPlugin-test.ts - Multiple variable declarations in the same statement are forbidden
 /plugins/banner/__tests__/BannerPlugin-test.ts - require statement not part of an import statement
 /plugins/banner/__tests__/BannerPlugin-test.ts - require statement not part of an import statement
-/plugins/catalog/src/js/repositories/RepositoriesAdd.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
 /plugins/catalog/src/js/repositories/RepositoriesDelete.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
 /plugins/catalog/src/js/repositories/RepositoriesList.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
 /plugins/catalog/src/js/repositories/data/repositoriesModel.ts - Shadowed name: 'liveFetchRepositories'
@@ -53,7 +49,6 @@ exports[`tslint snapshot should be up to date 1`] = `
 /plugins/jobs/src/js/data/JobModel.ts - Shadowed name: 'updateSchedule'
 /plugins/jobs/src/js/data/JobModel.ts - Shadowed name: 'deleteJob'
 /plugins/jobs/src/js/data/JobModel.ts - Shadowed name: 'stopJobRun'
-/plugins/jobs/src/js/data/__tests__/JobModel-test.ts - Multiple variable declarations in the same statement are forbidden
 /plugins/jobs/src/js/pages/JobRunHistoryTable.tsx - Shadowed name: 'startedAt'
 /plugins/jobs/src/js/pages/JobRunHistoryTable.tsx - Shadowed name: 'finishedAt'
 /plugins/jobs/src/js/pages/JobRunHistoryTable.tsx - Shadowed name: 'runTime'
@@ -64,9 +59,7 @@ exports[`tslint snapshot should be up to date 1`] = `
 /plugins/nodes/src/js/components/NodesGridDials.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
 /plugins/nodes/src/js/components/NodesTable.tsx - The function render has a cyclomatic complexity of 40 which is higher than the threshold of 20
 /plugins/nodes/src/js/components/__tests__/NodeBreadcrumbs-test.tsx - require statement not part of an import statement
-/plugins/nodes/src/js/components/__tests__/NodesGridDials-test.tsx - Multiple variable declarations in the same statement are forbidden
 /plugins/nodes/src/js/components/__tests__/NodesGridView-test.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
-/plugins/nodes/src/js/components/__tests__/NodesGridView-test.tsx - Multiple variable declarations in the same statement are forbidden
 /plugins/nodes/src/js/components/modals/DeactivateNodeConfirm.tsx - Shadowed name: 'node'
 /plugins/nodes/src/js/components/modals/DrainNodeModal.tsx - Shadowed name: 'node'
 /plugins/nodes/src/js/components/modals/DrainNodeModal.tsx - Shadowed name: 'props'
@@ -79,29 +72,15 @@ exports[`tslint snapshot should be up to date 1`] = `
 /plugins/nodes/src/js/filters/__tests__/NodesZoneFilter-test.ts - require statement not part of an import statement
 /plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx - Shadowed name: 'network'
 /plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx - Shadowed name: 'network'
-/plugins/nodes/src/js/stores/__tests__/NodeHealthStore-test.ts - Multiple variable declarations in the same statement are forbidden
 /plugins/oauth/components/AuthenticatedUserAccountDropdown.tsx - don't declare variable menuItems to return it immediately
 /plugins/services/src/js/columns/ServicesTableActionsColumn.tsx - The function has a cyclomatic complexity of 27 which is higher than the threshold of 20
-/plugins/services/src/js/components/ConfigurationMapTable.tsx - Identifier 'columnDefaults' is never reassigned; use 'const' instead of 'let'.
-/plugins/services/src/js/components/ConfigurationMapTable.tsx - Identifier 'data' is never reassigned; use 'const' instead of 'let'.
-/plugins/services/src/js/components/ConfigurationMapTable.tsx - Identifier 'onEditClick' is never reassigned; use 'const' instead of 'let'.
-/plugins/services/src/js/components/ConfigurationMapTable.tsx - Identifier 'tabViewID' is never reassigned; use 'const' instead of 'let'.
 /plugins/services/src/js/components/DeploymentsModal.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
-/plugins/services/src/js/components/RecentOffersSummary.tsx - Identifier 'offers' is never reassigned; use 'const' instead of 'let'.
-/plugins/services/src/js/components/RecentOffersSummary.tsx - Identifier 'matched' is never reassigned; use 'const' instead of 'let'.
 /plugins/services/src/js/components/RecentOffersSummary.tsx - Use a conditional expression instead of assigning to 'percentageMatched' in multiple places.
 /plugins/services/src/js/components/RecentOffersSummary.tsx - Use a conditional expression instead of assigning to 'percentageOffered' in multiple places.
-/plugins/services/src/js/components/SearchLog.tsx - Identifier 'totalFound' is never reassigned; use 'const' instead of 'let'.
-/plugins/services/src/js/components/SearchLog.tsx - Identifier 'searchString' is never reassigned; use 'const' instead of 'let'.
-/plugins/services/src/js/components/SearchLog.tsx - Identifier 'totalFound' is never reassigned; use 'const' instead of 'let'.
 /plugins/services/src/js/components/ServiceStatusProgressBar.tsx - require statement not part of an import statement
 /plugins/services/src/js/components/__tests__/ConfigurationMapTable-test.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
-/plugins/services/src/js/components/__tests__/FilterByFramework-test.tsx - Multiple variable declarations in the same statement are forbidden
-/plugins/services/src/js/components/__tests__/LogView-test.tsx - Multiple variable declarations in the same statement are forbidden
-/plugins/services/src/js/components/__tests__/MesosLogContainer-test.tsx - Multiple variable declarations in the same statement are forbidden
 /plugins/services/src/js/components/__tests__/MesosLogContainer-test.tsx - Identifier 'thisMesosLogStoreGetLogBuffer' is never reassigned; use 'const' instead of 'let'.
 /plugins/services/src/js/components/__tests__/ServiceBreadcrumbs-test.tsx - Missing \\"key\\" prop for element.
-/plugins/services/src/js/components/__tests__/ServiceList-test.tsx - Multiple variable declarations in the same statement are forbidden
 /plugins/services/src/js/components/forms/EnvironmentFormSection.tsx - Binds are forbidden in JSX attributes due to their rendering performance impact
 /plugins/services/src/js/components/forms/EnvironmentFormSection.tsx - Binds are forbidden in JSX attributes due to their rendering performance impact
 /plugins/services/src/js/components/forms/EnvironmentFormSection.tsx - Shadowed name: 'env'
@@ -114,9 +93,6 @@ exports[`tslint snapshot should be up to date 1`] = `
 /plugins/services/src/js/components/modals/CreateServiceModal.tsx - don't declare variable newState to return it immediately
 /plugins/services/src/js/components/modals/CreateServiceModalForm.tsx - Shadowed name: 'tabs'
 /plugins/services/src/js/components/modals/CreateServiceModalForm.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
-/plugins/services/src/js/components/modals/KillPodInstanceModal.tsx - Identifier 'details' is never reassigned; use 'const' instead of 'let'.
-/plugins/services/src/js/components/modals/KillTaskModal.tsx - Identifier 'details' is never reassigned; use 'const' instead of 'let'.
-/plugins/services/src/js/components/modals/ServiceDestroyModal.tsx - Identifier 'details' is never reassigned; use 'const' instead of 'let'.
 /plugins/services/src/js/components/modals/ServiceModals.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
 /plugins/services/src/js/components/modals/ServiceModals.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
 /plugins/services/src/js/components/modals/ServiceModals.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
@@ -126,39 +102,28 @@ exports[`tslint snapshot should be up to date 1`] = `
 /plugins/services/src/js/components/modals/ServiceModals.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
 /plugins/services/src/js/components/modals/ServiceModals.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
 /plugins/services/src/js/components/modals/ServiceRestartModal.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
-/plugins/services/src/js/components/modals/ServiceRestartModal.tsx - Identifier 'details' is never reassigned; use 'const' instead of 'let'.
-/plugins/services/src/js/components/modals/ServiceResumeModal.tsx - Identifier 'details' is never reassigned; use 'const' instead of 'let'.
-/plugins/services/src/js/components/modals/ServiceScaleFormModal.tsx - Identifier 'details' is never reassigned; use 'const' instead of 'let'.
 /plugins/services/src/js/components/modals/ServiceStopModal.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
-/plugins/services/src/js/components/modals/ServiceStopModal.tsx - Identifier 'details' is never reassigned; use 'const' instead of 'let'.
 /plugins/services/src/js/components/modals/TaskModals.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
 /plugins/services/src/js/components/modals/TaskModals.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
 /plugins/services/src/js/components/modals/TaskModals.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
 /plugins/services/src/js/components/modals/TaskModals.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
 /plugins/services/src/js/components/modals/__tests__/EditServiceModal-test.tsx - require statement not part of an import statement
-/plugins/services/src/js/containers/pod-debug/PodDebugContainer.tsx - Multiple variable declarations in the same statement are forbidden
 /plugins/services/src/js/containers/pod-debug/PodDebugContainer.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
 /plugins/services/src/js/containers/pod-detail/PodHeader.tsx - Missing \\"key\\" prop for element.
 /plugins/services/src/js/containers/pod-detail/PodHeader.tsx - Missing \\"key\\" prop for element.
 /plugins/services/src/js/containers/pod-detail/PodHeader.tsx - don't declare variable actionButtons to return it immediately
 /plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx - don't declare variable children to return it immediately
-/plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx - Identifier 'pod' is never reassigned; use 'const' instead of 'let'.
-/plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx - Identifier 'filterText' is never reassigned; use 'const' instead of 'let'.
-/plugins/services/src/js/containers/pod-instances/__tests__/PodInstancesContainer-test.tsx - Multiple variable declarations in the same statement are forbidden
 /plugins/services/src/js/containers/service-configuration/ServiceConfiguration.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
 /plugins/services/src/js/containers/service-configuration/__tests__/ServiceConfigurationContainer-test.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
 /plugins/services/src/js/containers/service-connection/MesosDNSList.tsx - Shadowed name: 'service'
 /plugins/services/src/js/containers/service-connection/MesosDNSList.tsx - Missing \\"key\\" prop for element.
-/plugins/services/src/js/containers/service-debug/ServiceDebugContainer.tsx - Multiple variable declarations in the same statement are forbidden
 /plugins/services/src/js/containers/service-debug/ServiceDebugContainer.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
 /plugins/services/src/js/containers/service-debug/TaskStatsTable.tsx - Forbidden constructor, use a literal or simple function call instead
 /plugins/services/src/js/containers/services/ServicesTable.tsx - The function render has a cyclomatic complexity of 38 which is higher than the threshold of 20
 /plugins/services/src/js/containers/services/ServicesTable.tsx - Shadowed name: 'Component'
 /plugins/services/src/js/containers/services/__tests__/ServicesContainer-test.tsx - require statement not part of an import statement
-/plugins/services/src/js/containers/services/__tests__/ServicesContainer-test.tsx - Multiple variable declarations in the same statement are forbidden
 /plugins/services/src/js/containers/tasks/TasksView.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
 /plugins/services/src/js/containers/tasks/__tests__/TaskTable-test.tsx - require statement not part of an import statement
-/plugins/services/src/js/containers/tasks/__tests__/TaskTable-test.tsx - Multiple variable declarations in the same statement are forbidden
 /plugins/services/src/js/containers/tasks/__tests__/TaskTable-test.tsx - Identifier 'thisGetNodeFromID' is never reassigned; use 'const' instead of 'let'.
 /plugins/services/src/js/containers/volume-detail/PodVolumeContainer.tsx - Shadowed name: 'volume'
 /plugins/services/src/js/containers/volume-detail/PodVolumeDetail.tsx - Missing \\"key\\" prop for element.
@@ -167,10 +132,8 @@ exports[`tslint snapshot should be up to date 1`] = `
 /plugins/services/src/js/data/__tests__/ServicePlansClient-test.ts - require statement not part of an import statement
 /plugins/services/src/js/data/errors/OvercommitQuotaError.ts - Shadowed name: 'resources'
 /plugins/services/src/js/data/groups/fetchers.ts - Shadowed name: 'groups'
-/plugins/services/src/js/events/TaskDirectoryActions.ts - Multiple variable declarations in the same statement are forbidden
 /plugins/services/src/js/events/__tests__/MarathonActions-test.ts - require statement not part of an import statement
 /plugins/services/src/js/events/__tests__/ServiceActions-test.ts - Shadowed name: 'serviceDefinition'
-/plugins/services/src/js/events/__tests__/TaskDirectoryActions-test.ts - Multiple variable declarations in the same statement are forbidden
 /plugins/services/src/js/filters/__tests__/PodInstanceStatusFilter-test.ts - require statement not part of an import statement
 /plugins/services/src/js/filters/__tests__/PodInstanceTextFilter-test.ts - require statement not part of an import statement
 /plugins/services/src/js/filters/__tests__/PodInstancesRegionFilter-test.ts - require statement not part of an import statement
@@ -192,15 +155,11 @@ exports[`tslint snapshot should be up to date 1`] = `
 /plugins/services/src/js/pages/EditFrameworkConfiguration.tsx - Binds are forbidden in JSX attributes due to their rendering performance impact
 /plugins/services/src/js/pages/task-details/TaskFileViewer.tsx - Shadowed name: 'file'
 /plugins/services/src/js/pages/task-details/TaskFileViewer.tsx - Binds are forbidden in JSX attributes due to their rendering performance impact
-/plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx - Identifier 'frameworkID' is never reassigned; use 'const' instead of 'let'.
-/plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx - Identifier 'id' is never reassigned; use 'const' instead of 'let'.
 /plugins/services/src/js/pages/task-details/__tests__/TaskDetail-test.ts - require statement not part of an import statement
 /plugins/services/src/js/pages/task-details/__tests__/TaskDetail-test.ts - require statement not part of an import statement
 /plugins/services/src/js/pages/task-details/__tests__/TaskDetail-test.ts - require statement not part of an import statement
-/plugins/services/src/js/pages/task-details/__tests__/TaskDetail-test.ts - Multiple variable declarations in the same statement are forbidden
 /plugins/services/src/js/pages/task-details/__tests__/TaskDetail-test.ts - require statement not part of an import statement
 /plugins/services/src/js/pages/task-details/__tests__/TaskDetail-test.ts - require statement not part of an import statement
-/plugins/services/src/js/pages/task-details/__tests__/TaskFileViewer-test.tsx - Multiple variable declarations in the same statement are forbidden
 /plugins/services/src/js/pages/task-details/__tests__/TaskIpAddressesRow-test.tsx - require statement not part of an import statement
 /plugins/services/src/js/pages/task-details/__tests__/TaskIpAddressesRow-test.tsx - require statement not part of an import statement
 /plugins/services/src/js/reducers/__tests__/JSONMultiContainer-test.ts - Don't bind scopes to arrow lambdas, as they already have a bound scope.
@@ -226,14 +185,8 @@ exports[`tslint snapshot should be up to date 1`] = `
 /plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/MultiContainerArtifacts-test.ts - Don't bind scopes to arrow lambdas, as they already have a bound scope.
 /plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/MultiContainerArtifacts-test.ts - Don't bind scopes to arrow lambdas, as they already have a bound scope.
 /plugins/services/src/js/reducers/serviceForm/JSONReducers/Artifacts.ts - Shadowed name: 'index'
-/plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.ts - Identifier 'name' is never reassigned; use 'const' instead of 'let'.
-/plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.ts - Identifier 'networkNames' is never reassigned; use 'const' instead of 'let'.
 /plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.ts - The function JSONReducer has a cyclomatic complexity of 39 which is higher than the threshold of 20
-/plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.ts - Identifier 'containerPort' is never reassigned; use 'const' instead of 'let'.
-/plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.ts - Identifier 'automaticPort' is never reassigned; use 'const' instead of 'let'.
 /plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.ts - Shadowed name: 'index'
-/plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.ts - Identifier 'vipLabel' is never reassigned; use 'const' instead of 'let'.
-/plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.ts - Identifier 'vipPort' is never reassigned; use 'const' instead of 'let'.
 /plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.ts - Shadowed name: 'index'
 /plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.ts - Shadowed name: 'index'
 /plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.ts - Shadowed name: 'index'
@@ -277,28 +230,20 @@ exports[`tslint snapshot should be up to date 1`] = `
 /plugins/services/src/js/service-configuration/ServiceHealthChecksConfigSection.tsx - Missing \\"key\\" prop for element.
 /plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.tsx - Missing \\"key\\" prop for element.
 /plugins/services/src/js/stores/MarathonStore.ts - The function has a cyclomatic complexity of 36 which is higher than the threshold of 20
-/plugins/services/src/js/stores/MarathonStore.ts - Identifier 'serviceID' is never reassigned; use 'const' instead of 'let'.
 /plugins/services/src/js/stores/MesosLogStore.ts - don't declare variable logBuffer to return it immediately
-/plugins/services/src/js/stores/__tests__/MesosLogStore-test.ts - Multiple variable declarations in the same statement are forbidden
 /plugins/services/src/js/stores/__tests__/SDKEndpointStore-test.ts - Shadowed name: 'endpoints'
 /plugins/services/src/js/structs/Framework.ts - Shadowed name: 'memo'
 /plugins/services/src/js/structs/LogBuffer.ts - Use a conditional expression instead of assigning to 'start' in multiple places.
 /plugins/services/src/js/structs/ServiceTree.ts - Expected a 'for-of' loop instead of a 'for' loop with this simple iteration
 /plugins/services/src/js/structs/ServiceTree.ts - == should be ===
 /plugins/services/src/js/structs/ServiceTree.ts - Shadowed name: 'marathonTask'
-/plugins/services/src/js/structs/__tests__/LogBuffer-test.ts - Multiple variable declarations in the same statement are forbidden
-/plugins/services/src/js/structs/__tests__/ServiceEndpoint-test.ts - Multiple variable declarations in the same statement are forbidden
 /plugins/services/src/js/utils/DeclinedOffersUtil.ts - Shadowed name: 'value'
-/plugins/services/src/js/utils/DeclinedOffersUtil.ts - Identifier 'name' is never reassigned; use 'const' instead of 'let'.
-/plugins/services/src/js/utils/DeclinedOffersUtil.ts - Identifier 'role' is never reassigned; use 'const' instead of 'let'.
 /plugins/services/src/js/utils/HostUtil.ts - Shadowed name: 'string'
 /plugins/services/src/js/utils/MarathonErrorUtil.ts - Shadowed name: 'memo'
 /plugins/services/src/js/utils/MarathonUtil.ts - Shadowed name: 'id'
 /plugins/services/src/js/utils/MarathonUtil.ts - Shadowed name: 'id'
 /plugins/services/src/js/utils/QuotaUtil.ts - Shadowed name: 'role'
 /plugins/services/src/js/utils/TaskUtil.ts - don't declare variable node to return it immediately
-/plugins/services/src/js/utils/__tests__/FrameworkUtil-test.ts - Multiple variable declarations in the same statement are forbidden
-/plugins/services/src/js/utils/__tests__/TaskTableUtil-test.ts - Multiple variable declarations in the same statement are forbidden
 /plugins/services/src/js/validators/MarathonAppValidators.ts - Shadowed name: 'type'
 /plugins/services/src/js/validators/MarathonAppValidators.ts - Shadowed name: 'isUnanchored'
 /plugins/services/src/js/validators/MarathonAppValidators.ts - Shadowed name: 'variables'
@@ -310,25 +255,11 @@ exports[`tslint snapshot should be up to date 1`] = `
 /plugins/tracking/hooks.tsx - require statement not part of an import statement
 /src/js/components/CollapsingString.tsx - Use a conditional expression instead of assigning to 'parent' in multiple places.
 /src/js/components/CosmosErrorMessage.tsx - Shadowed name: 'error'
-/src/js/components/DSLFormWithExpressionUpdates.tsx - Identifier 'groupCombiner' is never reassigned; use 'const' instead of 'let'.
-/src/js/components/DSLFormWithExpressionUpdates.tsx - Identifier 'itemCombiner' is never reassigned; use 'const' instead of 'let'.
-/src/js/components/DSLFormWithExpressionUpdates.tsx - Identifier 'parts' is never reassigned; use 'const' instead of 'let'.
-/src/js/components/DSLFormWithExpressionUpdates.tsx - Identifier 'updatePolicy' is never reassigned; use 'const' instead of 'let'.
 /src/js/components/ExpandingTable.tsx - Use a conditional expression instead of assigning to 'expandedRows[rowID]' in multiple places.
-/src/js/components/FilterButtons.tsx - Identifier 'filterByKey' is never reassigned; use 'const' instead of 'let'.
-/src/js/components/FilterButtons.tsx - Identifier 'filters' is never reassigned; use 'const' instead of 'let'.
-/src/js/components/FilterButtons.tsx - Identifier 'inverseStyle' is never reassigned; use 'const' instead of 'let'.
-/src/js/components/FilterButtons.tsx - Identifier 'selectedFilter' is never reassigned; use 'const' instead of 'let'.
-/src/js/components/FilterHeadline.tsx - Identifier 'className' is never reassigned; use 'const' instead of 'let'.
-/src/js/components/FilterHeadline.tsx - Identifier 'currentLength' is never reassigned; use 'const' instead of 'let'.
-/src/js/components/FilterHeadline.tsx - Identifier 'inverseStyle' is never reassigned; use 'const' instead of 'let'.
-/src/js/components/FilterHeadline.tsx - Identifier 'isFiltering' is never reassigned; use 'const' instead of 'let'.
-/src/js/components/FilterHeadline.tsx - Identifier 'totalLength' is never reassigned; use 'const' instead of 'let'.
 /src/js/components/FrameworkConfiguration.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
 /src/js/components/JSONEditor.tsx - Shadowed name: 'token'
 /src/js/components/JSONEditor.tsx - Shadowed name: 'token'
 /src/js/components/PlacementConstraintsPartial.tsx - Shadowed name: 'index'
-/src/js/components/ProgressBar.tsx - Identifier 'style' is never reassigned; use 'const' instead of 'let'.
 /src/js/components/RequestErrorMsg.tsx - Missing \\"key\\" prop for element.
 /src/js/components/RequestErrorMsg.tsx - Missing \\"key\\" prop for element.
 /src/js/components/ResourceSwitchDropdown.tsx - don't declare variable menuItems to return it immediately
@@ -342,37 +273,14 @@ exports[`tslint snapshot should be up to date 1`] = `
 /src/js/components/Sidebar.tsx - Missing \\"key\\" prop for element.
 /src/js/components/ToggleValue.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
 /src/js/components/YamlEditorSchemaField.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
-/src/js/components/__tests__/Authenticated-test.tsx - Multiple variable declarations in the same statement are forbidden
 /src/js/components/__tests__/Authenticated-test.tsx - require statement not part of an import statement
-/src/js/components/__tests__/ClickToSelect-test.tsx - Multiple variable declarations in the same statement are forbidden
-/src/js/components/__tests__/ExpandingTable-test.tsx - Multiple variable declarations in the same statement are forbidden
-/src/js/components/__tests__/FilterButtons-test.tsx - Multiple variable declarations in the same statement are forbidden
 /src/js/components/__tests__/NestedServiceLinks-test.tsx - Shadowed name: 'id'
-/src/js/components/__tests__/Panel-test.tsx - Multiple variable declarations in the same statement are forbidden
-/src/js/components/__tests__/PlacementConstraintsSchemaFields-test.tsx - Multiple variable declarations in the same statement are forbidden
-/src/js/components/__tests__/ServerErrorModal-test.tsx - Multiple variable declarations in the same statement are forbidden
-/src/js/components/__tests__/SideTabs-test.tsx - Multiple variable declarations in the same statement are forbidden
-/src/js/components/__tests__/TabButton-test.tsx - Multiple variable declarations in the same statement are forbidden
-/src/js/components/__tests__/TabButtonList-test.tsx - Multiple variable declarations in the same statement are forbidden
-/src/js/components/__tests__/Tabs-test.tsx - Multiple variable declarations in the same statement are forbidden
-/src/js/components/charts/Chart.tsx - Identifier 'width' is never reassigned; use 'const' instead of 'let'.
 /src/js/components/charts/TasksChart.tsx - Shadowed name: 'task'
-/src/js/components/charts/__tests__/TasksChart-test.tsx - Multiple variable declarations in the same statement are forbidden
-/src/js/components/charts/__tests__/TimeSeriesArea-test.tsx - Multiple variable declarations in the same statement are forbidden
-/src/js/components/charts/__tests__/TimeSeriesChart-test.tsx - Multiple variable declarations in the same statement are forbidden
 /src/js/components/modals/ActionsModal.tsx - Shadowed name: 'action'
-/src/js/components/modals/__tests__/CliInstallModal-test.tsx - Multiple variable declarations in the same statement are forbidden
 /src/js/components/modals/__tests__/CliInstallModal-test.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
 /src/js/components/modals/__tests__/CliInstallModal-test.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
-/src/js/components/modals/__tests__/ErrorModal-test.tsx - Multiple variable declarations in the same statement are forbidden
-/src/js/events/SystemLogActions.ts - Identifier 'cursor' is never reassigned; use 'const' instead of 'let'.
-/src/js/events/SystemLogActions.ts - Identifier 'skip_prev' is never reassigned; use 'const' instead of 'let'.
-/src/js/events/SystemLogActions.ts - Identifier 'limit' is never reassigned; use 'const' instead of 'let'.
-/src/js/events/VirtualNetworksActions.ts - Identifier 'vtep_mac_oui' is never reassigned; use 'const' instead of 'let'.
-/src/js/events/VirtualNetworksActions.ts - Identifier 'vtep_subnet' is never reassigned; use 'const' instead of 'let'.
 /src/js/events/VirtualNetworksActions.ts - require statement not part of an import statement
 /src/js/events/__tests__/CosmosPackagesActions-test.ts - require statement not part of an import statement
-/src/js/events/__tests__/SystemLogActions-test.ts - Multiple variable declarations in the same statement are forbidden
 /src/js/i18n.ts - require statement not part of an import statement
 /src/js/i18n.ts - require statement not part of an import statement
 /src/js/index.tsx - require statement not part of an import statement
@@ -384,14 +292,11 @@ exports[`tslint snapshot should be up to date 1`] = `
 /src/js/pages/catalog/PackageDetailTab.tsx - Shadowed name: 'dependency'
 /src/js/pages/catalog/PackagesTab.tsx - Missing \\"key\\" prop for element.
 /src/js/pages/catalog/PackagesTab.tsx - Missing \\"key\\" prop for element.
-/src/js/pages/catalog/__tests__/PackageDetailTab-test.tsx - Multiple variable declarations in the same statement are forbidden
 /src/js/pages/catalog/__tests__/PackagesTab-test.tsx - require statement not part of an import statement
 /src/js/pages/catalog/__tests__/PackagesTab-test.tsx - require statement not part of an import statement
 /src/js/pages/catalog/__tests__/PackagesTab-test.tsx - require statement not part of an import statement
-/src/js/pages/catalog/__tests__/PackagesTab-test.tsx - Multiple variable declarations in the same statement are forbidden
 /src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.tsx - Shadowed name: 'overlay'
 /src/js/pages/network/virtual-network-detail/VirtualNetworkTaskPage.tsx - Shadowed name: 'overlay'
-/src/js/pages/system/OrganizationTab.tsx - Identifier 'itemID' is never reassigned; use 'const' instead of 'let'.
 /src/js/pages/system/OverviewDetailTab.tsx - Use a conditional expression instead of assigning to 'ccid' in multiple places.
 /src/js/plugin-bridge/Loader.ts - require statement not part of an import statement
 /src/js/plugin-bridge/PluginSDK.ts - Use a conditional expression instead of assigning to 'path' in multiple places.
@@ -402,13 +307,9 @@ exports[`tslint snapshot should be up to date 1`] = `
 /src/js/plugin-bridge/PluginTestUtils.ts - Shadowed name: 'path'
 /src/js/plugin-bridge/PluginTestUtils.ts - Use a conditional expression instead of assigning to 'path' in multiple places.
 /src/js/plugin-bridge/__tests__/ActionsPubSub-test.ts - require statement not part of an import statement
-/src/js/plugin-bridge/__tests__/ActionsPubSub-test.ts - Multiple variable declarations in the same statement are forbidden
-/src/js/plugin-bridge/__tests__/Hooks-test.ts - Multiple variable declarations in the same statement are forbidden
-/src/js/plugin-bridge/__tests__/PluginSDK-test.ts - Multiple variable declarations in the same statement are forbidden
 /src/js/stores/CosmosPackagesStore.ts - The function has a cyclomatic complexity of 24 which is higher than the threshold of 20
 /src/js/stores/DCOSStore.ts - Use a conditional expression instead of assigning to 'id' in multiple places.
 /src/js/stores/DCOSStore.ts - Use a conditional expression instead of assigning to 'id' in multiple places.
-/src/js/stores/DCOSStore.ts - Identifier 'serviceID' is never reassigned; use 'const' instead of 'let'.
 /src/js/stores/MesosStateStore.ts - Shadowed name: 'framework'
 /src/js/stores/MesosStateStore.ts - Shadowed name: 'MesosStreamType'
 /src/js/stores/MesosStateStore.ts - require statement not part of an import statement
@@ -416,27 +317,18 @@ exports[`tslint snapshot should be up to date 1`] = `
 /src/js/stores/MesosStream/parsers/__tests__/tasks-test.ts - Shadowed name: 'message'
 /src/js/stores/MesosStream/parsers/tasks.ts - don't declare variable marathonId to return it immediately
 /src/js/stores/SystemLogStore.ts - Use a conditional expression instead of assigning to 'newLogData.entries' in multiple places.
-/src/js/stores/__tests__/AuthStore-test.ts - Multiple variable declarations in the same statement are forbidden
-/src/js/stores/__tests__/CosmosPackagesStore-test.ts - Multiple variable declarations in the same statement are forbidden
 /src/js/stores/__tests__/CosmosPackagesStore-test.ts - Shadowed name: 'packageVersions'
 /src/js/stores/__tests__/CosmosPackagesStore-test.ts - Shadowed name: 'packageVersions'
 /src/js/stores/__tests__/DCOSStore-test.ts - require statement not part of an import statement
 /src/js/stores/__tests__/DCOSStore-test.ts - require statement not part of an import statement
-/src/js/stores/__tests__/MesosStateStore-test.ts - Multiple variable declarations in the same statement are forbidden
 /src/js/stores/__tests__/MesosStateStore-test.ts - require statement not part of an import statement
 /src/js/stores/__tests__/MesosSummaryFetchers-test.tsx - require statement not part of an import statement
-/src/js/stores/__tests__/MesosSummaryStore-test.ts - Multiple variable declarations in the same statement are forbidden
-/src/js/stores/__tests__/UnitHealthStore-test.ts - Multiple variable declarations in the same statement are forbidden
-/src/js/stores/__tests__/UserSettingsStore-test.ts - Multiple variable declarations in the same statement are forbidden
-/src/js/stores/__tests__/UsersStore-test.ts - Multiple variable declarations in the same statement are forbidden
 /src/js/structs/Batch.ts - Use an optional parameter instead of initializing to 'undefined'. Also, the type declaration does not need to include '| undefined'.
-/src/js/structs/CompositeState.ts - Multiple variable declarations in the same statement are forbidden
 /src/js/structs/DSLASTNodes.ts - A maximum of 1 class per file is allowed.
 /src/js/structs/DSLASTNodes.ts - A maximum of 1 class per file is allowed.
 /src/js/structs/DSLExpressionPart.ts - Use an optional parameter instead of initializing to 'undefined'. Also, the type declaration does not need to include '| undefined'.
 /src/js/structs/Job.ts - don't declare variable cmd to return it immediately
 /src/js/structs/JobTree.ts - == should be ===
-/src/js/structs/SummaryList.ts - Multiple variable declarations in the same statement are forbidden
 /src/js/structs/__tests__/Batch-test.ts - Shadowed name: 'values'
 /src/js/structs/__tests__/Batch-test.ts - Shadowed name: 'values'
 /src/js/structs/__tests__/Batch-test.ts - Shadowed name: 'sum'
@@ -446,14 +338,10 @@ exports[`tslint snapshot should be up to date 1`] = `
 /src/js/structs/__tests__/DSLExpression-test.ts - require statement not part of an import statement
 /src/js/structs/__tests__/List-test.ts - A maximum of 1 class per file is allowed.
 /src/js/structs/__tests__/List-test.ts - unused expression, expected an assignment or function call
-/src/js/structs/__tests__/List-test.ts - Multiple variable declarations in the same statement are forbidden
-/src/js/structs/__tests__/SummaryList-test.ts - Multiple variable declarations in the same statement are forbidden
 /src/js/utils/DOMUtils.ts - Expected a 'for-of' loop instead of a 'for' loop with this simple iteration
 /src/js/utils/DOMUtils.ts - Use a conditional expression instead of assigning to 'compstyle' in multiple places.
 /src/js/utils/ErrorMessageUtil.ts - Shadowed name: 'rule'
 /src/js/utils/ErrorMessageUtil.ts - Shadowed name: 'rule'
-/src/js/utils/JSONUtil.ts - Identifier 'token' is never reassigned; use 'const' instead of 'let'.
-/src/js/utils/JSONUtil.ts - Identifier 'offset' is never reassigned; use 'const' instead of 'let'.
 /src/js/utils/JSONUtil.ts - Use a conditional expression instead of assigning to 'arrayIndex' in multiple places.
 /src/js/utils/JSONUtil.ts - The function getObjectInformation has a cyclomatic complexity of 23 which is higher than the threshold of 20
 /src/js/utils/JestUtil.tsx - A maximum of 1 class per file is allowed.
@@ -462,16 +350,10 @@ exports[`tslint snapshot should be up to date 1`] = `
 /src/js/utils/Maths.ts - asterisks in jsdoc must be aligned
 /src/js/utils/Maths.ts - jsdoc is not formatted correctly on this line
 /src/js/utils/MesosStateUtil.ts - Shadowed name: 'memo'
-/src/js/utils/MesosSummaryUtil.ts - Multiple variable declarations in the same statement are forbidden
 /src/js/utils/TableUtil.ts - == should be ===
 /src/js/utils/TableUtil.ts - == should be ===
-/src/js/utils/__tests__/DOMUtils-test.ts - Multiple variable declarations in the same statement are forbidden
 /src/js/utils/__tests__/DSLParserUtil-test.ts - A maximum of 1 class per file is allowed.
 /src/js/utils/__tests__/DSLParserUtil-test.ts - A maximum of 1 class per file is allowed.
-/src/js/utils/__tests__/DSLParserUtil-test.ts - Multiple variable declarations in the same statement are forbidden
-/src/js/utils/__tests__/DSLUtil-test.ts - Multiple variable declarations in the same statement are forbidden
-/src/js/utils/__tests__/FormUtil-test.ts - Multiple variable declarations in the same statement are forbidden
-/src/js/utils/__tests__/MesosStateUtil-test.ts - Multiple variable declarations in the same statement are forbidden
 /src/js/utils/__tests__/ParserUtil-test.ts - Shadowed name: 'state'
 /src/js/utils/__tests__/ParserUtil-test.ts - Shadowed name: 'state'
 /src/js/utils/__tests__/ReducerUtil-test.ts - Shadowed name: 'state'
@@ -480,19 +362,14 @@ exports[`tslint snapshot should be up to date 1`] = `
 /src/js/utils/__tests__/ReducerUtil-test.ts - Shadowed name: 'state'
 /src/js/utils/__tests__/ReducerUtil-test.ts - Shadowed name: 'state'
 /src/js/utils/__tests__/ReducerUtil-test.ts - Shadowed name: 'state'
-/src/js/utils/__tests__/ReducerUtil-test.ts - Multiple variable declarations in the same statement are forbidden
 /src/js/utils/__tests__/ReducerUtil-test.ts - Shadowed name: 'state'
-/src/js/utils/__tests__/SystemLogUtil-test.ts - Multiple variable declarations in the same statement are forbidden
-/src/js/utils/__tests__/TableUtil-test.ts - Multiple variable declarations in the same statement are forbidden
 /src/js/utils/__tests__/TemplateUtil-test.tsx - Missing \\"key\\" prop for element.
 /src/js/utils/__tests__/TemplateUtil-test.tsx - Missing \\"key\\" prop for element.
 /src/js/utils/__tests__/TemplateUtil-test.tsx - Missing \\"key\\" prop for element.
 /src/js/utils/__tests__/TemplateUtil-test.tsx - Missing \\"key\\" prop for element.
 /src/js/utils/__tests__/TemplateUtil-test.tsx - Missing \\"key\\" prop for element.
 /src/js/utils/__tests__/TemplateUtil-test.tsx - Missing \\"key\\" prop for element.
-/src/js/utils/__tests__/Util-test.ts - Multiple variable declarations in the same statement are forbidden
 /src/resources/grammar/__tests__/SearchDSL-test.ts - A maximum of 1 class per file is allowed.
 /src/resources/grammar/__tests__/SearchDSL-test.ts - A maximum of 1 class per file is allowed.
-/src/resources/grammar/__tests__/SearchDSL-test.ts - Multiple variable declarations in the same statement are forbidden
 /src/resources/grammar/__tests__/SearchDSL-test.ts - require statement not part of an import statement"
 `;

--- a/src/js/__tests__/__snapshots__/typecheck-test.ts.snap
+++ b/src/js/__tests__/__snapshots__/typecheck-test.ts.snap
@@ -68,16 +68,14 @@ plugins/banner/hooks.tsx: error TS2339: Property 'historyListenerAdded' does not
 plugins/banner/hooks.tsx: error TS2339: Property 'historyListenerAdded' does not exist on type *.
 plugins/banner/hooks.tsx: error TS2339: Property 'contentWindow' does not exist on type 'HTMLElement'.
 plugins/banner/hooks.tsx: error TS2339: Property 'location' does not exist on type 'Global'.
-plugins/catalog/src/js/repositories/RepositoriesAdd.tsx: error TS2339: Property 'description' does not exist on type '{}'.
-plugins/catalog/src/js/repositories/RepositoriesAdd.tsx: error TS2339: Property 'message' does not exist on type '{}'.
 plugins/catalog/src/js/repositories/RepositoriesAdd.tsx: error TS2571: Object is of type 'unknown'.
 plugins/catalog/src/js/repositories/RepositoriesAdd.tsx: error TS2571: Object is of type 'unknown'.
 plugins/catalog/src/js/repositories/RepositoriesAdd.tsx: error TS2571: Object is of type 'unknown'.
 plugins/catalog/src/js/repositories/RepositoriesAdd.tsx: error TS2571: Object is of type 'unknown'.
 plugins/catalog/src/js/repositories/RepositoriesAdd.tsx: error TS2571: Object is of type 'unknown'.
 plugins/catalog/src/js/repositories/RepositoriesAdd.tsx: error TS2339: Property 'pipe' does not exist on type 'Subscribable<unknown>'.
-plugins/catalog/src/js/repositories/RepositoriesAdd.tsx: error TS2322: type * is not assignable to type *.
 plugins/catalog/src/js/repositories/RepositoriesAdd.tsx: error TS2571: Object is of type 'unknown'.
+plugins/catalog/src/js/repositories/RepositoriesAdd.tsx: error TS2322: type * is not assignable to type *.
 plugins/catalog/src/js/repositories/RepositoriesAdd.tsx: error TS2571: Object is of type 'unknown'.
 plugins/catalog/src/js/repositories/RepositoriesAdd.tsx: error TS2571: Object is of type 'unknown'.
 plugins/catalog/src/js/repositories/RepositoriesAdd.tsx: error TS2571: Object is of type 'unknown'.

--- a/tslint.json
+++ b/tslint.json
@@ -37,9 +37,10 @@
     "object-literal-sort-keys": {
       "severity": "off"
     },
+    "one-variable-per-declaration": false,
     "ordered-imports": false,
     "prefer-conditional-expression": true,
-    "prefer-const": true,
+    "prefer-const": [true, { "destructuring": "all" }],
     "prefer-object-spread": true,
     "prefer-readonly": true,
     "react-hooks-nesting": "error",


### PR DESCRIPTION
* `"one-variable-per-declaration": false`
  as i see no real value in having one declaration per line.

* `"prefer-const": [true, { "destructuring": "all" }],`
  let's mute tslint in case we have a destructuring going on that's using a let
  but contains some consts. it will complain if all of those values are consts.

