### PR TITLE
D2IQ-66083 - properly truncate service names while searching

### DIFF
--- a/plugins/services/src/js/columns/ServicesTableNameColumn.tsx
+++ b/plugins/services/src/js/columns/ServicesTableNameColumn.tsx
@@ -39,17 +39,14 @@ const ServiceName = React.memo(
 
     return (
       <TextCell>
-        <div className="service-table-heading flex-box flex-box-align-vertical-center table-cell-flex-box text-overflow">
+        <div style={{ display: "flex" }}>
           <Link className="table-cell-icon" to={serviceLink}>
             {getImage(image, isGroup)}
           </Link>
-          <span
-            className="table-cell-value table-cell-flex-box"
-            style={{ marginRight: "7px" }}
-          >
+          <React.Fragment>
             {getServiceLink(id, name, isGroup, linkToQuota, isFiltered)}
             {getOpenInNewWindowLink(webUrl)}
-          </span>
+          </React.Fragment>
         </div>
       </TextCell>
     );
@@ -120,7 +117,11 @@ function getServiceLink(
   }
 
   return (
-    <Link className="table-cell-link-primary" to={serviceLink}>
+    <Link
+      className="table-cell-link-primary"
+      to={serviceLink}
+      style={{ overflow: "hidden", textOverflow: "ellipsis" }}
+    >
       {name}
     </Link>
   );

--- a/src/js/components/NestedServiceLinks.tsx
+++ b/src/js/components/NestedServiceLinks.tsx
@@ -76,15 +76,23 @@ export default class NestedServiceLinks extends React.Component {
     const anchorClasses = classNames("table-cell-link-primary");
 
     return (
-      <Link className={anchorClasses} to={serviceLink} title={label}>
-        <span className="text-overflow">{label}</span>
+      <Link
+        className={anchorClasses}
+        to={serviceLink}
+        title={label}
+        style={{
+          display: "block",
+          overflow: "hidden",
+          textOverflow: "ellipsis"
+        }}
+      >
+        {label}
       </Link>
     );
   }
 
   getServicesLink(key) {
     const minorLinkClasses = classNames("text-overflow service-link");
-
     const minorLinkAnchorClasses = classNames("table-cell-link-secondary");
 
     return (
@@ -109,11 +117,6 @@ export default class NestedServiceLinks extends React.Component {
   render() {
     const classes = classNames("nested-service-links", "service-breadcrumb");
 
-    const majorLinkClasses = classNames(
-      "text-overflow",
-      "service-breadcrumb-service-id"
-    );
-
     const minorLinkWrapperClasses = classNames(
       "table-cell-details-secondary flex",
       "flex-align-items-center table-cell-flex-box",
@@ -122,7 +125,7 @@ export default class NestedServiceLinks extends React.Component {
 
     return (
       <div className={classes}>
-        <div className={majorLinkClasses}>{this.getMajorLink()}</div>
+        {this.getMajorLink()}
         <div className={minorLinkWrapperClasses}>{this.getMinorLinks()}</div>
       </div>
     );


### PR DESCRIPTION
if you entered a search term, long service names would be truncated to a mere

`...`.

Now we truncate to as wide as the column let's us:

`long-service-na...`

Closes D2IQ-66083
