### PR TITLE
chore: refactor PodInstancesTable

### DIFF
--- a/plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx
+++ b/plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx
@@ -231,7 +231,9 @@ class PodInstancesTable extends React.Component {
       let containerResources = container.getResources();
 
       // TODO: Remove the following 4 lines when DCOS-10098 is addressed
-      const containerSpec = podSpec.getContainerSpec(container.name);
+      const containerSpec = podSpec
+        .getContainers()
+        .find(({ name }) => container.name === name);
       if (containerSpec) {
         containerResources = containerSpec.resources;
       }
@@ -257,7 +259,7 @@ class PodInstancesTable extends React.Component {
         cpus: containerResources.cpus,
         mem: containerResources.mem,
         resourceLimits:
-          containerSpec.resourceLimits || containerSpec.resources || {},
+          containerSpec?.resourceLimits || containerSpec?.resources || {},
         updated: container.getLastUpdated(),
         version: "",
         isHistoricalInstance: container.isHistoricalInstance,

--- a/plugins/services/src/js/filters/PodInstanceStatusFilter.ts
+++ b/plugins/services/src/js/filters/PodInstanceStatusFilter.ts
@@ -1,53 +1,40 @@
 import DSLFilterTypes from "#SRC/js/constants/DSLFilterTypes";
-import DSLFilter from "#SRC/js/structs/DSLFilter";
 
-const LABEL = "is";
-
-const LABEL_TO_STATUS = {
-  active: "active",
-  completed: "completed",
-};
+const getStatus = (label) =>
+  ({
+    active: "active",
+    completed: "completed",
+  }[label.toLowerCase()]);
 
 /**
  * This filter handles the `is:state` for instances
  */
-class PodInstanceStatusFilter extends DSLFilter {
+export default {
   /**
    * Handle all `is:XXXX` attribute filters that we can handle.
-   *
-   * @override
    */
-  filterCanHandle(filterType, filterArguments) {
+  filterCanHandle(filterType, { label, text }) {
     return (
-      filterType === DSLFilterTypes.ATTRIB &&
-      filterArguments.label === LABEL &&
-      LABEL_TO_STATUS[filterArguments.text.toLowerCase()] != null
+      filterType === DSLFilterTypes.ATTRIB && label === "is" && getStatus(text)
     );
-  }
+  },
 
   /**
-   * Keep only instances whose state matches the value of
-   * the `is` label
-   *
-   * @override
+   * Keep only instances whose state matches the value of the `is` label
    */
-  filterApply(resultSet, filterType, filterArguments) {
-    const testStatus = LABEL_TO_STATUS[filterArguments.text.toLowerCase()];
+  filterApply(resultSet, _filterType, { text }) {
+    const testStatus = getStatus(text);
 
     return resultSet.filterItems((instance) => {
       let instanceStatus = "completed";
-
       if (instance.isStaging()) {
         instanceStatus = "staging";
       }
-
       if (instance.isRunning()) {
         instanceStatus = "active";
       }
 
       return instanceStatus === testStatus;
     });
-  }
-}
-
-export default PodInstanceStatusFilter;
+  },
+};

--- a/plugins/services/src/js/filters/PodInstanceTextFilter.ts
+++ b/plugins/services/src/js/filters/PodInstanceTextFilter.ts
@@ -1,10 +1,9 @@
 import DSLFilterTypes from "#SRC/js/constants/DSLFilterTypes";
-import DSLFilter from "#SRC/js/structs/DSLFilter";
 
 /**
  * This filter handles the `text` attributes against pod instance's `id` value
  */
-class PodInstanceTextFilter extends DSLFilter {
+export default {
   /**
    * Handle all `id` attribute filters that we can handle.
    *
@@ -14,27 +13,15 @@ class PodInstanceTextFilter extends DSLFilter {
     return (
       filterType === DSLFilterTypes.EXACT || filterType === DSLFilterTypes.FUZZY
     );
-  }
+  },
 
   /**
    * Keep only tasks whose id contains part of the filter's text
    *
    * @override
    */
-  filterApply(resultSet, filterType, filterArguments) {
-    const filteredItems = resultSet.filterItems(
-      (instance) => instance.id.indexOf(filterArguments.text) !== -1
-    );
-
-    if (
-      filteredItems.getItems().length !== 0 &&
-      filteredItems.getItems().length < resultSet.getItems().length
-    ) {
-      return filteredItems;
-    }
-
-    return resultSet;
-  }
-}
-
-export default PodInstanceTextFilter;
+  filterApply(resultSet, _filterType, { text }) {
+    const filteredItems = resultSet.filterItems(({ id }) => id.includes(text));
+    return filteredItems.list.length !== 0 ? filteredItems : resultSet;
+  },
+};

--- a/plugins/services/src/js/filters/PodInstancesRegionFilter.ts
+++ b/plugins/services/src/js/filters/PodInstancesRegionFilter.ts
@@ -1,52 +1,23 @@
 import DSLFilterTypes from "#SRC/js/constants/DSLFilterTypes";
-import DSLFilter from "#SRC/js/structs/DSLFilter";
 import InstanceUtil from "../utils/InstanceUtil";
 
-const LABEL = "region";
-
-/**
- * This filter handles the `region:XXXX` for instances
- */
-class PodInstancesRegionFilter extends DSLFilter {
-  constructor(regions = []) {
-    super();
-    this.regions = regions;
-  }
+export default {
   /**
    * Handle all `region:XXXX` attribute filters that we can handle.
-   *
-   * @override
    */
-  filterCanHandle(filterType, filterArguments) {
-    const regions = this.regions;
-
-    return (
-      filterType === DSLFilterTypes.ATTRIB &&
-      filterArguments.label === LABEL &&
-      regions.includes(filterArguments.text.toLowerCase())
-    );
-  }
+  filterCanHandle(filterType, { label }) {
+    return filterType === DSLFilterTypes.ATTRIB && label === "region";
+  },
 
   /**
    * Keep only instances whose region matches the value of
    * the `region` label
-   *
-   * @override
    */
-  filterApply(resultSet, filterType, filterArguments) {
-    let region = "";
-    const filterArgumentsValue = filterArguments.text.toLowerCase();
-
-    if (this.regions.includes(filterArgumentsValue)) {
-      region = filterArgumentsValue;
-    }
-
-    return resultSet.filterItems((instance) => {
-      const node = InstanceUtil.getNode(instance);
-
-      return node && node.getRegionName().toLowerCase() === region;
-    });
-  }
-}
-
-export default PodInstancesRegionFilter;
+  filterApply(resultSet, _filterType, { text }) {
+    const region = text.toLowerCase();
+    return resultSet.filterItems(
+      (instance) =>
+        InstanceUtil.getNode(instance)?.getRegionName().toLowerCase() === region
+    );
+  },
+};

--- a/plugins/services/src/js/filters/PodInstancesZoneFilter.ts
+++ b/plugins/services/src/js/filters/PodInstancesZoneFilter.ts
@@ -1,52 +1,23 @@
 import DSLFilterTypes from "#SRC/js/constants/DSLFilterTypes";
-import DSLFilter from "#SRC/js/structs/DSLFilter";
 import InstanceUtil from "../utils/InstanceUtil";
 
-const LABEL = "zone";
-
-/**
- * This filter handles the `zone:XXXX` for instances
- */
-class PodInstancesZoneFilter extends DSLFilter {
-  constructor(zones = []) {
-    super();
-    this.zones = zones;
-  }
+export default {
   /**
    * Handle all `zone:XXXX` attribute filters that we can handle.
-   *
-   * @override
    */
-  filterCanHandle(filterType, filterArguments) {
-    const zones = this.zones;
-
-    return (
-      filterType === DSLFilterTypes.ATTRIB &&
-      filterArguments.label === LABEL &&
-      zones.includes(filterArguments.text.toLowerCase())
-    );
-  }
+  filterCanHandle(filterType, { label }) {
+    return filterType === DSLFilterTypes.ATTRIB && label === "zone";
+  },
 
   /**
    * Keep only instances whose zone matches the value of
    * the `zone` label
-   *
-   * @override
    */
-  filterApply(resultSet, filterType, filterArguments) {
-    let zone = "";
-    const filterArgumentsValue = filterArguments.text.toLowerCase();
-
-    if (this.zones.includes(filterArgumentsValue)) {
-      zone = filterArgumentsValue;
-    }
-
-    return resultSet.filterItems((instance) => {
-      const node = InstanceUtil.getNode(instance);
-
-      return node && node.getZoneName().toLowerCase() === zone;
-    });
-  }
-}
-
-export default PodInstancesZoneFilter;
+  filterApply(resultSet, _filterType, { text }) {
+    const zone = text.toLowerCase();
+    return resultSet.filterItems(
+      (instance) =>
+        InstanceUtil.getNode(instance)?.getZoneName().toLowerCase() === zone
+    );
+  },
+};

--- a/plugins/services/src/js/filters/__tests__/PodInstanceStatusFilter-test.ts
+++ b/plugins/services/src/js/filters/__tests__/PodInstanceStatusFilter-test.ts
@@ -24,7 +24,7 @@ describe("PodInstanceStatusFilter", () => {
     const services = new List({ items: thisMockItems });
     const expr = SearchDSL.parse("is:active");
 
-    const filters = [new PodInstanceStatusFilter()];
+    const filters = [PodInstanceStatusFilter];
 
     expect(expr.filter(filters, services).getItems()).toEqual([
       thisMockItems[0],
@@ -35,7 +35,7 @@ describe("PodInstanceStatusFilter", () => {
     const services = new List({ items: thisMockItems });
     const expr = SearchDSL.parse("is:completed");
 
-    const filters = [new PodInstanceStatusFilter()];
+    const filters = [PodInstanceStatusFilter];
 
     expect(expr.filter(filters, services).getItems()).toEqual([
       thisMockItems[1],

--- a/plugins/services/src/js/filters/__tests__/PodInstanceTextFilter-test.ts
+++ b/plugins/services/src/js/filters/__tests__/PodInstanceTextFilter-test.ts
@@ -29,7 +29,7 @@ describe("PodInstancesZoneFilter", () => {
     const services = new List({ items: thisMockItems });
     const expr = SearchDSL.parse("zone:zone-1");
 
-    const filters = [new PodInstancesZoneFilter(["zone-1"])];
+    const filters = [PodInstancesZoneFilter];
 
     expect(expr.filter(filters, services).getItems()).toEqual([
       thisMockItems[0],

--- a/plugins/services/src/js/filters/__tests__/PodInstancesRegionFilter-test.ts
+++ b/plugins/services/src/js/filters/__tests__/PodInstancesRegionFilter-test.ts
@@ -11,16 +11,8 @@ describe("PodInstancesRegionFilter", () => {
   beforeEach(() => {
     InstanceUtil.getNode = (item) => item;
     thisMockItems = [
-      {
-        getRegionName() {
-          return "region-1";
-        },
-      },
-      {
-        getRegionName() {
-          return "region-2";
-        },
-      },
+      { getRegionName: () => "region-1" },
+      { getRegionName: () => "region-2" },
     ];
   });
 
@@ -28,7 +20,7 @@ describe("PodInstancesRegionFilter", () => {
     const services = new List({ items: thisMockItems });
     const expr = SearchDSL.parse("region:region-1");
 
-    const filters = [new PodInstancesRegionFilter(["region-1"])];
+    const filters = [PodInstancesRegionFilter];
 
     expect(expr.filter(filters, services).getItems()).toEqual([
       thisMockItems[0],

--- a/plugins/services/src/js/filters/__tests__/PodInstancesZoneFilter-test.ts
+++ b/plugins/services/src/js/filters/__tests__/PodInstancesZoneFilter-test.ts
@@ -11,24 +11,15 @@ describe("PodInstancesZoneFilter", () => {
   beforeEach(() => {
     InstanceUtil.getNode = (item) => item;
     thisMockItems = [
-      {
-        getZoneName() {
-          return "zone-1";
-        },
-      },
-      {
-        getZoneName() {
-          return "zone-2";
-        },
-      },
+      { getZoneName: () => "zone-1" },
+      { getZoneName: () => "zone-2" },
     ];
   });
 
   it("keeps tasks with specific zone mentioned", () => {
     const services = new List({ items: thisMockItems });
     const expr = SearchDSL.parse("zone:zone-1");
-
-    const filters = [new PodInstancesZoneFilter(["zone-1"])];
+    const filters = [PodInstancesZoneFilter];
 
     expect(expr.filter(filters, services).getItems()).toEqual([
       thisMockItems[0],

--- a/plugins/services/src/js/structs/PodContainer.ts
+++ b/plugins/services/src/js/structs/PodContainer.ts
@@ -58,13 +58,7 @@ export default class PodContainer extends Item {
   }
 
   getResources() {
-    return {
-      cpus: 0,
-      mem: 0,
-      gpus: 0,
-      disk: 0,
-      ...this.get("resources"),
-    };
+    return { cpus: 0, mem: 0, gpus: 0, disk: 0, ...this.get("resources") };
   }
 
   hasHealthChecks() {

--- a/plugins/services/src/js/structs/PodInstance.ts
+++ b/plugins/services/src/js/structs/PodInstance.ts
@@ -12,9 +12,7 @@ export default class PodInstance extends Item {
   }
 
   getContainers() {
-    const containers = this.get("containers") || [];
-
-    return containers.map((container) => new PodContainer(container));
+    return (this.get("containers") || []).map((c) => new PodContainer(c));
   }
 
   getId() {
@@ -90,15 +88,7 @@ export default class PodInstance extends Item {
   }
 
   getResources() {
-    const resources = this.get("resources") || {};
-
-    return {
-      cpus: 0,
-      mem: 0,
-      gpus: 0,
-      disk: 0,
-      ...resources,
-    };
+    return { cpus: 0, mem: 0, gpus: 0, disk: 0, ...this.get("resources") };
   }
 
   getIpAddresses() {

--- a/plugins/services/src/js/structs/PodSpec.ts
+++ b/plugins/services/src/js/structs/PodSpec.ts
@@ -10,10 +10,6 @@ export default class PodSpec extends ServiceSpec {
     return this.get("containers") || [];
   }
 
-  getContainerSpec(name) {
-    return this.getContainers().find((container) => container.name === name);
-  }
-
   getLabels() {
     return this.get("labels") || {};
   }

--- a/plugins/services/src/js/structs/Service.ts
+++ b/plugins/services/src/js/structs/Service.ts
@@ -133,7 +133,7 @@ export default class Service extends Item {
 
   getResourceLimits() {
     const instances = this.getInstancesCount();
-    const { cpus = 0, mem = 0 } = this.get("resourceLimits") || {};
+    const { cpus = 0, mem = 0 } = this.resourceLimits || {};
 
     return {
       cpus: cpus !== "unlimited" ? cpus * instances : cpus,

--- a/plugins/services/src/js/structs/ServiceSpec.ts
+++ b/plugins/services/src/js/structs/ServiceSpec.ts
@@ -6,11 +6,6 @@ export default class ServiceSpec extends Item {
   }
 
   getResources() {
-    return {
-      cpus: 0,
-      mem: 0,
-      gpus: 0,
-      disk: 0,
-    };
+    return { cpus: 0, mem: 0, gpus: 0, disk: 0 };
   }
 }

--- a/plugins/services/src/js/structs/__tests__/PodSpec-test.ts
+++ b/plugins/services/src/js/structs/__tests__/PodSpec-test.ts
@@ -26,16 +26,6 @@ describe("PodSpec", () => {
     });
   });
 
-  describe("#getContainerSpec", () => {
-    it("returns the correct value", () => {
-      const podSpec = new PodSpec(PodFixture.spec);
-
-      expect(podSpec.getContainerSpec("container-1")).toEqual(
-        PodFixture.spec.containers[0]
-      );
-    });
-  });
-
   describe("#getLabels", () => {
     it("returns the correct value", () => {
       const podSpec = new PodSpec(PodFixture.spec);

--- a/plugins/services/src/js/utils/InstanceUtil.ts
+++ b/plugins/services/src/js/utils/InstanceUtil.ts
@@ -33,16 +33,12 @@ const InstanceUtil = {
   },
 
   getNode(task) {
-    if (!task || !task.agentId) {
+    if (!task?.agentId) {
       return null;
     }
 
-    const nodesList = CompositeState.getNodesList();
-
-    return nodesList
-      .filter({
-        ids: [task.agentId],
-      })
+    return CompositeState.getNodesList()
+      .filter({ ids: [task.agentId] })
       .last();
   },
 };

--- a/src/js/__tests__/__snapshots__/typecheck-test.ts.snap
+++ b/src/js/__tests__/__snapshots__/typecheck-test.ts.snap
@@ -3036,8 +3036,6 @@ plugins/services/src/js/containers/pod-detail/PodHeader.tsx: error TS2556: Expec
 plugins/services/src/js/containers/pod-detail/PodHeader.tsx: error TS2339: Property 'pod' does not exist on type *.
 plugins/services/src/js/containers/pod-detail/PodHeader.tsx: error TS2339: Property 'onScale' does not exist on type *.
 plugins/services/src/js/containers/pod-detail/PodHeader.tsx: error TS2339: Property 'onEdit' does not exist on type *.
-plugins/services/src/js/containers/pod-instances/PodInstancesContainer.tsx: error TS2345: Argument of type 'string[]' is not assignable to parameter of type 'never[]'.
-plugins/services/src/js/containers/pod-instances/PodInstancesContainer.tsx: error TS2345: Argument of type 'string[]' is not assignable to parameter of type 'never[]'.
 plugins/services/src/js/containers/pod-instances/PodInstancesContainer.tsx: error TS2556: Expected 3 arguments, but got 0 or more.
 plugins/services/src/js/containers/pod-instances/PodInstancesContainer.tsx: error TS2339: Property 'actionErrors' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/containers/pod-instances/PodInstancesContainer.tsx: error TS2339: Property 'pendingActions' does not exist on type 'Readonly<{}>'.
@@ -3055,12 +3053,9 @@ plugins/services/src/js/containers/pod-instances/PodInstancesContainer.tsx: erro
 plugins/services/src/js/containers/pod-instances/PodInstancesContainer.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/containers/pod-instances/PodInstancesContainer.tsx: error TS2339: Property 'childContextTypes' does not exist on type *.
 plugins/services/src/js/containers/pod-instances/PodInstancesContainer.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
-plugins/services/src/js/containers/pod-instances/PodInstancesContainer.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/services/src/js/containers/pod-instances/PodInstancesContainer.tsx: error TS2339: Property 'dispatcher' does not exist on type 'PodInstancesContainer'.
 plugins/services/src/js/containers/pod-instances/PodInstancesContainer.tsx: error TS2339: Property 'dispatcher' does not exist on type 'PodInstancesContainer'.
 plugins/services/src/js/containers/pod-instances/PodInstancesContainer.tsx: error TS2339: Property 'location' does not exist on type *.
-plugins/services/src/js/containers/pod-instances/PodInstancesContainer.tsx: error TS2339: Property 'defaultFilterData' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/pod-instances/PodInstancesContainer.tsx: error TS2339: Property 'filterExpression' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS2339: Property 'pod' does not exist on type *.
 plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS6133: 'prop' is declared but its value is never read.
 plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS2339: Property 'isParent' does not exist on type '{}'.
@@ -3441,16 +3436,6 @@ plugins/services/src/js/events/__tests__/MarathonActions-test.ts: error TS2554: 
 plugins/services/src/js/events/__tests__/SDKEndpointsActions-test.ts: error TS2739: type * is missing the following properties from type *: DONE, HEADERS_RECEIVED, LOADING, OPENED, UNSENT
 plugins/services/src/js/events/__tests__/ServiceActions-test.ts: error TS2554: Expected 2 arguments, but got 1.
 plugins/services/src/js/events/__tests__/ServiceActions-test.ts: error TS2554: Expected 2 arguments, but got 1.
-plugins/services/src/js/filters/PodInstanceStatusFilter.ts: error TS6133: 'filterType' is declared but its value is never read.
-plugins/services/src/js/filters/PodInstanceTextFilter.ts: error TS6133: 'filterType' is declared but its value is never read.
-plugins/services/src/js/filters/PodInstancesRegionFilter.ts: error TS2339: Property 'regions' does not exist on type 'PodInstancesRegionFilter'.
-plugins/services/src/js/filters/PodInstancesRegionFilter.ts: error TS2339: Property 'regions' does not exist on type 'PodInstancesRegionFilter'.
-plugins/services/src/js/filters/PodInstancesRegionFilter.ts: error TS6133: 'filterType' is declared but its value is never read.
-plugins/services/src/js/filters/PodInstancesRegionFilter.ts: error TS2339: Property 'regions' does not exist on type 'PodInstancesRegionFilter'.
-plugins/services/src/js/filters/PodInstancesZoneFilter.ts: error TS2339: Property 'zones' does not exist on type 'PodInstancesZoneFilter'.
-plugins/services/src/js/filters/PodInstancesZoneFilter.ts: error TS2339: Property 'zones' does not exist on type 'PodInstancesZoneFilter'.
-plugins/services/src/js/filters/PodInstancesZoneFilter.ts: error TS6133: 'filterType' is declared but its value is never read.
-plugins/services/src/js/filters/PodInstancesZoneFilter.ts: error TS2339: Property 'zones' does not exist on type 'PodInstancesZoneFilter'.
 plugins/services/src/js/filters/ServiceAttributeHealthFilter.ts: error TS6133: 'filterType' is declared but its value is never read.
 plugins/services/src/js/filters/ServiceAttributeIsFilter.ts: error TS6133: 'filterType' is declared but its value is never read.
 plugins/services/src/js/filters/ServiceNameTextFilter.ts: error TS6133: 'filterType' is declared but its value is never read.
@@ -3464,9 +3449,6 @@ plugins/services/src/js/filters/TasksZoneFilter.ts: error TS2339: Property 'zone
 plugins/services/src/js/filters/TasksZoneFilter.ts: error TS2339: Property 'zones' does not exist on type 'TasksZoneFilter'.
 plugins/services/src/js/filters/TasksZoneFilter.ts: error TS6133: 'filterType' is declared but its value is never read.
 plugins/services/src/js/filters/TasksZoneFilter.ts: error TS2339: Property 'zones' does not exist on type 'TasksZoneFilter'.
-plugins/services/src/js/filters/__tests__/PodInstanceTextFilter-test.ts: error TS2322: Type 'string' is not assignable to type 'never'.
-plugins/services/src/js/filters/__tests__/PodInstancesRegionFilter-test.ts: error TS2322: Type 'string' is not assignable to type 'never'.
-plugins/services/src/js/filters/__tests__/PodInstancesZoneFilter-test.ts: error TS2322: Type 'string' is not assignable to type 'never'.
 plugins/services/src/js/filters/__tests__/TaskRegionFilter-test.ts: error TS2322: Type 'string' is not assignable to type 'never'.
 plugins/services/src/js/filters/__tests__/TaskZoneFilter-test.ts: error TS2322: Type 'string' is not assignable to type 'never'.
 plugins/services/src/js/pages/EditFrameworkConfiguration.tsx: error TS2339: Property 'packageDetails' does not exist on type 'Readonly<{}>'.
@@ -4374,6 +4356,7 @@ plugins/services/src/js/structs/Pod.ts: error TS2339: Property '_regions' does n
 plugins/services/src/js/structs/Pod.ts: error TS2339: Property 'spec' does not exist on type 'Pod'.
 plugins/services/src/js/structs/Pod.ts: error TS2339: Property 'spec' does not exist on type 'Pod'.
 plugins/services/src/js/structs/Service.ts: error TS2339: Property '_regions' does not exist on type 'Service'.
+plugins/services/src/js/structs/Service.ts: error TS2339: Property 'resourceLimits' does not exist on type 'Service'.
 plugins/services/src/js/structs/Service.ts: error TS2339: Property '_regions' does not exist on type 'Service'.
 plugins/services/src/js/structs/Service.ts: error TS2339: Property '_regions' does not exist on type 'Service'.
 plugins/services/src/js/structs/Service.ts: error TS2339: Property '_regions' does not exist on type 'Service'.

--- a/src/js/structs/Node.ts
+++ b/src/js/structs/Node.ts
@@ -93,14 +93,7 @@ class Node extends Item {
   }
 
   getResources() {
-    return (
-      this.get("used_resources") || {
-        cpus: 0,
-        mem: 0,
-        gpus: 0,
-        disk: 0,
-      }
-    );
+    return this.get("used_resources") || { cpus: 0, mem: 0, gpus: 0, disk: 0 };
   }
 
   isPublic() {


### PR DESCRIPTION
while trying to consolidate implementations for the ServicesTable and the
PodInstancesTable (we'll also later need to have a look at the
ServicesInstancesContainer) these changes emerged.

They help in comprehending what's going on and will be utterly helpful when
fixing the FilterBar on that Table (which has several bugs, as i learned during
this exercise).
