### PR TITLE
chore: fix CI-flakes

### DIFF
--- a/cypress.system-tests.json
+++ b/cypress.system-tests.json
@@ -8,7 +8,7 @@
     "mochaFile": "cypress/result-system-[hash].xml"
   },
   "screenshotsFolder": "cypress/screenshots",
-  "supportFile": "system-tests/_support",
+  "supportFile": "system-tests/_support/index.js",
   "videosFolder": "cypress/videos",
   "waitForAnimations": true
 }

--- a/system-tests-ee/ee-services/test-apps-secrets-cy.js
+++ b/system-tests-ee/ee-services/test-apps-secrets-cy.js
@@ -1,5 +1,3 @@
-require("../_support/utils/ServicesUtil");
-
 describe("Services", () => {
   const SECRET_NAME = `${Cypress.env("TEST_UUID")}-secret`;
 

--- a/system-tests/_support/index.js
+++ b/system-tests/_support/index.js
@@ -1,4 +1,5 @@
 require("./formChildCommands");
+require("./utils/ServicesUtil");
 /**
  * Visit the specified (Routed) URL
  *
@@ -46,17 +47,21 @@ function validateServiceId(id) {
  * @param {Object} serviceDefinition - The service JSON definition file
  *
  */
-export function createService(serviceDefinition) {
-  validateServiceId(serviceDefinition.id);
-  const serviceName = serviceDefinition.id.split("/").pop();
+Cypress.Commands.add(
+  "createService",
+  { prevSubject: false },
+  (serviceDefinition) => {
+    validateServiceId(serviceDefinition.id);
+    const serviceName = serviceDefinition.id.split("/").pop();
 
-  cy.exec(
-    `echo '${JSON.stringify(serviceDefinition)}' | dcos marathon app add`
-  );
-  cy.visitUrl(`services/overview/%2F${Cypress.env("TEST_UUID")}`);
-  cy.get(".page-body-content .service-table").contains(serviceName);
-  cy.get(".page-body-content .service-table").contains("Running");
-}
+    cy.exec(
+      `echo '${JSON.stringify(serviceDefinition)}' | dcos marathon app add`
+    );
+    cy.visitUrl(`services/overview/%2F${Cypress.env("TEST_UUID")}`);
+    cy.get(".page-body-content .service-table").contains(serviceName);
+    cy.get(".page-body-content .service-table").contains("Running");
+  }
+);
 
 Cypress.Commands.add("retype", { prevSubject: true }, (subject, text) =>
   cy.wrap(subject).type(`{selectall}${text}`)
@@ -68,11 +73,11 @@ Cypress.Commands.add("retype", { prevSubject: true }, (subject, text) =>
  * @param {String} serviceId - The service id which it will delete
  *
  */
-export function deleteService(serviceId) {
+Cypress.Commands.add("deleteService", { prevSubject: false }, (serviceId) => {
   validateServiceId(serviceId);
   const serviceName = serviceId.split("/").pop();
 
   cy.exec(`dcos marathon app remove ${serviceId}`);
   cy.visitUrl(`services/overview/%2F${Cypress.env("TEST_UUID")}`);
   cy.get(".page-body-content").contains(serviceName).should("not.exist");
-}
+});

--- a/system-tests/dashboard/test-dashboard-cy.js
+++ b/system-tests/dashboard/test-dashboard-cy.js
@@ -1,6 +1,3 @@
-require("../_support/utils/ServicesUtil");
-const { createService, deleteService } = require("../_support/index");
-
 const serviceDefinition = {
   id: `/${Cypress.env("TEST_UUID")}/dashboard-test-service`,
   instances: 1,
@@ -48,7 +45,7 @@ describe("Dashboard statistics", () => {
     });
 
     // CREATE SERVICE AND RUN ASSERTIONS
-    createService(serviceDefinition);
+    cy.createService(serviceDefinition);
     cy.visitUrl("dashboard");
 
     getAllocationElementFor("CPU Allocation").should(($label) => {
@@ -86,7 +83,7 @@ describe("Dashboard statistics", () => {
     });
 
     // DELETE SERVICE AND RUN ASSERTIONS
-    deleteService(serviceDefinition.id);
+    cy.deleteService(serviceDefinition.id);
 
     cy.visitUrl("dashboard");
     getAllocationElementFor("CPU Allocation").should(($label) => {

--- a/system-tests/services/test-apps-cy.js
+++ b/system-tests/services/test-apps-cy.js
@@ -1,5 +1,3 @@
-require("../_support/utils/ServicesUtil");
-
 // creates an app with ucr config and command
 // creates an app with persistent volume
 describe("Services", () => {

--- a/system-tests/services/test-external-volumes-cy.js
+++ b/system-tests/services/test-external-volumes-cy.js
@@ -1,6 +1,3 @@
-require("../_support");
-require("../_support/utils/ServicesUtil");
-
 describe("Services", () => {
   /**
    * Test the external volumes

--- a/system-tests/services/test-pods-cy.js
+++ b/system-tests/services/test-pods-cy.js
@@ -1,5 +1,3 @@
-require("../_support/utils/ServicesUtil");
-
 describe("Services", () => {
   /**
    * Test the pods

--- a/system-tests/universe/test-universe-cy.js
+++ b/system-tests/universe/test-universe-cy.js
@@ -1,5 +1,3 @@
-require("../_support/utils/ServicesUtil");
-
 describe("Universe", () => {
   describe("on catalog/packages", () => {
     beforeEach(() => {

--- a/tests/enterprise-plugins/dss/DSS-cy.js
+++ b/tests/enterprise-plugins/dss/DSS-cy.js
@@ -1,5 +1,3 @@
-require("../../_support/utils/ServicesUtil");
-
 describe("DC/OS Storage Service", () => {
   context("DSS (Single Container)", () => {
     beforeEach(() => {

--- a/tests/pages/nodes/node/NodeDetail-cy.js
+++ b/tests/pages/nodes/node/NodeDetail-cy.js
@@ -1,5 +1,3 @@
-require("../../../_support/utils/ServicesUtil");
-
 describe("Nodes Detail Page", () => {
   beforeEach(() => {
     cy.configureCluster({

--- a/tests/pages/services/ServiceExternalVolumes-cy.js
+++ b/tests/pages/services/ServiceExternalVolumes-cy.js
@@ -1,5 +1,3 @@
-require("../../_support/utils/ServicesUtil");
-
 describe("Services", () => {
   /**
    * Test the external volumes

--- a/tests/pages/services/ServicePodReviewScreen-cy.js
+++ b/tests/pages/services/ServicePodReviewScreen-cy.js
@@ -1,5 +1,3 @@
-require("../../_support/utils/ServicesUtil");
-
 describe("Services", () => {
   /**
    * Test the pods

--- a/tests/pages/services/ServiceReviewScreen-cy.js
+++ b/tests/pages/services/ServiceReviewScreen-cy.js
@@ -1,5 +1,3 @@
-require("../../_support/utils/ServicesUtil");
-
 describe("Services", () => {
   /**
    * Test the applications


### PR DESCRIPTION
we are often greeted by something like this:

`cy.visitUrl is not a function Because this error occurred during a 'before
each' hook we are skipping the remaining tests in the current suite: 'LDAP
users'`.

this try to fix it is just something out of the blue. apparently there seems to
be something wrong in cypress, as that command should have been added from the
support file. to get a better feel for how exactly things go wrong, we now load
this stuff ONLY ONCE.
