### PR TITLE
Pb/fix flake

### DIFF
--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -268,6 +268,7 @@ describe("Service Form Modal", () => {
             .contains("JSON Editor")
             .click();
 
+          // TODO: sometimes the editor does not yet have the content we're deleting in this step
           cy.get(".ace_text-input")
             .focus()
             .type("{selectall}{backspace}", { force: true });
@@ -279,7 +280,7 @@ describe("Service Form Modal", () => {
           // The closing } is auto inserted
           cy.get(".ace_text-input")
             .focus()
-            .type('{{}\n\t"id": "/foo"\n', { force: true });
+            .type('{selectall}{{}\n\t"id": "/foo"\n', { force: true });
 
           cy.get(".infoBoxWrapper").should("not.be.visible");
           cy.get("input[name=id]").should("have.value", "/foo");


### PR DESCRIPTION
you can observe this when you run this test in cypress and slow down your CPU by
6x. the content of the JSON-editor somehow is not yet present when we're seeking
to delete it - so we're basically deleting nothing only to have the content show
up right before the last `.type` kicks in and adds stuff to the editor - making
its content invalid again.

we're now deleting everything right before the second `.type` again via the
selectall.
