### PR TITLE
remove listenAlways

### DIFF
--- a/plugins/intercom/stores/IntercomStore.ts
+++ b/plugins/intercom/stores/IntercomStore.ts
@@ -33,8 +33,7 @@ class IntercomStore extends GetSetBaseStore<{
       events: {
         intercomChange: INTERCOM_CHANGE
       },
-      unmountWhen: () => true,
-      listenAlways: true
+      unmountWhen: () => false
     });
   }
 

--- a/plugins/nodes/src/js/pages/nodes/NodesTaskDetailPage.tsx
+++ b/plugins/nodes/src/js/pages/nodes/NodesTaskDetailPage.tsx
@@ -18,8 +18,9 @@ class NodesTaskDetailPage extends mixin(StoreMixin) {
   constructor(...args) {
     super(...args);
 
+    // prettier-ignore
     this.store_listeners = [
-      { name: "summary", events: ["success"], listenAlways: false }
+      { name: "summary", events: ["success"], unmountWhen: (store, event) => event === "success" && store.get("statesProcessed") }
     ];
   }
 

--- a/plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.tsx
+++ b/plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.tsx
@@ -31,7 +31,7 @@ class NodesGridContainer extends mixin(StoreMixin) {
     };
     // prettier-ignore
     this.store_listeners = [
-      {events: ["success"], listenAlways: false, name: "nodeHealth", suppressUpdate: true},
+      {events: ["success"], name: "nodeHealth", suppressUpdate: true},
       {events: ["success", "error"], name: "state", suppressUpdate: true}
     ];
   }

--- a/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx
+++ b/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx
@@ -30,9 +30,8 @@ class NodesTableContainer extends mixin(StoreMixin) {
       reactivateNetworkError: false
     };
 
-    // prettier-ignore
     this.store_listeners = [
-      {events: ["success"], listenAlways: false, name: "nodeHealth", suppressUpdate: true},
+      { events: ["success"], name: "nodeHealth", suppressUpdate: true },
       { name: "state", events: ["success"], suppressUpdate: true }
     ];
 

--- a/plugins/nodes/src/js/stores/NodeHealthStore.ts
+++ b/plugins/nodes/src/js/stores/NodeHealthStore.ts
@@ -74,8 +74,7 @@ class NodeHealthStore extends GetSetBaseStore {
         unitSuccess: HEALTH_NODE_UNIT_SUCCESS,
         unitError: HEALTH_NODE_UNIT_ERROR
       },
-      unmountWhen: () => true,
-      listenAlways: true
+      unmountWhen: () => true
     });
 
     AppDispatcher.register(payload => {

--- a/plugins/nodes/src/js/stores/NodeHealthStore.ts
+++ b/plugins/nodes/src/js/stores/NodeHealthStore.ts
@@ -74,9 +74,7 @@ class NodeHealthStore extends GetSetBaseStore {
         unitSuccess: HEALTH_NODE_UNIT_SUCCESS,
         unitError: HEALTH_NODE_UNIT_ERROR
       },
-      unmountWhen() {
-        return true;
-      },
+      unmountWhen: () => true,
       listenAlways: true
     });
 

