### PR TITLE
chore: run CI against the current build

### DIFF
--- a/scripts/utils/tests-functions
+++ b/scripts/utils/tests-functions
@@ -106,7 +106,7 @@ function setup() {
     fi
     npx http-server -sp "${PROXY_PORT}" --proxy "${CLUSTER_URL}" --proxy-secure=false "${PROJECT_ROOT}/dist" &
     PROXY_PID=$!
-    CLUSTER_URL="http://127.0.0.1:${PROXY_PORT}"
+    CYPRESS_CLUSTER_URL="http://127.0.0.1:${PROXY_PORT}"
     echo "===> done (PID: ${PROXY_PID})."
   fi
 }


### PR DESCRIPTION
we seem to have tested the UI that the cluster brings in our system tests for
quite a while...
