### PR TITLE
COPS-5814 - allow to toggle the way placement-info is stored

### DIFF
--- a/src/js/__tests__/__snapshots__/typecheck-test.ts.snap
+++ b/src/js/__tests__/__snapshots__/typecheck-test.ts.snap
@@ -1715,25 +1715,17 @@ plugins/placement/components/PlacementFormPartial.tsx: error TS2322: Type 'Eleme
 plugins/placement/components/PlacementFormPartial.tsx: error TS2769: No overload matches this call.
 plugins/placement/components/PlacementRegionSelection.tsx: error TS2322: type * is not assignable to type *.
 plugins/placement/components/PlacementRegionSelection.tsx: error TS2339: Property 'data' does not exist on type *.
-plugins/placement/components/PlacementSchemaField.tsx: error TS2339: Property 'batch' does not exist on type 'Readonly<{}>'.
-plugins/placement/components/PlacementSchemaField.tsx: error TS2339: Property 'fieldProps' does not exist on type *.
-plugins/placement/components/PlacementSchemaField.tsx: error TS2339: Property 'errorMessage' does not exist on type *.
-plugins/placement/components/PlacementSchemaField.tsx: error TS2339: Property 'renderRegion' does not exist on type *.
-plugins/placement/components/PlacementSchemaField.tsx: error TS2339: Property 'fieldProps' does not exist on type *.
-plugins/placement/components/PlacementSchemaField.tsx: error TS2339: Property 'label' does not exist on type *.
-plugins/placement/components/PlacementSchemaField.tsx: error TS2339: Property 'batch' does not exist on type 'Readonly<{}>'.
-plugins/placement/components/PlacementSchemaField.tsx: error TS2339: Property 'fieldProps' does not exist on type *.
-plugins/placement/components/PlacementSchemaField.tsx: error TS2339: Property 'fieldProps' does not exist on type *.
-plugins/placement/components/PlacementSchemaField.tsx: error TS2322: type * is not assignable to type *.
-plugins/placement/components/PlacementSchemaField.tsx: error TS2769: No overload matches this call.
-plugins/placement/components/PlacementSchemaField.tsx: error TS2339: Property 'defaultProps' does not exist on type *.
-plugins/placement/components/PlacementSchemaField.tsx: error TS2339: Property 'propTypes' does not exist on type *.
-plugins/placement/components/PlacementSchemaField.tsx: error TS2339: Property 'fieldProps' does not exist on type *.
-plugins/placement/components/PlacementSchemaField.tsx: error TS2339: Property 'batch' does not exist on type 'Readonly<{}>'.
 plugins/placement/components/PlacementSchemaField.tsx: error TS2339: Property 'formData' does not exist on type 'Readonly<{}>'.
-plugins/placement/components/PlacementSchemaField.tsx: error TS2339: Property 'fieldProps' does not exist on type *.
 plugins/placement/components/PlacementSchemaField.tsx: error TS2339: Property 'batch' does not exist on type 'Readonly<{}>'.
-plugins/placement/components/PlacementSchemaField.tsx: error TS2339: Property 'fieldProps' does not exist on type *.
+plugins/placement/components/PlacementSchemaField.tsx: error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'string'.
+plugins/placement/components/PlacementSchemaField.tsx: error TS2339: Property 'batch' does not exist on type 'Readonly<{}>'.
+plugins/placement/components/PlacementSchemaField.tsx: error TS2339: Property 'batch' does not exist on type 'Readonly<{}>'.
+plugins/placement/components/PlacementSchemaField.tsx: error TS2339: Property 'name' does not exist on type *.
+plugins/placement/components/PlacementSchemaField.tsx: error TS2339: Property 'required' does not exist on type *.
+plugins/placement/components/PlacementSchemaField.tsx: error TS2571: Object is of type 'unknown'.
+plugins/placement/components/PlacementSchemaField.tsx: error TS2769: No overload matches this call.
+plugins/placement/components/PlacementSchemaField.tsx: error TS2339: Property 'batch' does not exist on type 'Readonly<{}>'.
+plugins/placement/components/PlacementSchemaField.tsx: error TS2571: Object is of type 'unknown'.
 plugins/placement/components/PlacementSection.tsx: error TS2339: Property 'data' does not exist on type *.
 plugins/placement/components/PlacementSection.tsx: error TS2339: Property 'errors' does not exist on type *.
 plugins/placement/components/PlacementSection.tsx: error TS2339: Property 'onAddItem' does not exist on type *.
@@ -4822,14 +4814,7 @@ plugins/ui-update/utils/index.ts: error TS2345: Argument of type * is not assign
 src/js/components/AccessDeniedPage.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 src/js/components/BaseConfig.tsx: error TS2322: Type 'void' is not assignable to type 'string'.
 src/js/components/BaseConfig.tsx: error TS2322: type * is not assignable to type *.
-src/js/components/BatchContainer.tsx: error TS2339: Property 'batch' does not exist on type *.
-src/js/components/BatchContainer.tsx: error TS2339: Property 'onChange' does not exist on type *.
-src/js/components/BatchContainer.tsx: error TS2339: Property 'batch' does not exist on type *.
-src/js/components/BatchContainer.tsx: error TS2339: Property 'onChange' does not exist on type *.
-src/js/components/BatchContainer.tsx: error TS2339: Property 'batch' does not exist on type *.
-src/js/components/BatchContainer.tsx: error TS2339: Property 'onChange' does not exist on type *.
 src/js/components/BatchContainer.tsx: error TS2769: No overload matches this call.
-src/js/components/BatchContainer.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 src/js/components/CheckboxTable.tsx: error TS2339: Property 'allowMultipleSelect' does not exist on type *.
 src/js/components/CheckboxTable.tsx: error TS2339: Property 'checkedItemsMap' does not exist on type *.
 src/js/components/CheckboxTable.tsx: error TS2339: Property 'disabledItemsMap' does not exist on type *.
@@ -5328,7 +5313,6 @@ src/js/components/PlacementConstraintsSchemaField.tsx: error TS2339: Property 'e
 src/js/components/PlacementConstraintsSchemaField.tsx: error TS2339: Property 'batch' does not exist on type 'Readonly<{}>'.
 src/js/components/PlacementConstraintsSchemaField.tsx: error TS2339: Property 'fieldProps' does not exist on type *.
 src/js/components/PlacementConstraintsSchemaField.tsx: error TS2339: Property 'fieldProps' does not exist on type *.
-src/js/components/PlacementConstraintsSchemaField.tsx: error TS2322: type * is not assignable to type *.
 src/js/components/PlacementConstraintsSchemaField.tsx: error TS2322: type * is not assignable to type *.
 src/js/components/PlacementConstraintsSchemaField.tsx: error TS2339: Property 'defaultProps' does not exist on type *.
 src/js/components/PlacementConstraintsSchemaField.tsx: error TS2339: Property 'propTypes' does not exist on type *.

--- a/src/js/components/BatchContainer.tsx
+++ b/src/js/components/BatchContainer.tsx
@@ -2,10 +2,18 @@ import * as React from "react";
 
 import Transaction from "#SRC/js/structs/Transaction";
 import * as TransactionTypes from "#SRC/js/constants/TransactionTypes";
+import Batch from "../structs/Batch";
 
-export default class BatchContainer extends React.Component {
-  constructor(...args) {
-    super(...args);
+type BatchContainerProps = {
+  batch: Batch;
+  onChange: (batch: Batch, fieldName?: string) => void;
+};
+
+export default class BatchContainer extends React.Component<
+  BatchContainerProps
+> {
+  constructor(props: BatchContainerProps) {
+    super(props);
 
     this.handleChange = this.handleChange.bind(this);
     this.handleAddItem = this.handleAddItem.bind(this);

--- a/src/js/components/PlacementConstraintsSchemaField.tsx
+++ b/src/js/components/PlacementConstraintsSchemaField.tsx
@@ -92,9 +92,12 @@ export default class PlacementConstraintsSchemaField extends React.Component {
   }
 
   handleBatchChange(batch) {
-    const { formData, onChange } = this.props.fieldProps;
-    const newJson = batch.reduce(jsonReducer, []);
-    const newData = JSON.stringify(newJson.constraints);
+    const { formData, onChange, schema } = this.props.fieldProps;
+    const { constraints } = batch.reduce(jsonReducer, []);
+
+    // handle differently depending on `type` of jsonschema-field
+    const newData =
+      schema.type === "string" ? JSON.stringify(constraints) : constraints;
 
     if (newData !== formData) {
       onChange(newData);

--- a/src/js/components/SchemaField.tsx
+++ b/src/js/components/SchemaField.tsx
@@ -276,12 +276,10 @@ class SchemaField extends React.Component {
       case "boolean":
         return this.renderCheckbox(errorMessage, this.props);
       case "string":
-        if (schema.enum && schema.enum.length <= RADIO_SELECT_THRESHOLD) {
-          return this.renderRadioButtons(errorMessage, this.props);
-        }
-
-        if (schema.enum && schema.enum.length > RADIO_SELECT_THRESHOLD) {
-          return this.renderSelect(errorMessage, autofocus, this.props);
+        if (schema.enum) {
+          return schema.enum.length <= RADIO_SELECT_THRESHOLD
+            ? this.renderRadioButtons(errorMessage, this.props)
+            : this.renderSelect(errorMessage, autofocus, this.props);
         }
 
         return this.renderTextInput(errorMessage, autofocus, this.props);


### PR DESCRIPTION
fields with one of the following media-types now react to the specified field's
type.

* SchemaField:application/x-region-zone-constraints+json
* SchemaField:application/x-zone-constraints+json

if you set the type of the field to "string" it will render a stringified
version of the input into that field as before. if you use any other type,
you'll now get the raw data injected into that field.

a particular feature request was to change the placement_constraints-portion in
the JSON from the former to the latter format:

```
// with `type: 'string'`:
"placement_constraints": "[[\"@zone\",\"GROUP_BY\",\"1\"]]"

// with any other (or no) type:
"placement_constraints": [["@zone","GROUP_BY","1"]]
```

Closes COPS-5814