--- a/plugins/services/src/js/components/DeploymentStatusIndicator.tsx
+++ b/plugins/services/src/js/components/DeploymentStatusIndicator.tsx
@@ -20,9 +20,7 @@ export default class DeploymentStatusIndicator extends mixin(StoreMixin) {
   constructor(...args) {
     super(...args);
 
-    this.store_listeners = [
-      { name: "dcos", events: ["change"], listenAlways: true }
-    ];
+    this.store_listeners = [{ name: "dcos", events: ["change"] }];
 
     this.state = {
       isOpen: false

--- a/plugins/services/src/js/pages/task-details/TaskDetail.tsx
+++ b/plugins/services/src/js/pages/task-details/TaskDetail.tsx
@@ -28,9 +28,9 @@ class TaskDetail extends mixin(StoreMixin) {
 
     // prettier-ignore
     this.store_listeners = [
-      { name: "marathon", events: ["appsSuccess"], listenAlways: false },
-      { name: "state", events: ["success"], listenAlways: false },
-      { name: "summary", events: ["success"], listenAlways: false },
+      { name: "marathon", events: ["appsSuccess"], unmountWhen: (store, event) => event !== "appsSuccess" || store.hasProcessedApps() },
+      { name: "state", events: ["success"], unmountWhen: (store, event) => (event === "success") && Object.keys(store.get("lastMesosState")).length },
+      { name: "summary", events: ["success"], unmountWhen: (store, event) => event === "success" && store.get("statesProcessed") },
       { name: "taskDirectory", events: ["error", "success", "nodeStateError", "nodeStateSuccess"], suppressUpdate: true }
     ];
 

--- a/plugins/services/src/js/pages/task-details/TaskLogsContainer.tsx
+++ b/plugins/services/src/js/pages/task-details/TaskLogsContainer.tsx
@@ -22,7 +22,7 @@ class TaskLogsContainer extends mixin(StoreMixin) {
     };
 
     this.store_listeners = [
-      { name: "config", events: ["success", "error"], listenAlways: false }
+      { name: "config", events: ["success", "error"], unmountWhen: () => true }
     ];
   }
 

--- a/plugins/services/src/js/stores/MarathonStore.ts
+++ b/plugins/services/src/js/stores/MarathonStore.ts
@@ -183,14 +183,7 @@ class MarathonStore extends GetSetBaseStore<{
         taskKillSuccess: MARATHON_TASK_KILL_SUCCESS,
         taskKillError: MARATHON_TASK_KILL_ERROR
       },
-      unmountWhen(store, event) {
-        if (event === "appsSuccess") {
-          return store.hasProcessedApps();
-        }
-
-        return true;
-      },
-      listenAlways: true
+      unmountWhen: () => false
     });
 
     AppDispatcher.register(payload => {

--- a/plugins/services/src/js/stores/MesosLogStore.ts
+++ b/plugins/services/src/js/stores/MesosLogStore.ts
@@ -41,8 +41,7 @@ class MesosLogStore extends BaseStore {
         offsetSuccess: MESOS_INITIALIZE_LOG_CHANGE,
         offsetError: MESOS_INITIALIZE_LOG_REQUEST_ERROR
       },
-      unmountWhen: () => true,
-      listenAlways: true,
+      unmountWhen: () => false,
       suppressUpdate: true
     });
 

--- a/plugins/services/src/js/stores/MesosLogStore.ts
+++ b/plugins/services/src/js/stores/MesosLogStore.ts
@@ -41,9 +41,7 @@ class MesosLogStore extends BaseStore {
         offsetSuccess: MESOS_INITIALIZE_LOG_CHANGE,
         offsetError: MESOS_INITIALIZE_LOG_REQUEST_ERROR
       },
-      unmountWhen() {
-        return true;
-      },
+      unmountWhen: () => true,
       listenAlways: true,
       suppressUpdate: true
     });

