### PR TITLE
refactor: remove TabsMixin from places that do not use it

### DIFF
--- a/plugins/nodes/src/js/routes/nodes.ts
+++ b/plugins/nodes/src/js/routes/nodes.ts
@@ -111,13 +111,11 @@ export default [
             component: TaskDetailsTab,
             hideHeaderNavigation: true,
             title: "Details",
-            path: "details",
-            isTab: true
+            path: "details"
           },
           {
             hideHeaderNavigation: true,
             component: TaskFilesTab,
-            isTab: true,
             path: "files",
             title: "Files",
             type: Route,
@@ -140,7 +138,6 @@ export default [
           {
             component: TaskLogsContainer,
             hideHeaderNavigation: true,
-            isTab: true,
             path: "logs",
             title: "Logs",
             type: Route,
@@ -154,7 +151,6 @@ export default [
           {
             component: VolumeTable,
             hideHeaderNavigation: true,
-            isTab: true,
             path: "volumes",
             title: "Volumes",
             type: Route

--- a/plugins/services/src/js/routes/services.ts
+++ b/plugins/services/src/js/routes/services.ts
@@ -77,8 +77,7 @@ const serviceRoutes = [
         children: [
           {
             type: Route,
-            path: ":id",
-            isTab: true
+            path: ":id"
           }
         ]
       },
@@ -182,14 +181,12 @@ const serviceRoutes = [
                 type: Route,
                 component: TaskDetailsTab,
                 hideHeaderNavigation: true,
-                isTab: true,
                 path: "details",
                 title: "Details"
               },
               {
                 hideHeaderNavigation: true,
                 component: TaskFilesTab,
-                isTab: true,
                 path: "files",
                 title: "Files",
                 type: Route,
@@ -212,7 +209,6 @@ const serviceRoutes = [
               {
                 component: TaskLogsContainer,
                 hideHeaderNavigation: true,
-                isTab: true,
                 path: "logs",
                 title: "Logs",
                 type: Route,
@@ -226,7 +222,6 @@ const serviceRoutes = [
               {
                 component: VolumeTable,
                 hideHeaderNavigation: true,
-                isTab: true,
                 path: "volumes",
                 title: "Volumes",
                 type: Route
@@ -234,7 +229,6 @@ const serviceRoutes = [
               {
                 component: PodVolumeTable,
                 hideHeaderNavigation: true,
-                isTab: true,
                 path: "podvolumes",
                 title: "Volumes",
                 type: Route

--- a/src/js/__tests__/__snapshots__/typecheck-test.ts.snap
+++ b/src/js/__tests__/__snapshots__/typecheck-test.ts.snap
@@ -540,13 +540,9 @@ plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.tsx: error TS2339: Pr
 plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.tsx: error TS2339: Property 'filters' does not exist on type 'Readonly<{}>'.
 plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.tsx: error TS2339: Property 'defaultFilterData' does not exist on type 'Readonly<{}>'.
 plugins/nodes/src/js/pages/nodes/NodeDetailHealthTab.tsx: error TS2322: type * is not assignable to type *.
-plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'props' does not exist on type 'NodeDetailPage'.
-plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'setState' does not exist on type 'NodeDetailPage'.
-plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'props' does not exist on type 'NodeDetailPage'.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2322: Type 'string' is not assignable to type 'never'.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2322: type * is not assignable to type 'never'.
-plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2322: Type 'string' is not assignable to type 'never'.
-plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2322: type * is not assignable to type 'never'.
+plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS6133: 'RouterUtil' is declared but its value is never read.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2322: Type 'string' is not assignable to type 'never'.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2322: type * is not assignable to type 'never'.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'props' does not exist on type 'NodeDetailPage'.
@@ -558,26 +554,21 @@ plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'sta
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'props' does not exist on type 'NodeDetailPage'.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'props' does not exist on type 'NodeDetailPage'.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'state' does not exist on type 'NodeDetailPage'.
-plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'context' does not exist on type 'NodeDetailPage'.
-plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'context' does not exist on type 'NodeDetailPage'.
-plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'context' does not exist on type 'NodeDetailPage'.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'props' does not exist on type 'NodeDetailPage'.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'contextTypes' does not exist on type *.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2345: Argument of type * is not assignable to parameter of type 'ComponentType<any>'.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'store_listeners' does not exist on type 'NodeDetailPage'.
-plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'tabs_tabs' does not exist on type 'NodeDetailPage'.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'state' does not exist on type 'NodeDetailPage'.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'props' does not exist on type 'NodeDetailPage'.
-plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'props' does not exist on type 'NodeDetailPage'.
-plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'tabs_tabs' does not exist on type 'NodeDetailPage'.
-plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'tabs_tabs' does not exist on type 'NodeDetailPage'.
-plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2554: Expected 1 arguments, but got 0.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'props' does not exist on type 'NodeDetailPage'.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'state' does not exist on type 'NodeDetailPage'.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'setState' does not exist on type 'NodeDetailPage'.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'setState' does not exist on type 'NodeDetailPage'.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2345: Argument of type '\\"statesProcessed\\"' is not assignable to parameter of type 'never'.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2345: Argument of type '\\"states\\"' is not assignable to parameter of type 'never'.
+plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'props' does not exist on type 'NodeDetailPage'.
+plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2322: Type 'string' is not assignable to type 'never'.
+plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2322: type * is not assignable to type 'never'.
 plugins/nodes/src/js/pages/nodes/NodeDetailTab.tsx: error TS2339: Property 'version' does not exist on type 'Readonly<{}>'.
 plugins/nodes/src/js/pages/nodes/NodeDetailTab.tsx: error TS2769: No overload matches this call.
 plugins/nodes/src/js/pages/nodes/NodeDetailTab.tsx: error TS2339: Property 'masterRegion' does not exist on type 'Readonly<{}>'.
@@ -2438,19 +2429,6 @@ plugins/services/src/js/pages/task-details/ServiceTaskDetailPage.tsx: error TS23
 plugins/services/src/js/pages/task-details/ServiceTaskDetailPage.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/pages/task-details/ServiceTaskDetailPage.tsx: error TS2605: JSX element type 'TaskDetail' is not a constructor function for JSX elements.
 plugins/services/src/js/pages/task-details/ServiceTaskDetailPage.tsx: error TS2607: JSX element class does not support attributes because it does not have a 'props' property.
-plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'tabs_tabs' does not exist on type 'TaskDetail'.
-plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2554: Expected 1 arguments, but got 0.
-plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'props' does not exist on type 'TaskDetail'.
-plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'setState' does not exist on type 'TaskDetail'.
-plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'props' does not exist on type 'TaskDetail'.
-plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'setState' does not exist on type 'TaskDetail'.
-plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'store_removeEventListenerForStoreID' does not exist on type 'TaskDetail'.
-plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'setState' does not exist on type 'TaskDetail'.
-plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'state' does not exist on type 'TaskDetail'.
-plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'props' does not exist on type 'TaskDetail'.
-plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2345: Argument of type '\\"directory\\"' is not assignable to parameter of type 'never'.
-plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'setState' does not exist on type 'TaskDetail'.
-plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'props' does not exist on type 'TaskDetail'.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'setState' does not exist on type 'TaskDetail'.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'context' does not exist on type 'TaskDetail'.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'props' does not exist on type 'TaskDetail'.
@@ -2464,9 +2442,8 @@ plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Propert
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'props' does not exist on type 'TaskDetail'.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'tabs_getRoutedTabs' does not exist on type 'TaskDetail'.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2769: No overload matches this call.
-plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'setState' does not exist on type 'TaskDetail'.
+plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS6133: 'path' is declared but its value is never read.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'props' does not exist on type 'TaskDetail'.
-plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2345: Argument of type '\\"innerPath\\"' is not assignable to parameter of type 'never'.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'props' does not exist on type 'TaskDetail'.
@@ -2476,14 +2453,19 @@ plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Propert
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2345: Argument of type '\\"lastMesosState\\"' is not assignable to parameter of type 'never'.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'contextTypes' does not exist on type *.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'propTypes' does not exist on type *.
-plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2769: No overload matches this call.
-plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'tabs_tabs' does not exist on type 'TaskDetail'.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'state' does not exist on type 'TaskDetail'.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'store_listeners' does not exist on type 'TaskDetail'.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'onTaskDirectoryStoreNodeStateError' does not exist on type 'TaskDetail'.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'onTaskDirectoryStoreNodeStateSuccess' does not exist on type 'TaskDetail'.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'props' does not exist on type 'TaskDetail'.
-plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'tabs_tabs' does not exist on type 'TaskDetail'.
+plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'setState' does not exist on type 'TaskDetail'.
+plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'store_removeEventListenerForStoreID' does not exist on type 'TaskDetail'.
+plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'setState' does not exist on type 'TaskDetail'.
+plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'state' does not exist on type 'TaskDetail'.
+plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'props' does not exist on type 'TaskDetail'.
+plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2345: Argument of type '\\"directory\\"' is not assignable to parameter of type 'never'.
+plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'setState' does not exist on type 'TaskDetail'.
+plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'props' does not exist on type 'TaskDetail'.
 plugins/services/src/js/pages/task-details/TaskDetailsTab.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/services/src/js/pages/task-details/TaskDetailsTab.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/pages/task-details/TaskDetailsTab.tsx: error TS2339: Property 'task' does not exist on type *.

--- a/src/js/routes/factories/network.ts
+++ b/src/js/routes/factories/network.ts
@@ -55,7 +55,6 @@ export default {
           {
             component: TaskDetailsTab,
             hideHeaderNavigation: true,
-            isTab: true,
             path: "details",
             title: "Details",
             type: Route
@@ -63,7 +62,6 @@ export default {
           {
             hideHeaderNavigation: true,
             component: TaskFilesTab,
-            isTab: true,
             path: "files",
             title: "Files",
             type: Route,
@@ -86,7 +84,6 @@ export default {
           {
             component: TaskLogsContainer,
             hideHeaderNavigation: true,
-            isTab: true,
             path: "logs",
             title: "Logs",
             type: Route,

--- a/src/js/routes/jobs.ts
+++ b/src/js/routes/jobs.ts
@@ -57,7 +57,6 @@ export default [
             children: [
               {
                 component: TaskDetailsTab,
-                isTab: true,
                 path: "details",
                 title: "Details",
                 type: Route
@@ -65,7 +64,6 @@ export default [
               {
                 hideHeaderNavigation: true,
                 component: TaskFilesTab,
-                isTab: true,
                 path: "files",
                 title: "Files",
                 type: Route,
@@ -88,7 +86,6 @@ export default [
               {
                 component: TaskLogsContainer,
                 hideHeaderNavigation: true,
-                isTab: true,
                 path: "logs",
                 title: "Logs",
                 type: Route,


### PR DESCRIPTION
at some point in time Page.Header was introduced, which can handle tabs really
well as long as those are navigable via routes.

the instances here ARE navigable via routes and thus don't need to be complected
with the TabsMixin anymore.

in order to have tabs be active at the right point in time the tabs on the
NodesDetailPage have been transformed to use `routePath` instead of custom
handlers.

the rest of the changes is stuff that does not seem to be referenced anywhere
anymore.
