### PR TITLE
chore: do not upload a latest-release to universe

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -190,8 +190,6 @@ pipeline {
         withCredentials([
           string(credentialsId: "d146870f-03b0-4f6a-ab70-1d09757a51fc", variable: "GH_TOKEN"), // semantic-release
           string(credentialsId: "sentry_io_token", variable: "SENTRY_AUTH_TOKEN"), // upload-build
-          string(credentialsId: "1ddc25d8-0873-4b6f-949a-ae803b074e7a", variable: "AWS_ACCESS_KEY_ID"),
-          string(credentialsId: "875cfce9-90ca-4174-8720-816b4cb7f10f", variable: "AWS_SECRET_ACCESS_KEY"),
           usernamePassword(credentialsId: "a7ac7f84-64ea-4483-8e66-bb204484e58f", passwordVariable: "GIT_PASSWORD", usernameVariable: "GIT_USER"), // update-dcos-repo
           usernamePassword(credentialsId: "6c147571-7145-410a-bf9c-4eec462fbe02", passwordVariable: "JIRA_PASS", usernameVariable: "JIRA_USER") // semantic-release-jira
         ]) {

--- a/scripts/ci/finalize-release
+++ b/scripts/ci/finalize-release
@@ -60,9 +60,6 @@ cat <<EOF > "${PROJECT_ROOT}/buildinfo.json"
 }
 EOF
 
-git clone https://github.com/mesosphere/dcos-commons.git ../dcos-commons
-S3_BUCKET='dcos-ui-universe' S3_DIR_PATH='oss' S3_DIR_NAME='latest' ../dcos-commons/tools/build_package.sh 'dcos-ui' ./ -a ./release.tar.gz aws
-
 # Upload source maps to sentry.io
 SENTRY_AUTH_TOKEN="${SENTRY_AUTH_TOKEN}"
 RELEASE_NAME="${PKG_VERSION}"


### PR DESCRIPTION
it looks like the upload recently broke. maybe because of change credentials?
as we currently do not use that latest-package we evade figuring out what's
going on by just NOT uploading the package to S3 and relying on github-releases
instead.

## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
