### PR TITLE
fix: speed up ServiceTable integration test

### DIFF
--- a/plugins/services/src/js/columns/ServicesTableNameColumn.tsx
+++ b/plugins/services/src/js/columns/ServicesTableNameColumn.tsx
@@ -119,15 +119,7 @@ function getServiceLink(
     : `/services/detail/${id}`;
 
   if (isFiltered) {
-    return (
-      <NestedServiceLinks
-        serviceLink={serviceLink}
-        serviceID={id}
-        className="service-breadcrumb"
-        majorLinkClassName="service-breadcrumb-service-id"
-        minorLinkWrapperClassName="service-breadcrumb-crumb"
-      />
-    );
+    return <NestedServiceLinks serviceLink={serviceLink} serviceID={id} />;
   }
 
   return (

--- a/plugins/services/src/js/components/LogView.tsx
+++ b/plugins/services/src/js/components/LogView.tsx
@@ -296,7 +296,7 @@ class LogView extends React.Component {
     // Show loader since we will start a request for more logs
     return (
       <div className="pod flush-top">
-        <Loader innerClassName="loader--small" type="ballSpinFadeLoader" />
+        <Loader size="small" type="ballSpinFadeLoader" />
       </div>
     );
   }

--- a/plugins/services/src/js/components/dsl/ServiceHealthDSLSection.tsx
+++ b/plugins/services/src/js/components/dsl/ServiceHealthDSLSection.tsx
@@ -37,7 +37,7 @@ const ServiceHealthDSLSection = props => {
           <FormGroup>
             <FieldLabel>
               <FieldInput
-                checked={data.is_healthy}
+                defaultChecked={data.is_healthy}
                 disabled={!enabled}
                 name="is_healthy"
                 type="checkbox"
@@ -46,7 +46,7 @@ const ServiceHealthDSLSection = props => {
             </FieldLabel>
             <FieldLabel>
               <FieldInput
-                checked={data.no_healthchecks}
+                defaultChecked={data.no_healthchecks}
                 disabled={!enabled}
                 name="no_healthchecks"
                 type="checkbox"
@@ -59,7 +59,7 @@ const ServiceHealthDSLSection = props => {
           <FormGroup>
             <FieldLabel>
               <FieldInput
-                checked={data.is_unhealthy}
+                defaultChecked={data.is_unhealthy}
                 disabled={!enabled}
                 name="is_unhealthy"
                 type="checkbox"

--- a/plugins/services/src/js/components/dsl/ServiceOtherDSLSection.tsx
+++ b/plugins/services/src/js/components/dsl/ServiceOtherDSLSection.tsx
@@ -37,7 +37,7 @@ const ServiceOtherDSLSection = props => {
           <FormGroup>
             <FieldLabel>
               <FieldInput
-                checked={data.is_catalog}
+                defaultChecked={data.is_catalog}
                 disabled={!enabled}
                 name="is_catalog"
                 type="checkbox"
@@ -46,7 +46,7 @@ const ServiceOtherDSLSection = props => {
             </FieldLabel>
             <FieldLabel>
               <FieldInput
-                checked={data.is_pod}
+                defaultChecked={data.is_pod}
                 disabled={!enabled}
                 name="is_pod"
                 type="checkbox"
@@ -59,7 +59,7 @@ const ServiceOtherDSLSection = props => {
           <FormGroup>
             <FieldLabel>
               <FieldInput
-                checked={data.has_volumes}
+                defaultChecked={data.has_volumes}
                 disabled={!enabled}
                 name="has_volumes"
                 type="checkbox"

--- a/plugins/services/src/js/components/dsl/ServiceStatusDSLSection.tsx
+++ b/plugins/services/src/js/components/dsl/ServiceStatusDSLSection.tsx
@@ -39,7 +39,7 @@ const ServiceStatusDSLSection = props => {
           <FormGroup>
             <FieldLabel>
               <FieldInput
-                checked={data.is_running}
+                defaultChecked={data.is_running}
                 disabled={!enabled}
                 name="is_running"
                 type="checkbox"
@@ -48,7 +48,7 @@ const ServiceStatusDSLSection = props => {
             </FieldLabel>
             <FieldLabel>
               <FieldInput
-                checked={data.is_deploying}
+                defaultChecked={data.is_deploying}
                 disabled={!enabled}
                 name="is_deploying"
                 type="checkbox"
@@ -57,7 +57,7 @@ const ServiceStatusDSLSection = props => {
             </FieldLabel>
             <FieldLabel>
               <FieldInput
-                checked={data.is_recovering}
+                defaultChecked={data.is_recovering}
                 disabled={!enabled}
                 name="is_recovering"
                 type="checkbox"
@@ -70,7 +70,7 @@ const ServiceStatusDSLSection = props => {
           <FormGroup>
             <FieldLabel>
               <FieldInput
-                checked={data.is_stopped}
+                defaultChecked={data.is_stopped}
                 disabled={!enabled}
                 name="is_stopped"
                 type="checkbox"
@@ -79,7 +79,7 @@ const ServiceStatusDSLSection = props => {
             </FieldLabel>
             <FieldLabel>
               <FieldInput
-                checked={data.is_deleting}
+                defaultChecked={data.is_deleting}
                 disabled={!enabled}
                 name="is_deleting"
                 type="checkbox"

--- a/plugins/services/src/js/components/modals/ServiceModals.tsx
+++ b/plugins/services/src/js/components/modals/ServiceModals.tsx
@@ -14,7 +14,17 @@ import ServiceSpecUtil from "../../utils/ServiceSpecUtil";
 import ServiceStopModal from "./ServiceStopModal";
 import DisabledGroupDestroyModal from "./DisabledGroupDestroyModal";
 
-class ServiceModals extends React.Component {
+const actionPropTypes = PropTypes.shape({
+  revertDeployment: PropTypes.func,
+  createGroup: PropTypes.func,
+  deleteGroup: PropTypes.func,
+  editGroup: PropTypes.func,
+  deleteService: PropTypes.func,
+  restartService: PropTypes.func,
+  resetDelayedService: PropTypes.func
+}).isRequired;
+
+export default class ServiceModals extends React.Component {
   static propTypes = {
     actionErrors: PropTypes.object.isRequired,
     actions: actionPropTypes,
@@ -260,15 +270,3 @@ class ServiceModals extends React.Component {
     );
   }
 }
-
-const actionPropTypes = PropTypes.shape({
-  revertDeployment: PropTypes.func,
-  createGroup: PropTypes.func,
-  deleteGroup: PropTypes.func,
-  editGroup: PropTypes.func,
-  deleteService: PropTypes.func,
-  restartService: PropTypes.func,
-  resetDelayedService: PropTypes.func
-}).isRequired;
-
-export default ServiceModals;

--- a/plugins/services/src/js/containers/services/ServiceTreeView.tsx
+++ b/plugins/services/src/js/containers/services/ServiceTreeView.tsx
@@ -218,11 +218,7 @@ class ServiceTreeView extends React.Component {
       const pageHeader = serviceTree.isTopLevel() ? (
         <Page.Header
           breadcrumbs={<ServiceBreadcrumbs serviceID={serviceTree.id} />}
-          supplementalContent={
-            <React.Fragment>
-              <DeploymentStatusIndicator />
-            </React.Fragment>
-          }
+          supplementalContent={<DeploymentStatusIndicator />}
           actions={editGroupActions}
           tabs={tabs}
         />

--- a/plugins/services/src/js/containers/services/ServicesContainer.tsx
+++ b/plugins/services/src/js/containers/services/ServicesContainer.tsx
@@ -153,8 +153,8 @@ class ServicesContainer extends React.Component {
     params: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired
   };
-  constructor(...args) {
-    super(...args);
+  constructor(props) {
+    super(props);
 
     this.state = {
       actionErrors: {},
@@ -165,18 +165,17 @@ class ServicesContainer extends React.Component {
       pendingActions: {},
       roles: []
     };
+  }
 
+  componentDidMount() {
     // This is so we get notified when the serviceTree is ready in DCOSStore. Making this a promise would be nice.
+    DCOSStore.addChangeListener(DCOS_CHANGE, this.onStoreChange);
     DCOSStore.on(DCOS_CHANGE, () => {
       if (this.state.isLoading) {
         this.forceUpdate();
       }
     });
     this.onStoreChange();
-  }
-
-  componentDidMount() {
-    DCOSStore.addChangeListener(DCOS_CHANGE, this.onStoreChange);
 
     // Listen for server actions so we can update state immediately
     // on the completion of an API request.

--- a/plugins/services/src/js/pages/ServicesPage.tsx
+++ b/plugins/services/src/js/pages/ServicesPage.tsx
@@ -9,7 +9,7 @@ import { iconSizeS } from "@dcos/ui-kit/dist/packages/design-tokens/build/js/des
 import CosmosPackagesStore from "#SRC/js/stores/CosmosPackagesStore";
 import StoreMixin from "#SRC/js/mixins/StoreMixin";
 
-class ServicesPage extends mixin(StoreMixin) {
+export default class ServicesPage extends mixin(StoreMixin) {
   public static contextTypes = {
     router: routerShape
   };
@@ -35,5 +35,3 @@ class ServicesPage extends mixin(StoreMixin) {
     return this.props.children;
   }
 }
-
-export default ServicesPage;

--- a/src/js/__tests__/__snapshots__/typecheck-test.ts.snap
+++ b/src/js/__tests__/__snapshots__/typecheck-test.ts.snap
@@ -1432,17 +1432,18 @@ plugins/services/src/js/components/modals/ServiceGroupFormModal.tsx: error TS233
 plugins/services/src/js/components/modals/ServiceGroupFormModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceGroupFormModal.tsx: error TS2339: Property 'open' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceGroupFormModal.tsx: error TS2339: Property 'parentGroupId' does not exist on type *.
-plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2339: Property 'actionErrors' does not exist on type *.
-plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2339: Property 'onClose' does not exist on type *.
-plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2339: Property 'modalProps' does not exist on type *.
-plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2339: Property 'pendingActions' does not exist on type *.
-plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2339: Property 'actions' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2339: Property 'actionErrors' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2339: Property 'onClose' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2339: Property 'modalProps' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2339: Property 'pendingActions' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2339: Property 'actions' does not exist on type *.
+plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2339: Property 'actionErrors' does not exist on type *.
+plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2339: Property 'onClose' does not exist on type *.
+plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2339: Property 'modalProps' does not exist on type *.
+plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2339: Property 'pendingActions' does not exist on type *.
+plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2339: Property 'actionErrors' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2339: Property 'onClose' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2339: Property 'modalProps' does not exist on type *.
@@ -1453,7 +1454,6 @@ plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2339: Prope
 plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2339: Property 'onClose' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2339: Property 'modalProps' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2339: Property 'pendingActions' does not exist on type *.
-plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2448: Block-scoped variable 'actionPropTypes' used before its declaration.
 plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2339: Property 'actions' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2339: Property 'actions' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2322: type * is not assignable to type *.
@@ -1476,7 +1476,6 @@ plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2339: Prope
 plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2339: Property 'actions' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2339: Property 'actions' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2322: type * is not assignable to type *.
-plugins/services/src/js/components/modals/ServiceModals.tsx: error TS2339: Property 'actions' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceRestartModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceRestartModal.tsx: error TS2339: Property 'isPending' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceRestartModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
@@ -1837,7 +1836,6 @@ plugins/services/src/js/containers/services/ServiceTreeView.tsx: error TS2339: P
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2571: Object is of type 'unknown'.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2571: Object is of type 'unknown'.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2571: Object is of type 'unknown'.
-plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'isLoading' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'dispatcher' does not exist on type 'ServicesContainer'.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'rolesSub' does not exist on type 'ServicesContainer'.
@@ -3572,10 +3570,7 @@ src/js/components/JSONEditor.tsx: error TS2339: Property 'aceEditorState' does n
 src/js/components/JSONEditor.tsx: error TS2769: No overload matches this call.
 src/js/components/JSONEditor.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 src/js/components/JSONEditor.tsx: error TS2339: Property 'value' does not exist on type *.
-src/js/components/Loader.tsx: error TS2448: Block-scoped variable 'classPropType' used before its declaration.
-src/js/components/Loader.tsx: error TS2448: Block-scoped variable 'classPropType' used before its declaration.
 src/js/components/Loader.tsx: error TS2339: Property 'className' does not exist on type *.
-src/js/components/Loader.tsx: error TS2339: Property 'innerClassName' does not exist on type *.
 src/js/components/Loader.tsx: error TS2339: Property 'flip' does not exist on type *.
 src/js/components/Loader.tsx: error TS2339: Property 'size' does not exist on type *.
 src/js/components/Loader.tsx: error TS2339: Property 'type' does not exist on type *.
@@ -3593,30 +3588,13 @@ src/js/components/Modals.tsx: error TS2322: type * is not assignable to type *.
 src/js/components/Modals.tsx: error TS2322: type * is not assignable to type *.
 src/js/components/Modals.tsx: error TS2339: Property 'modalErrorMsg' does not exist on type *.
 src/js/components/Modals.tsx: error TS2339: Property 'showErrorModal' does not exist on type *.
-src/js/components/NestedServiceLinks.tsx: error TS2339: Property 'minorLinkClassName' does not exist on type *.
-src/js/components/NestedServiceLinks.tsx: error TS2339: Property 'minorLinkAnchorClassName' does not exist on type *.
 src/js/components/NestedServiceLinks.tsx: error TS2339: Property 'serviceID' does not exist on type *.
-src/js/components/NestedServiceLinks.tsx: error TS2339: Property 'className' does not exist on type *.
-src/js/components/NestedServiceLinks.tsx: error TS2339: Property 'majorLinkClassName' does not exist on type *.
-src/js/components/NestedServiceLinks.tsx: error TS2339: Property 'minorLinkWrapperClassName' does not exist on type *.
-src/js/components/NestedServiceLinks.tsx: error TS2448: Block-scoped variable 'classPropType' used before its declaration.
-src/js/components/NestedServiceLinks.tsx: error TS2448: Block-scoped variable 'classPropType' used before its declaration.
-src/js/components/NestedServiceLinks.tsx: error TS2448: Block-scoped variable 'classPropType' used before its declaration.
-src/js/components/NestedServiceLinks.tsx: error TS2448: Block-scoped variable 'classPropType' used before its declaration.
-src/js/components/NestedServiceLinks.tsx: error TS2448: Block-scoped variable 'classPropType' used before its declaration.
-src/js/components/NestedServiceLinks.tsx: error TS2448: Block-scoped variable 'classPropType' used before its declaration.
-src/js/components/NestedServiceLinks.tsx: error TS2339: Property 'minorLinkClassName' does not exist on type *.
-src/js/components/NestedServiceLinks.tsx: error TS2339: Property 'minorLinkAnchorClassName' does not exist on type *.
 src/js/components/NestedServiceLinks.tsx: error TS2345: Argument of type 'Element' is not assignable to parameter of type 'never'.
 src/js/components/NestedServiceLinks.tsx: error TS2345: Argument of type 'Element' is not assignable to parameter of type 'never'.
-src/js/components/NestedServiceLinks.tsx: error TS2339: Property 'majorLinkAnchorClassName' does not exist on type *.
 src/js/components/NestedServiceLinks.tsx: error TS2339: Property 'serviceLink' does not exist on type *.
 src/js/components/Page.tsx: error TS2322: type * is not assignable to type *.
 src/js/components/PageHeaderActions.tsx: error TS2339: Property 'supplementalContent' does not exist on type *.
 src/js/components/PageHeaderActions.tsx: error TS2322: type * is not assignable to type *.
-src/js/components/PageHeaderActions.tsx: error TS2448: Block-scoped variable 'menuActionsProps' used before its declaration.
-src/js/components/PageHeaderActions.tsx: error TS2448: Block-scoped variable 'menuActionsProps' used before its declaration.
-src/js/components/PageHeaderActions.tsx: error TS2448: Block-scoped variable 'menuActionsProps' used before its declaration.
 src/js/components/PageHeaderActions.tsx: error TS7030: Not all code paths return a value.
 src/js/components/PageHeaderActions.tsx: error TS2339: Property 'actions' does not exist on type *.
 src/js/components/PageHeaderActions.tsx: error TS2339: Property 'actionsDisabled' does not exist on type *.
@@ -3885,6 +3863,9 @@ src/js/components/__tests__/JSONEditor-test.tsx: error TS2531: Object is possibl
 src/js/components/__tests__/JSONEditor-test.tsx: error TS2531: Object is possibly 'null'.
 src/js/components/__tests__/JSONEditor-test.tsx: error TS2531: Object is possibly 'null'.
 src/js/components/__tests__/JSONEditor-test.tsx: error TS2322: Type 'number' is not assignable to type *.
+src/js/components/__tests__/NestedServiceLinks-test.tsx: error TS2769: No overload matches this call.
+src/js/components/__tests__/NestedServiceLinks-test.tsx: error TS2769: No overload matches this call.
+src/js/components/__tests__/NestedServiceLinks-test.tsx: error TS2769: No overload matches this call.
 src/js/components/__tests__/PlacementConstraintsSchemaFields-test.tsx: error TS2322: type * is not assignable to type *.
 src/js/components/__tests__/PlacementConstraintsSchemaFields-test.tsx: error TS2322: type * is not assignable to type *.
 src/js/components/__tests__/ProgressBar-test.tsx: error TS2345: Argument of type 'number' is not assignable to parameter of type 'never'.

--- a/src/js/components/DSLInputField.tsx
+++ b/src/js/components/DSLInputField.tsx
@@ -108,11 +108,8 @@ class DSLInputField extends React.Component {
    * @param {SyntheticEvent} event - The change event
    */
   handleChange = event => {
-    this.setState(
-      {
-        expression: new DSLExpression(event.target.value)
-      },
-      () => this.props.onChange(this.state.expression)
+    this.setState({ expression: new DSLExpression(event.target.value) }, () =>
+      this.props.onChange(this.state.expression)
     );
   };
 
@@ -234,9 +231,7 @@ class DSLInputField extends React.Component {
     const { expression, focus } = this.state;
 
     let iconColor = greyDark;
-    const iconSearchClasses = classNames({
-      active: focus
-    });
+    const iconSearchClasses = classNames({ active: focus });
 
     if (!inverseStyle && (focus || expression.defined)) {
       iconColor = purple;
@@ -256,10 +251,8 @@ class DSLInputField extends React.Component {
     );
 
     const formGroupClasses = classNames(
-      {
-        "form-group": true,
-        "form-group-danger": expression.hasErrors
-      },
+      "form-group",
+      { "form-group-danger": expression.hasErrors },
       className
     );
 

--- a/src/js/components/Loader.tsx
+++ b/src/js/components/Loader.tsx
@@ -43,7 +43,7 @@ const typeMap = {
   // triangleSkewSpin: {className: 'triangle-skew-spin', divCount: 1}
 };
 
-class Loader extends React.Component {
+export default class Loader extends React.Component {
   static defaultProps = {
     className: "",
     innerClassName: "",
@@ -52,9 +52,8 @@ class Loader extends React.Component {
   };
   static propTypes = {
     suppressHorizontalCenter: PropTypes.bool,
-    className: classPropType,
+    className: PropTypes.string,
     flip: PropTypes.oneOf(["horizontal"]),
-    innerClassName: classPropType,
     size: PropTypes.oneOf(["small", "mini"]),
     type: PropTypes.oneOf([
       "ballBeat",
@@ -70,21 +69,17 @@ class Loader extends React.Component {
   }
 
   render() {
-    const { className, innerClassName, flip, size, type } = this.props;
+    const { className, flip, size, type } = this.props;
     const config = typeMap[type] || typeMap.ballScale;
     const classes = classNames("loader", className, {
       "horizontal-center": !this.props.suppressHorizontalCenter
     });
 
-    const innerClasses = classNames(
-      config.className,
-      {
-        "loader--small": size === "small",
-        "loader--mini": size === "mini",
-        [`loader--flip-${flip}`]: flip != null
-      },
-      innerClassName
-    );
+    const innerClasses = classNames(config.className, {
+      "loader--small": size === "small",
+      "loader--mini": size === "mini",
+      [`loader--flip-${flip}`]: flip != null
+    });
 
     return (
       <div className={classes}>
@@ -93,11 +88,3 @@ class Loader extends React.Component {
     );
   }
 }
-
-const classPropType = PropTypes.oneOfType([
-  PropTypes.array,
-  PropTypes.object,
-  PropTypes.string
-]);
-
-export default Loader;

--- a/src/js/components/NestedServiceLinks.tsx
+++ b/src/js/components/NestedServiceLinks.tsx
@@ -7,19 +7,13 @@ import { Icon } from "@dcos/ui-kit";
 import { SystemIcons } from "@dcos/ui-kit/dist/packages/icons/dist/system-icons-enum";
 import { iconSizeXxs } from "@dcos/ui-kit/dist/packages/design-tokens/build/js/designTokens";
 
-class NestedServiceLinks extends React.Component {
+export default class NestedServiceLinks extends React.Component {
   static defaultProps = {};
   static propTypes = {
     serviceLink: PropTypes.string.isRequired,
-    serviceID: PropTypes.string.isRequired,
-    // Classes
-    className: classPropType,
-    majorLinkAnchorClassName: classPropType,
-    majorLinkClassName: classPropType,
-    minorLinkAnchorClassName: classPropType,
-    minorLinkClassName: classPropType,
-    minorLinkWrapperClassName: classPropType
+    serviceID: PropTypes.string.isRequired
   };
+
   getMinorLink(label, id, key, minorLinkClasses, minorLinkAnchorClasses) {
     return (
       <div key={key} className="table-cell-value">
@@ -46,15 +40,8 @@ class NestedServiceLinks extends React.Component {
 
   getMinorLinks() {
     let componentKey = 0;
-    const { minorLinkClassName, minorLinkAnchorClassName } = this.props;
-    const minorLinkClasses = classNames(
-      "text-overflow service-link",
-      minorLinkClassName
-    );
-    const minorLinkAnchorClasses = classNames(
-      "table-cell-link-secondary",
-      minorLinkAnchorClassName
-    );
+    const minorLinkClasses = classNames("text-overflow service-link");
+    const minorLinkAnchorClasses = classNames("table-cell-link-secondary");
     let nestedGroups = this.getServicePathParts();
 
     nestedGroups = nestedGroups.slice(0, nestedGroups.length - 1);
@@ -83,13 +70,10 @@ class NestedServiceLinks extends React.Component {
   }
 
   getMajorLink() {
-    const { majorLinkAnchorClassName, serviceLink } = this.props;
+    const { serviceLink } = this.props;
     const label = this.getServicePathParts().pop();
 
-    const anchorClasses = classNames(
-      "table-cell-link-primary",
-      majorLinkAnchorClassName
-    );
+    const anchorClasses = classNames("table-cell-link-primary");
 
     return (
       <Link className={anchorClasses} to={serviceLink} title={label}>
@@ -99,15 +83,9 @@ class NestedServiceLinks extends React.Component {
   }
 
   getServicesLink(key) {
-    const minorLinkClasses = classNames(
-      "text-overflow service-link",
-      this.props.minorLinkClassName
-    );
+    const minorLinkClasses = classNames("text-overflow service-link");
 
-    const minorLinkAnchorClasses = classNames(
-      "table-cell-link-secondary",
-      this.props.minorLinkAnchorClassName
-    );
+    const minorLinkAnchorClasses = classNames("table-cell-link-secondary");
 
     return (
       <div key={key} className="table-cell-value">
@@ -129,20 +107,17 @@ class NestedServiceLinks extends React.Component {
   }
 
   render() {
-    const {
-      className,
-      majorLinkClassName,
-      minorLinkWrapperClassName
-    } = this.props;
+    const classes = classNames("nested-service-links", "service-breadcrumb");
 
-    const classes = classNames("nested-service-links", className);
-
-    const majorLinkClasses = classNames("text-overflow", majorLinkClassName);
+    const majorLinkClasses = classNames(
+      "text-overflow",
+      "service-breadcrumb-service-id"
+    );
 
     const minorLinkWrapperClasses = classNames(
       "table-cell-details-secondary flex",
       "flex-align-items-center table-cell-flex-box",
-      minorLinkWrapperClassName
+      "service-breadcrumb-crumb"
     );
 
     return (
@@ -153,11 +128,3 @@ class NestedServiceLinks extends React.Component {
     );
   }
 }
-
-const classPropType = PropTypes.oneOfType([
-  PropTypes.array,
-  PropTypes.object,
-  PropTypes.string
-]);
-
-export default NestedServiceLinks;

--- a/src/js/components/PageHeaderActions.tsx
+++ b/src/js/components/PageHeaderActions.tsx
@@ -24,7 +24,19 @@ const getDropdownAction = (action, index) => {
   );
 };
 
-class PageHeaderActions extends React.Component {
+const classProps = PropTypes.oneOfType([
+  PropTypes.array,
+  PropTypes.object,
+  PropTypes.string
+]);
+
+const menuActionsProps = PropTypes.shape({
+  className: classProps,
+  onItemSelect: PropTypes.func.isRequired,
+  label: PropTypes.node.isRequired
+});
+
+export default class PageHeaderActions extends React.Component {
   static defaultProps = {
     actions: [],
     actionsDisabled: false
@@ -107,17 +119,3 @@ class PageHeaderActions extends React.Component {
     );
   }
 }
-
-const classProps = PropTypes.oneOfType([
-  PropTypes.array,
-  PropTypes.object,
-  PropTypes.string
-]);
-
-const menuActionsProps = PropTypes.shape({
-  className: classProps,
-  onItemSelect: PropTypes.func.isRequired,
-  label: PropTypes.node.isRequired
-});
-
-export default PageHeaderActions;

--- a/src/js/config/Config.ts
+++ b/src/js/config/Config.ts
@@ -32,7 +32,6 @@ interface IConfiguration {
   stateLongPoll: number;
   supportEmail: string;
   tailRefresh: number;
-  testHistoryInterval: number;
   uiConfigurationFixture?: object;
   useUIConfigFixtures?: boolean;
   unitHealthAPIPrefix: string;
@@ -59,7 +58,6 @@ let Config: IConfiguration = {
   metronomeAPI: "/service/metronome",
   productName: "Mesosphere DC/OS",
   productHomepageURI: "https://dcos.io",
-  testHistoryInterval: 10000,
   rootUrl: "",
   slackChannel: "https://dcos-community.slack.com/messages/general/",
   defaultRefreshRate: 2000,

--- a/tests/_support/index.js
+++ b/tests/_support/index.js
@@ -8,6 +8,35 @@ Cypress.Commands.add("configureCluster", configuration => {
   router.clearRoutes();
   cy.server();
 
+  // //////////////////////////////////////////////////////////////////////////
+  //                                 DEFAULTS                                //
+  // //////////////////////////////////////////////////////////////////////////
+
+  cy.route({
+    method: "POST",
+    url: /mesos\/api\/v1\?GET_VERSION/,
+    response: require("../_fixtures/v1/get_version"),
+    headers: { "Content-Type": "application/json" }
+  })
+    .route({
+      method: "POST",
+      url: /mesos\/api\/v1\?subscribe/,
+      response: require("../_fixtures/marathon-1-task/mesos-subscribe"),
+      headers: {
+        "Content-Type": "application/json"
+      }
+    })
+    .route({
+      method: "POST",
+      url: /mesos\/api\/v1\?GET_MASTER/,
+      response: "fx:marathon-1-task/mesos-get-master",
+      headers: { "Content-Type": "application/json" }
+    });
+
+  // //////////////////////////////////////////////////////////////////////////
+  //                                OVERRIDES                                //
+  // //////////////////////////////////////////////////////////////////////////
+
   if (configuration.mesos === "cluster-overview") {
     cy.route({
       method: "POST",
@@ -36,28 +65,6 @@ Cypress.Commands.add("configureCluster", configuration => {
     configuration.mesos === "1-task-delayed" ||
     configuration.mesos === "1-task-healthy-with-quota"
   ) {
-    cy.route({
-      method: "POST",
-      url: /mesos\/api\/v1\?GET_VERSION/,
-      response: require("../_fixtures/v1/get_version"),
-      headers: { "Content-Type": "application/json" }
-    }).as("getVersion");
-    cy.route({
-      method: "POST",
-      url: /mesos\/api\/v1\?subscribe/,
-      response: require("../_fixtures/marathon-1-task/mesos-subscribe"),
-      headers: {
-        "Content-Type": "application/json"
-      }
-    }).route({
-      method: "POST",
-      url: /mesos\/api\/v1\?GET_MASTER/,
-      response: "fx:marathon-1-task/mesos-get-master",
-      headers: {
-        "Content-Type": "application/json"
-      }
-    });
-
     router
       .route(/service\/marathon\/v2\/apps/, "fx:marathon-1-task/app")
       .route(/net\/v1\/nodes/, "fx:1-app-for-each-health/nodes")


### PR DESCRIPTION
sorry for the big ball of mud-commit, but:
the primary goal of it is to reduce the amount of time the serviceTable-test
spends on CI. in order to properly debug it all the runtime errors now have
gone! along the way some cosmetic changes came up...

we're grouping some test-cases that are easy to test together and won't cause a
lot of harm if we need to tell the apart (since cypress will show the exact step
that went wrong in the video anyway).

test times should be down from ~160 sec to ~50 sec.

## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
