### PR TITLE
chore: update JIRA API URL

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -38,7 +38,7 @@
     "@semantic-release/github",
     {
       "path": "semantic-release-jira",
-      "apiURL": "https://jira.mesosphere.com/rest/api/2/issue/${issueKey}",
+      "apiURL": "https://jira.d2iq.com/rest/api/2/issue/${issueKey}",
       "apiJSON":
         "{ \"update\": { \"labels\": [ { \"add\": \"released-repo:dcos-ui\" }, { \"add\": \"released-tag:master+v${version}\" } ] } }"
     }


### PR DESCRIPTION
JIRA Was moved to new URL, old links seem to be valid, but some housekeeping cant be bad :)