--- a/plugins/services/src/js/stores/SDKEndpointStore.ts
+++ b/plugins/services/src/js/stores/SDKEndpointStore.ts
@@ -26,7 +26,7 @@ class SDKEndpointStore extends GetSetBaseStore {
     PluginSDK.addStoreConfig({
       store: this,
       storeID: this.storeID,
-      listenAlways: true
+      unmountWhen: () => false
     });
 
     AppDispatcher.register(payload => {

--- a/plugins/services/src/js/stores/TaskDirectoryStore.ts
+++ b/plugins/services/src/js/stores/TaskDirectoryStore.ts
@@ -58,8 +58,7 @@ class TaskDirectoryStore extends GetSetBaseStore {
         nodeStateError: REQUEST_NODE_STATE_ERROR,
         nodeStateSuccess: REQUEST_NODE_STATE_SUCCESS
       },
-      unmountWhen: () => true,
-      listenAlways: true
+      unmountWhen: () => false
     });
 
     AppDispatcher.register(payload => {

--- a/plugins/services/src/js/stores/TaskDirectoryStore.ts
+++ b/plugins/services/src/js/stores/TaskDirectoryStore.ts
@@ -58,9 +58,7 @@ class TaskDirectoryStore extends GetSetBaseStore {
         nodeStateError: REQUEST_NODE_STATE_ERROR,
         nodeStateSuccess: REQUEST_NODE_STATE_SUCCESS
       },
-      unmountWhen() {
-        return true;
-      },
+      unmountWhen: () => true,
       listenAlways: true
     });
 

--- a/src/js/__tests__/__snapshots__/typecheck-test.ts.snap
+++ b/src/js/__tests__/__snapshots__/typecheck-test.ts.snap
@@ -4940,8 +4940,8 @@ src/js/stores/DCOSStore.ts: error TS2345: Argument of type 'null' is not assigna
 src/js/stores/DCOSStore.ts: error TS2339: Property 'data' does not exist on type 'DCOSStore'.
 src/js/stores/DCOSStore.ts: error TS2339: Property 'data' does not exist on type 'DCOSStore'.
 src/js/stores/DCOSStore.ts: error TS2345: Argument of type '\\"states\\"' is not assignable to parameter of type 'never'.
-src/js/stores/DCOSStore.ts: error TS2556: Expected 0 arguments, but got 1 or more.
 src/js/stores/DCOSStore.ts: error TS2358: The left-hand side of an 'instanceof' expression must be of type 'any', an object type or a type parameter.
+src/js/stores/DCOSStore.ts: error TS2556: Expected 0 arguments, but got 1 or more.
 src/js/stores/DCOSStore.ts: error TS2339: Property 'data' does not exist on type 'DCOSStore'.
 src/js/stores/DCOSStore.ts: error TS2339: Property 'store' does not exist on type 'never'.
 src/js/stores/DCOSStore.ts: error TS2339: Property 'event' does not exist on type 'never'.

--- a/src/js/__tests__/__snapshots__/typecheck-test.ts.snap
+++ b/src/js/__tests__/__snapshots__/typecheck-test.ts.snap
@@ -4970,12 +4970,11 @@ src/js/stores/GetSetBaseStore.ts: error TS2322: Type '{}' is not assignable to t
 src/js/stores/GetSetBaseStore.ts: error TS2564: Property 'getSet_data' has no initializer and is not definitely assigned in the constructor.
 src/js/stores/LanguageModalStore.ts: error TS2556: Expected 0 arguments, but got 1 or more.
 src/js/stores/MesosStateStore.ts: error TS2571: Object is of type 'unknown'.
-src/js/stores/MesosStateStore.ts: error TS2571: Object is of type 'unknown'.
 src/js/stores/MesosStateStore.ts: error TS2345: Argument of type '\\"lastMesosState\\"' is not assignable to parameter of type 'never'.
 src/js/stores/MesosStateStore.ts: error TS2345: Argument of type '\\"master\\"' is not assignable to parameter of type 'never'.
-src/js/stores/MesosStateStore.ts: error TS7030: Not all code paths return a value.
 src/js/stores/MesosStateStore.ts: error TS2571: Object is of type 'unknown'.
 src/js/stores/MesosStateStore.ts: error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'string'.
+src/js/stores/MesosStateStore.ts: error TS2571: Object is of type 'unknown'.
 src/js/stores/MesosStream/parsers/__tests__/master-test.ts: error TS2339: Property 'start_time' does not exist on type *.
 src/js/stores/MesosStream/parsers/tasks.ts: error TS2339: Property 'id' does not exist on type '{}'.
 src/js/stores/MesosSummaryStore.ts: error TS2345: Argument of type '\\"states\\"' is not assignable to parameter of type 'never'.

--- a/src/js/components/ClusterHeader.tsx
+++ b/src/js/components/ClusterHeader.tsx
@@ -22,9 +22,10 @@ export default class ClusterHeader extends mixin(StoreMixin) {
   constructor(...args) {
     super(...args);
 
+    // prettier-ignore
     this.store_listeners = [
-      { name: "metadata", events: ["success"], listenAlways: false },
-      { name: "summary", events: ["success"], listenAlways: false }
+      { name: "metadata", events: ["success"], unmountWhen: () => true },
+      { name: "summary", events: ["success"], unmountWhen: (store, event) => event === "success" && store.get("statesProcessed") }
     ];
   }
 

--- a/src/js/components/UserAccountDropdownTrigger.tsx
+++ b/src/js/components/UserAccountDropdownTrigger.tsx
@@ -8,7 +8,7 @@ export default class UserAccountDropdownTrigger extends mixin(StoreMixin) {
     super(...args);
 
     this.store_listeners = [
-      { name: "metadata", events: ["success"], listenAlways: false }
+      { name: "metadata", events: ["success"], unmountWhen: () => true }
     ];
   }
 

--- a/src/js/mixins/StoreMixin.ts
+++ b/src/js/mixins/StoreMixin.ts
@@ -11,7 +11,6 @@ let ListenersDescription: Record<string, StoreConfig> = {
   //   unmountWhen: function () {
   //     return true;
   //   },
-  //   listenAlways: true,
   //   suppressUpdate: false
   // }
 };
@@ -141,28 +140,19 @@ export default {
     const args = Array.prototype.slice.call(arguments, 2);
     // See if we need to remove our change listener
     const listenerDetail = this.store_listeners[storeID];
-    // Maybe remove listener
-    if (listenerDetail.unmountWhen && !listenerDetail.listenAlways) {
-      // Remove change listener if the settings want to unmount after a certain
-      // condition is truthy
-      if (listenerDetail.unmountWhen(listenerDetail.store, event)) {
-        this.store_removeEventListenerForStoreID(storeID, event);
-      }
+    // Remove change listener if the settings want to unmount after a certain
+    // condition is truthy
+    if (listenerDetail.unmountWhen?.(listenerDetail.store, event)) {
+      this.store_removeEventListenerForStoreID(storeID, event);
     }
 
     // Call callback on component that implements mixin if it exists
     const onChangeFn = this.store_getChangeFunctionName(storeID, event);
-
-    if (this[onChangeFn]) {
-      this[onChangeFn].apply(this, args);
-    }
+    this[onChangeFn]?.apply(this, args);
 
     // forceUpdate if not suppressed by configuration
-    if (
-      listenerDetail.suppressUpdate !== true &&
-      typeof this.forceUpdate === "function"
-    ) {
-      this.forceUpdate();
+    if (listenerDetail.suppressUpdate !== true) {
+      this.forceUpdate?.();
     }
   },
 

--- a/src/js/stores/AuthStore.ts
+++ b/src/js/stores/AuthStore.ts
@@ -31,9 +31,7 @@ class AuthStore extends GetSetBaseStore {
         logoutSuccess: AUTH_USER_LOGOUT_SUCCESS,
         logoutError: AUTH_USER_LOGOUT_ERROR
       },
-      unmountWhen() {
-        return true;
-      },
+      unmountWhen: () => true,
       listenAlways: true
     });
 

--- a/src/js/stores/AuthStore.ts
+++ b/src/js/stores/AuthStore.ts
@@ -31,8 +31,7 @@ class AuthStore extends GetSetBaseStore {
         logoutSuccess: AUTH_USER_LOGOUT_SUCCESS,
         logoutError: AUTH_USER_LOGOUT_ERROR
       },
-      unmountWhen: () => true,
-      listenAlways: true
+      unmountWhen: () => false
     });
 
     AppDispatcher.register(payload => {

--- a/src/js/stores/ConfigStore.ts
+++ b/src/js/stores/ConfigStore.ts
@@ -40,8 +40,7 @@ class ConfigStore extends GetSetBaseStore<{ ccid: unknown; config: unknown }> {
         ccidSuccess: CLUSTER_CCID_SUCCESS,
         ccidError: CLUSTER_CCID_ERROR
       },
-      unmountWhen: () => true,
-      listenAlways: true
+      unmountWhen: () => false
     });
 
     AppDispatcher.register(payload => {

--- a/src/js/stores/CosmosPackagesStore.ts
+++ b/src/js/stores/CosmosPackagesStore.ts
@@ -104,10 +104,7 @@ class CosmosPackagesStore extends GetSetBaseStore {
         serviceUpdateSuccess: COSMOS_SERVICE_UPDATE_SUCCESS,
         serviceUpdateError: COSMOS_SERVICE_UPDATE_ERROR
       },
-      unmountWhen(store, event) {
-        return event === "availableSuccess";
-      },
-      listenAlways: false
+      unmountWhen: (store, event) => event === "availableSuccess"
     });
 
     AppDispatcher.register(payload => {

--- a/src/js/stores/DCOSStore.ts
+++ b/src/js/stores/DCOSStore.ts
@@ -31,8 +31,7 @@ class DCOSStore extends EventEmitter {
       store: this,
       storeID: this.storeID,
       events,
-      unmountWhen: () => true,
-      listenAlways: true
+      unmountWhen: () => false
     });
 
     this.data = {

--- a/src/js/stores/LanguageModalStore.ts
+++ b/src/js/stores/LanguageModalStore.ts
@@ -20,8 +20,7 @@ class LanguageModalStore extends GetSetBaseStore {
     PluginSDK.addStoreConfig({
       store: this,
       storeID: this.storeID,
-      unmountWhen: () => true,
-      listenAlways: true
+      unmountWhen: () => false
     });
 
     AppDispatcher.register(payload => {

--- a/src/js/stores/MesosStateStore.ts
+++ b/src/js/stores/MesosStateStore.ts
@@ -58,12 +58,7 @@ class MesosStateStore extends GetSetBaseStore {
         success: MESOS_STATE_CHANGE,
         error: MESOS_STATE_REQUEST_ERROR
       },
-      unmountWhen(store, event) {
-        if (event === "success") {
-          return Object.keys(store.get("lastMesosState")).length;
-        }
-      },
-      listenAlways: true
+      unmountWhen: () => false
     });
   }
 

--- a/src/js/stores/MesosSummaryStore.ts
+++ b/src/js/stores/MesosSummaryStore.ts
@@ -53,16 +53,7 @@ class MesosSummaryStore extends GetSetBaseStore {
         success: MESOS_SUMMARY_CHANGE,
         error: MESOS_SUMMARY_REQUEST_ERROR
       },
-
-      // When to remove listener
-      unmountWhen(store, event) {
-        if (event === "success") {
-          return store.get("statesProcessed");
-        }
-      },
-
-      // Set to true to keep listening until unmount
-      listenAlways: true
+      unmountWhen: () => false
     });
 
     AppDispatcher.register(payload => {

--- a/src/js/stores/MetadataStore.ts
+++ b/src/js/stores/MetadataStore.ts
@@ -34,8 +34,7 @@ class MetadataStore extends GetSetBaseStore {
         dcosBuildInfoChange: DCOS_BUILD_INFO_CHANGE,
         dcosBuildInfoError: DCOS_BUILD_INFO_ERROR
       },
-      unmountWhen: () => true,
-      listenAlways: true
+      unmountWhen: () => false
     });
 
     AppDispatcher.register(payload => {

--- a/src/js/stores/NotificationStore.ts
+++ b/src/js/stores/NotificationStore.ts
@@ -17,8 +17,7 @@ class NotificationStore extends GetSetBaseStore {
       events: {
         change: NOTIFICATION_CHANGE
       },
-      unmountWhen: () => true,
-      listenAlways: true
+      unmountWhen: () => false
     });
   }
 

