### PR TITLE
chore: apply some learnings from dcos-core-cli

### DIFF
--- a/scripts/terraform/up.sh
+++ b/scripts/terraform/up.sh
@@ -1,21 +1,18 @@
 #!/usr/bin/env bash
 
+export TF_INPUT=false
+export TF_IN_AUTOMATION=1
+
 eval "$(ssh-agent -s)"
 
 ssh-keygen -t rsa -N "" -f ~/.ssh/$TF_VAR_variant
 ssh-add ~/.ssh/$TF_VAR_variant
 
 echo "Running terraform init"
-for i in {1..3}; do terraform init && break; done
+for i in {1..3}; do terraform init >&2 && break; done
 
 echo "Running terraform apply. This may take a while. Expect 15 minutes."
 # we try to recover a couple times in case the first try did not work - which currently happens frequently.
-for i in {1..3}; do terraform apply -auto-approve > ./log && break; done
+for i in {1..3}; do terraform apply -auto-approve >&2 && break; done
 
-cat log
-
-# something like `cluster-address = dcos-ui-system-tests-1371554912.us-west-2.elb.amazonaws.com`
-line=$(grep -o "cluster-address = \S*" ./log | head -n1)
-
-# print that cluster url
-echo http://$(echo $line | cut -d" " -f3)
+echo http://$(terraform output cluster-address)


### PR DESCRIPTION
set some env-vars that tell terraform that it is in CI-mode - it won't ask for
missing variables (and fail directly instead) and adjusts its output.

also we now use `terraform output` instead of greping through the output
manually :grimacing:
