### PR TITLE
fix(build): disallow es modules for images

### DIFF
--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -122,7 +122,8 @@ module.exports = {
           {
             loader: "file-loader",
             options: {
-              name: "./[hash]-[name].[ext]"
+              name: "./[hash]-[name].[ext]",
+              esModule: false
             }
           },
           {


### PR DESCRIPTION
This disables es Modules for images which fixes the issue where all images in the `index.html` woudl
have a source which is `[Object Module]`.


## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->