--- a/src/js/stores/SidebarStore.ts
+++ b/src/js/stores/SidebarStore.ts
@@ -39,8 +39,7 @@ class SidebarStore extends GetSetBaseStore<{
       events: {
         widthChange: SIDEBAR_WIDTH_CHANGE
       },
-      unmountWhen: () => true,
-      listenAlways: true
+      unmountWhen: () => false
     });
 
     AppDispatcher.register(payload => {

--- a/src/js/stores/SystemLogStore.ts
+++ b/src/js/stores/SystemLogStore.ts
@@ -41,8 +41,7 @@ class SystemLogStore extends BaseStore {
         streamSuccess: SYSTEM_LOG_STREAM_TYPES_SUCCESS,
         streamError: SYSTEM_LOG_STREAM_TYPES_ERROR
       },
-      unmountWhen: () => true,
-      listenAlways: true,
+      unmountWhen: () => false,
       suppressUpdate: true
     });
 

--- a/src/js/stores/UnitHealthStore.ts
+++ b/src/js/stores/UnitHealthStore.ts
@@ -73,9 +73,7 @@ class UnitHealthStore extends GetSetBaseStore {
         nodeSuccess: HEALTH_UNIT_NODE_SUCCESS,
         nodeError: HEALTH_UNIT_NODE_ERROR
       },
-      unmountWhen() {
-        return true;
-      },
+      unmountWhen: () => true,
       listenAlways: true
     });
 

--- a/src/js/stores/UnitHealthStore.ts
+++ b/src/js/stores/UnitHealthStore.ts
@@ -73,8 +73,7 @@ class UnitHealthStore extends GetSetBaseStore {
         nodeSuccess: HEALTH_UNIT_NODE_SUCCESS,
         nodeError: HEALTH_UNIT_NODE_ERROR
       },
-      unmountWhen: () => true,
-      listenAlways: true
+      unmountWhen: () => false
     });
 
     AppDispatcher.register(payload => {

--- a/src/js/stores/UserStore.ts
+++ b/src/js/stores/UserStore.ts
@@ -40,8 +40,7 @@ class UserStore extends EventEmitter {
         deleteSuccess: USER_DELETE_SUCCESS,
         deleteError: USER_DELETE_ERROR
       },
-      unmountWhen: () => true,
-      listenAlways: true
+      unmountWhen: () => false
     });
 
     AppDispatcher.register(payload => {

--- a/src/js/stores/UsersStore.ts
+++ b/src/js/stores/UsersStore.ts
@@ -24,9 +24,7 @@ class UsersStore extends GetSetBaseStore {
         success: USERS_CHANGE,
         error: USERS_REQUEST_ERROR
       },
-      unmountWhen() {
-        return true;
-      },
+      unmountWhen: () => true,
       listenAlways: true
     });
 

--- a/src/js/stores/UsersStore.ts
+++ b/src/js/stores/UsersStore.ts
@@ -24,8 +24,7 @@ class UsersStore extends GetSetBaseStore {
         success: USERS_CHANGE,
         error: USERS_REQUEST_ERROR
       },
-      unmountWhen: () => true,
-      listenAlways: true
+      unmountWhen: () => false
     });
 
     AppDispatcher.register(payload => {

--- a/src/js/stores/VirtualNetworksStore.ts
+++ b/src/js/stores/VirtualNetworksStore.ts
@@ -32,8 +32,7 @@ class VirtualNetworksStore extends BaseStore {
         success: VIRTUAL_NETWORKS_CHANGE,
         error: VIRTUAL_NETWORKS_REQUEST_ERROR
       },
-      unmountWhen: () => true,
-      listenAlways: true
+      unmountWhen: () => false
     });
 
     // Handle app actions


### PR DESCRIPTION
we can express `listenAlways` via `unmountWhen`. let's do so!

this will help in mechanically refactoring stores/actions (and eventually picking the correct rxjs-stream-helpers for each use case).