### PR TITLE
fix: calculation of resource limits for pods/service table

### DIFF
--- a/plugins/services/src/js/columns/ServicesTableCPUColumn.tsx
+++ b/plugins/services/src/js/columns/ServicesTableCPUColumn.tsx
@@ -6,6 +6,7 @@ import Pod from "../structs/Pod";
 import Service from "../structs/Service";
 import ServiceTree from "../structs/ServiceTree";
 import Units from "#SRC/js/utils/Units";
+import { getResourceLimits } from "./resourceLimits";
 
 export const ServiceCPU = React.memo(
   ({
@@ -45,14 +46,11 @@ export const ServiceCPU = React.memo(
   }
 );
 
-export function cpuRenderer(
-  service: Service | Pod | ServiceTree
-): React.ReactNode {
-  return (
-    <ServiceCPU
-      id={service.getId()}
-      resource={service.getResources().cpus}
-      limit={service.getResourceLimits().cpus}
-    />
-  );
-}
+type TreeItem = Service | Pod | ServiceTree;
+export const cpuRenderer = (service: TreeItem): React.ReactNode => (
+  <ServiceCPU
+    id={service.getId()}
+    resource={service.getResources().cpus}
+    limit={getResourceLimits(service).cpus}
+  />
+);

--- a/plugins/services/src/js/columns/ServicesTableMemColumn.tsx
+++ b/plugins/services/src/js/columns/ServicesTableMemColumn.tsx
@@ -6,6 +6,7 @@ import Pod from "../structs/Pod";
 import Service from "../structs/Service";
 import ServiceTree from "../structs/ServiceTree";
 import Units from "#SRC/js/utils/Units";
+import { getResourceLimits } from "./resourceLimits";
 
 export const ServiceMem = React.memo(
   ({
@@ -44,14 +45,11 @@ export const ServiceMem = React.memo(
   }
 );
 
-export function memRenderer(
-  service: Service | Pod | ServiceTree
-): React.ReactNode {
-  return (
-    <ServiceMem
-      id={service.getId()}
-      resource={service.getResources().mem}
-      limit={service.getResourceLimits().mem}
-    />
-  );
-}
+type TreeItem = Service | Pod | ServiceTree;
+export const memRenderer = (service: TreeItem): React.ReactNode => (
+  <ServiceMem
+    id={service.getId()}
+    resource={service.getResources().mem}
+    limit={getResourceLimits(service).mem}
+  />
+);

--- a/plugins/services/src/js/columns/resourceLimits.ts
+++ b/plugins/services/src/js/columns/resourceLimits.ts
@@ -1,0 +1,63 @@
+import Pod from "../structs/Pod";
+import Service from "../structs/Service";
+import ServiceTree from "../structs/ServiceTree";
+
+type TreeItem = Service | Pod | ServiceTree;
+type ResourceLimit = number | "unlimited";
+type ResourceLimits = { cpus: ResourceLimit; mem: ResourceLimit };
+
+export const getResourceLimits = (treeItem: TreeItem): ResourceLimits => {
+  if (treeItem instanceof ServiceTree) {
+    return treeItem.reduceItems(
+      (acc: ResourceLimits, item: TreeItem) => {
+        const { cpus, mem } = getResourceLimits(item);
+        acc.cpus = addResourceLimit(cpus, acc.cpus);
+        acc.mem = addResourceLimit(mem, acc.mem);
+        return acc;
+      },
+      { cpus: 0, mem: 0 }
+    );
+  }
+
+  const instances = treeItem.getInstancesCount();
+  if (treeItem instanceof Pod) {
+    const limits = treeItem.spec.containers.reduce(
+      (acc: ResourceLimits, container) => {
+        const { cpus, mem } = getLimits(container);
+        acc.cpus = addResourceLimit(acc.cpus, cpus);
+        acc.mem = addResourceLimit(acc.mem, mem);
+        return acc;
+      },
+      { cpus: 0, mem: 0, ...treeItem.spec.executorResources }
+    );
+    return multInstances(limits, instances);
+  }
+  if (treeItem instanceof Service) {
+    return multInstances(getLimits(treeItem), instances);
+  }
+  throw Error(
+    `could not get resource limits for unexpected row in table: ${treeItem}`
+  );
+};
+
+// TODO: type thing. it's currently either a Service or a Pod.spec.containers[]
+// we currently fall back to using the allocated resources as the limit in
+// case a limit is not set until marathon gives us the correct limits according to whether cGroups are shared or not.
+const getLimits = (thing) => {
+  const { cpus = 0, mem = 0 } = thing.getResources?.() || thing.resources;
+  return {
+    cpus: thing.resourceLimits?.cpus ?? cpus,
+    mem: thing.resourceLimits?.mem ?? mem,
+  };
+};
+
+const multInstances = (limits, instances) => ({
+  cpus: multResourceLimit(limits.cpus, instances),
+  mem: multResourceLimit(limits.mem, instances),
+});
+
+const addResourceLimit = (a: ResourceLimit, b: ResourceLimit) =>
+  a === "unlimited" || b === "unlimited" ? "unlimited" : a + b;
+
+const multResourceLimit = (rl: ResourceLimit, mult: number) =>
+  rl === "unlimited" ? rl : rl * mult;

--- a/plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx
+++ b/plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx
@@ -14,13 +14,15 @@ import {
 
 import CheckboxTable from "#SRC/js/components/CheckboxTable";
 import CollapsingString from "#SRC/js/components/CollapsingString";
-import ExpandingTable from "#SRC/js/components/ExpandingTable";
+import ExpandingTable, { RowOptions } from "#SRC/js/components/ExpandingTable";
 import TimeAgo from "#SRC/js/components/TimeAgo";
 import Units from "#SRC/js/utils/Units";
 import TableUtil from "#SRC/js/utils/TableUtil";
 import DateUtil from "#SRC/js/utils/DateUtil";
 
 import Pod from "../../structs/Pod";
+import PodInstance from "../../structs/PodInstance";
+import PodSpec from "../../structs/PodSpec";
 import PodUtil from "../../utils/PodUtil";
 import InstanceUtil from "../../utils/InstanceUtil";
 import PodTableHeaderLabels from "../../constants/PodTableHeaderLabels";
@@ -40,7 +42,12 @@ const tableColumnClasses = {
   version: "task-table-column-version",
 };
 
-class PodInstancesTable extends React.Component {
+class PodInstancesTable extends React.Component<{
+  filterText: string;
+  instances: PodInstance[];
+  onSelectionChange: (a: {}) => void;
+  pod: Pod;
+}> {
   static defaultProps = {
     filterText: "",
     instances: null,
@@ -55,13 +62,8 @@ class PodInstancesTable extends React.Component {
     onSelectionChange: PropTypes.func,
     pod: PropTypes.instanceOf(Pod).isRequired,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      checkedItems: {},
-    };
-  }
+  state = { checkedItems: {} };
 
   UNSAFE_componentWillReceiveProps(nextProps) {
     const { checkedItems } = this.state;
@@ -71,22 +73,18 @@ class PodInstancesTable extends React.Component {
     // When the `instances` property is changed and we have selected
     // items, re-trigger selection change in order to remove checked
     // entries that are no longer present.
-
-    if (
-      Object.keys(checkedItems).length &&
-      !isEqual(prevInstances, nextInstances)
-    ) {
+    if (!isEqual(prevInstances, nextInstances)) {
       this.triggerSelectionChange(checkedItems, nextProps.instances);
     }
   }
 
-  triggerSelectionChange(checkedItems, instances) {
+  triggerSelectionChange(checkedItems: {}, instances: PodInstance[]) {
     const checkedItemInstances = instances.filter(
       (item) => checkedItems[item.getId()]
     );
     this.props.onSelectionChange(checkedItemInstances);
   }
-  handleItemCheck = (idsChecked) => {
+  handleItemCheck = (idsChecked: number[]) => {
     const checkedItems = {};
 
     idsChecked.forEach((id) => {
@@ -226,17 +224,15 @@ class PodInstancesTable extends React.Component {
     ];
   }
 
-  getContainersWithResources(podSpec, containers, agentAddress) {
-    const children = containers.map((container) => {
+  getContainersWithResources(podSpec: PodSpec, containers, agentAddress) {
+    return containers.map((container) => {
       let containerResources = container.getResources();
 
       // TODO: Remove the following 4 lines when DCOS-10098 is addressed
       const containerSpec = podSpec
         .getContainers()
         .find(({ name }) => container.name === name);
-      if (containerSpec) {
-        containerResources = containerSpec.resources;
-      }
+      containerResources = containerSpec?.resources ?? containerResources;
 
       const addressComponents = container.getEndpoints().map((endpoint, i) => [
         <a
@@ -265,8 +261,6 @@ class PodInstancesTable extends React.Component {
         isHistoricalInstance: container.isHistoricalInstance,
       };
     });
-
-    return children;
   }
 
   getDisabledItemsMap(instances) {
@@ -279,7 +273,7 @@ class PodInstancesTable extends React.Component {
     }, {});
   }
 
-  getTableDataFor(instances, filterText) {
+  getTableDataFor(instances: PodInstance[], filterText) {
     const podSpec = this.props.pod.getSpec();
 
     return instances.map((instance) => {
@@ -305,21 +299,21 @@ class PodInstancesTable extends React.Component {
         updated: instance.getLastUpdated(),
         status: instance.getInstanceStatus(),
         version: podSpec.getVersion(),
-        resourceLimits: { cpu: "peter", mem: "pan" },
+        resourceLimits: { cpu: 0, mem: 0 },
         children,
         podSpec,
       };
     });
   }
 
-  renderWithClickHandler(rowOptions, content, className?) {
+  renderWithClickHandler(rowOptions: RowOptions, content, className?) {
     return (
       <div onClick={rowOptions.clickHandler} className={className}>
         {content}
       </div>
     );
   }
-  renderColumnID = (prop, col, rowOptions = {}) => {
+  renderColumnID = (_prop, col, rowOptions: RowOptions) => {
     const { id: taskID, name: taskName } = col;
     if (!rowOptions.isParent) {
       const id = encodeURIComponent(this.props.pod.getId());
@@ -347,7 +341,7 @@ class PodInstancesTable extends React.Component {
       classes
     );
   };
-  renderColumnLogs = (prop, row, rowOptions = {}) => {
+  renderColumnLogs = (_prop, row, rowOptions: RowOptions) => {
     if (rowOptions.isParent) {
       // Because elements are just stacked we need a spacer
       return <span>&nbsp;</span>;
@@ -366,7 +360,7 @@ class PodInstancesTable extends React.Component {
       </Link>
     );
   };
-  renderColumnAddress = (prop, row, rowOptions = {}) => {
+  renderColumnAddress = (_prop, row, rowOptions: RowOptions) => {
     const { address } = row;
 
     if (rowOptions.isParent) {
@@ -393,7 +387,7 @@ class PodInstancesTable extends React.Component {
 
     return this.renderWithClickHandler(rowOptions, address);
   };
-  renderColumnStatus = (prop, row, rowOptions = {}) => {
+  renderColumnStatus = (_prop, row, rowOptions: RowOptions) => {
     const { status } = row;
 
     return this.renderWithClickHandler(
@@ -405,7 +399,7 @@ class PodInstancesTable extends React.Component {
       />
     );
   };
-  renderColumnHealth = (prop, row, rowOptions = {}) => {
+  renderColumnHealth = (prop, row, rowOptions: RowOptions) => {
     const { status } = row;
     const { healthStatus } = status;
     let tooltipContent = <Trans render="span">Healthy</Trans>;
@@ -432,8 +426,9 @@ class PodInstancesTable extends React.Component {
       </div>
     );
   };
-  renderColumnResource = (prop, row, rowOptions = {}) => {
-    if (rowOptions.hasChildren) {
+  // TODO rendering for pods
+  renderColumnResource = (prop, row, rowOptions: RowOptions) => {
+    if (rowOptions.isParent) {
       const executorResource = row.podSpec?.executorResources?.[prop] ?? 0;
       const childResources = row.children.filter(
         (child) => !child.isHistoricalInstance
@@ -499,13 +494,13 @@ class PodInstancesTable extends React.Component {
       </Tooltip>
     );
   };
-  renderColumnUpdated = (prop, row, rowOptions = {}) => {
+  renderColumnUpdated = (_prop, row, rowOptions: RowOptions) => {
     return this.renderWithClickHandler(
       rowOptions,
       <TimeAgo time={row.updated} />
     );
   };
-  renderColumnVersion = (prop, row, rowOptions = {}) => {
+  renderColumnVersion = (_prop, row, rowOptions: RowOptions) => {
     if (!row.version) {
       return null;
     }
@@ -522,7 +517,7 @@ class PodInstancesTable extends React.Component {
       <span>{localeVersion}</span>
     );
   };
-  renderRegion = (prop, instance, rowOptions) => {
+  renderRegion = (_prop, instance, rowOptions) => {
     if (!rowOptions.isParent) {
       return null;
     }
@@ -535,7 +530,7 @@ class PodInstancesTable extends React.Component {
       </div>
     );
   };
-  renderZone = (prop, instance, rowOptions) => {
+  renderZone = (_prop, instance, rowOptions) => {
     if (!rowOptions.isParent) {
       return null;
     }

--- a/plugins/services/src/js/containers/tasks/TaskTable.tsx
+++ b/plugins/services/src/js/containers/tasks/TaskTable.tsx
@@ -24,6 +24,7 @@ import TaskStates from "../../constants/TaskStates";
 import TaskTableHeaderLabels from "../../constants/TaskTableHeaderLabels";
 import TaskTableUtil from "../../utils/TaskTableUtil";
 import TaskUtil from "../../utils/TaskUtil";
+import { getResourceLimits } from "../../columns/resourceLimits";
 
 const tableColumnClasses = {
   checkbox: "task-table-column-checkbox",
@@ -350,7 +351,8 @@ class TaskTable extends React.Component {
     );
   };
   renderMem = (_, task) => {
-    const memLimit = getService(task.id)?.getResourceLimits().mem;
+    const service = getService(task.id);
+    const memLimit = service && getResourceLimits(service).mem;
     if (memLimit != null && memLimit !== 0) {
       return (
         <Tooltip
@@ -375,7 +377,8 @@ class TaskTable extends React.Component {
     return <span>{Units.formatResource("mem", task.resources.mem)}</span>;
   };
   renderCpus = (_, task) => {
-    const cpusLimit = getService(task.id)?.getResourceLimits().cpus;
+    const service = getService(task.id);
+    const cpusLimit = service && getResourceLimits(service).cpus;
     if (cpusLimit != null && cpusLimit !== 0) {
       return (
         <Tooltip

--- a/plugins/services/src/js/filters/PodInstanceTextFilter.ts
+++ b/plugins/services/src/js/filters/PodInstanceTextFilter.ts
@@ -6,8 +6,6 @@ import DSLFilterTypes from "#SRC/js/constants/DSLFilterTypes";
 export default {
   /**
    * Handle all `id` attribute filters that we can handle.
-   *
-   * @override
    */
   filterCanHandle(filterType) {
     return (

--- a/plugins/services/src/js/structs/Pod.ts
+++ b/plugins/services/src/js/structs/Pod.ts
@@ -243,32 +243,6 @@ export default class Pod extends Service {
     return this._regions;
   }
 
-  getResourceLimits() {
-    const instances = this.getInstancesCount();
-
-    const { cpus, mem } = this.spec.containers.reduce(
-      (accLimits, container) => {
-        const limits = { ...container.resources, ...container.resourceLimits };
-        Object.entries(limits).forEach(([key, limit]) => {
-          accLimits[key] = (accLimits[key] || 0) + limit;
-        });
-        return accLimits;
-      },
-      { ...this.spec.executorResources }
-    );
-
-    return {
-      cpus:
-        typeof cpus === "string" && cpus.match(/unlimited/)
-          ? "unlimited"
-          : cpus * instances,
-      mem:
-        typeof mem === "string" && mem.match(/unlimited/)
-          ? "unlimited"
-          : mem * instances,
-    };
-  }
-
   isDelayed() {
     const queue = this.getQueue();
     return findNestedPropertyInObject(queue, "delay.overdue") === false;

--- a/plugins/services/src/js/structs/PodInstance.ts
+++ b/plugins/services/src/js/structs/PodInstance.ts
@@ -7,15 +7,16 @@ import PodInstanceStatus from "../constants/PodInstanceStatus";
 import PodInstanceState from "../constants/PodInstanceState";
 
 export default class PodInstance extends Item {
-  getAgentAddress() {
+  agentId?: string;
+  getAgentAddress(): string {
     return this.get("agentHostname") || "";
   }
 
-  getContainers() {
+  getContainers(): PodContainer[] {
     return (this.get("containers") || []).map((c) => new PodContainer(c));
   }
 
-  getId() {
+  getId(): string {
     return this.get("id") || "";
   }
 
@@ -23,7 +24,7 @@ export default class PodInstance extends Item {
     return this.getId();
   }
 
-  getStatus() {
+  getStatus(): string {
     // API returns mix of uppercase and lowercase depending on status :(
     return this.get("status").toLowerCase();
   }
@@ -75,11 +76,11 @@ export default class PodInstance extends Item {
     return new Date(this.get("lastChanged"));
   }
 
-  getAgentRegion() {
+  getAgentRegion(): string {
     return this.get("agentRegion") || "";
   }
 
-  getAgentZone() {
+  getAgentZone(): string {
     return this.get("agentZone") || "";
   }
 

--- a/plugins/services/src/js/structs/Service.ts
+++ b/plugins/services/src/js/structs/Service.ts
@@ -8,6 +8,10 @@ import * as ServiceStatus from "../constants/ServiceStatus";
 import ServiceSpec from "./ServiceSpec";
 
 export default class Service extends Item {
+  resourceLimits?: {
+    cpus?: "unlimited" | number;
+    mem?: "unlimited" | number;
+  };
   constructor(...args) {
     super(...args);
     this._regions = undefined;
@@ -128,16 +132,6 @@ export default class Service extends Item {
       mem: (mem + executorMem) * instances,
       gpus: (gpus + executorGpus) * instances,
       disk: (disk + executorDisk) * instances,
-    };
-  }
-
-  getResourceLimits() {
-    const instances = this.getInstancesCount();
-    const { cpus = 0, mem = 0 } = this.resourceLimits || {};
-
-    return {
-      cpus: cpus !== "unlimited" ? cpus * instances : cpus,
-      mem: mem !== "unlimited" ? mem * instances : mem,
     };
   }
 

--- a/plugins/services/src/js/structs/ServiceTree.ts
+++ b/plugins/services/src/js/structs/ServiceTree.ts
@@ -221,10 +221,6 @@ export default class ServiceTree extends Tree {
     );
   }
 
-  getResourceLimits() {
-    return {};
-  }
-
   getStatus() {
     return this.getServiceStatus().displayName;
   }

--- a/src/js/__tests__/__snapshots__/tslint-test.ts.snap
+++ b/src/js/__tests__/__snapshots__/tslint-test.ts.snap
@@ -402,7 +402,6 @@ exports[`tslint snapshot should be up to date 1`] = `
 /plugins/services/src/js/containers/pod-detail/PodHeader.tsx - Missing \\"key\\" prop for element.
 /plugins/services/src/js/containers/pod-detail/PodHeader.tsx - Missing \\"key\\" prop for element.
 /plugins/services/src/js/containers/pod-detail/PodHeader.tsx - don't declare variable actionButtons to return it immediately
-/plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx - don't declare variable children to return it immediately
 /plugins/services/src/js/containers/service-configuration/ServiceConfiguration.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
 /plugins/services/src/js/containers/service-configuration/__tests__/ServiceConfigurationContainer-test.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
 /plugins/services/src/js/containers/service-connection/MesosDNSList.tsx - Missing \\"key\\" prop for element.

--- a/src/js/__tests__/__snapshots__/typecheck-test.ts.snap
+++ b/src/js/__tests__/__snapshots__/typecheck-test.ts.snap
@@ -2038,8 +2038,8 @@ plugins/services/src/js/columns/QuotaOverviewDiskConsumedColumn.tsx: error TS255
 plugins/services/src/js/columns/QuotaOverviewDiskConsumedColumn.tsx: error TS2554: Expected 5 arguments, but got 2.
 plugins/services/src/js/columns/QuotaOverviewMemoryConsumedColumn.tsx: error TS2554: Expected 5 arguments, but got 2.
 plugins/services/src/js/columns/QuotaOverviewMemoryConsumedColumn.tsx: error TS2554: Expected 5 arguments, but got 2.
-plugins/services/src/js/columns/ServicesTableCPUColumn.tsx: error TS2339: Property 'cpus' does not exist on type '{}'.
-plugins/services/src/js/columns/ServicesTableMemColumn.tsx: error TS2339: Property 'mem' does not exist on type '{}'.
+plugins/services/src/js/columns/resourceLimits.ts: error TS2339: Property 'spec' does not exist on type 'Pod'.
+plugins/services/src/js/columns/resourceLimits.ts: error TS2339: Property 'spec' does not exist on type 'Pod'.
 plugins/services/src/js/components/ConfigurationMapTable.tsx: error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
 plugins/services/src/js/components/ConfigurationMapTable.tsx: error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
 plugins/services/src/js/components/DeclinedOffersTable.tsx: error TS2339: Property 'summary' does not exist on type *.
@@ -3053,34 +3053,9 @@ plugins/services/src/js/containers/pod-instances/PodInstancesContainer.tsx: erro
 plugins/services/src/js/containers/pod-instances/PodInstancesContainer.tsx: error TS2339: Property 'dispatcher' does not exist on type 'PodInstancesContainer'.
 plugins/services/src/js/containers/pod-instances/PodInstancesContainer.tsx: error TS2339: Property 'dispatcher' does not exist on type 'PodInstancesContainer'.
 plugins/services/src/js/containers/pod-instances/PodInstancesContainer.tsx: error TS2339: Property 'location' does not exist on type *.
-plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS2339: Property 'pod' does not exist on type *.
-plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS6133: 'prop' is declared but its value is never read.
-plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS2339: Property 'isParent' does not exist on type '{}'.
-plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS2339: Property 'pod' does not exist on type *.
-plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS2339: Property 'isExpanded' does not exist on type '{}'.
-plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS6133: 'prop' is declared but its value is never read.
-plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS2339: Property 'isParent' does not exist on type '{}'.
-plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS2339: Property 'pod' does not exist on type *.
-plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS6133: 'prop' is declared but its value is never read.
-plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS2339: Property 'isParent' does not exist on type '{}'.
-plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS6133: 'prop' is declared but its value is never read.
-plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS2339: Property 'hasChildren' does not exist on type '{}'.
 plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS2322: Type 'string' is not assignable to type 'Direction'.
 plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS2322: Type 'string' is not assignable to type 'Direction'.
-plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS6133: 'prop' is declared but its value is never read.
-plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS6133: 'prop' is declared but its value is never read.
-plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS6133: 'prop' is declared but its value is never read.
-plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS6133: 'prop' is declared but its value is never read.
-plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS2339: Property 'instances' does not exist on type *.
-plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS2339: Property 'pod' does not exist on type *.
-plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS2339: Property 'filterText' does not exist on type *.
-plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS2339: Property 'checkedItems' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS2322: type * is not assignable to type *.
-plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS2339: Property 'checkedItems' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS2339: Property 'instances' does not exist on type *.
-plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS2339: Property 'onSelectionChange' does not exist on type *.
-plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS2339: Property 'instances' does not exist on type *.
 plugins/services/src/js/containers/pod-instances/PodInstancesView.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/containers/pod-instances/PodInstancesView.tsx: error TS2339: Property 'inverseStyle' does not exist on type *.
 plugins/services/src/js/containers/pod-instances/PodInstancesView.tsx: error TS2339: Property 'instances' does not exist on type *.
@@ -4350,10 +4325,7 @@ plugins/services/src/js/structs/Pod.ts: error TS2339: Property '_spec' does not 
 plugins/services/src/js/structs/Pod.ts: error TS2339: Property '_regions' does not exist on type 'Pod'.
 plugins/services/src/js/structs/Pod.ts: error TS2339: Property '_regions' does not exist on type 'Pod'.
 plugins/services/src/js/structs/Pod.ts: error TS2339: Property '_regions' does not exist on type 'Pod'.
-plugins/services/src/js/structs/Pod.ts: error TS2339: Property 'spec' does not exist on type 'Pod'.
-plugins/services/src/js/structs/Pod.ts: error TS2339: Property 'spec' does not exist on type 'Pod'.
 plugins/services/src/js/structs/Service.ts: error TS2339: Property '_regions' does not exist on type 'Service'.
-plugins/services/src/js/structs/Service.ts: error TS2339: Property 'resourceLimits' does not exist on type 'Service'.
 plugins/services/src/js/structs/Service.ts: error TS2339: Property '_regions' does not exist on type 'Service'.
 plugins/services/src/js/structs/Service.ts: error TS2339: Property '_regions' does not exist on type 'Service'.
 plugins/services/src/js/structs/Service.ts: error TS2339: Property '_regions' does not exist on type 'Service'.
@@ -4881,6 +4853,7 @@ src/js/components/ErrorsAlert.tsx: error TS2339: Property 'isPermissive' does no
 src/js/components/ErrorsAlert.tsx: error TS2339: Property 'path' does not exist on type 'never'.
 src/js/components/ErrorsAlert.tsx: error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.
 src/js/components/ErrorsAlert.tsx: error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.
+src/js/components/ExpandingTable.tsx: error TS2339: Property 'expandAll' does not exist on type *.
 src/js/components/ExpandingTable.tsx: error TS2339: Property 'expandedRows' does not exist on type 'Readonly<{}>'.
 src/js/components/ExpandingTable.tsx: error TS2339: Property 'childRowClassName' does not exist on type *.
 src/js/components/ExpandingTable.tsx: error TS2339: Property 'className' does not exist on type *.
@@ -4890,7 +4863,6 @@ src/js/components/ExpandingTable.tsx: error TS2339: Property 'tableComponent' do
 src/js/components/ExpandingTable.tsx: error TS2339: Property 'columns' does not exist on type *.
 src/js/components/ExpandingTable.tsx: error TS2339: Property 'expandedRows' does not exist on type 'Readonly<{}>'.
 src/js/components/ExpandingTable.tsx: error TS2339: Property 'expandedRows' does not exist on type 'Readonly<{}>'.
-src/js/components/ExpandingTable.tsx: error TS2339: Property 'expandAll' does not exist on type *.
 src/js/components/FilterBar.tsx: error TS2339: Property 'leftChildrenClass' does not exist on type *.
 src/js/components/FilterBar.tsx: error TS2339: Property 'rightChildrenClass' does not exist on type *.
 src/js/components/FilterBar.tsx: error TS2339: Property 'className' does not exist on type *.

--- a/src/js/components/ExpandingTable.tsx
+++ b/src/js/components/ExpandingTable.tsx
@@ -7,6 +7,13 @@ import Util from "../utils/Util";
 
 const WHITESPACE = "\u00A0";
 
+export type RowOptions = {
+  hasChildren: boolean;
+  isExpanded: boolean;
+  isParent: boolean;
+  clickHandler: () => {};
+};
+
 class ExpandingTable extends React.Component {
   static defaultProps = {
     alignCells: "top",

--- a/tests/pages/nodes/node/HealthTab-cy.js
+++ b/tests/pages/nodes/node/HealthTab-cy.js
@@ -1,9 +1,6 @@
 describe("Node Health Tab [0fa]", () => {
   beforeEach(() => {
-    cy.configureCluster({
-      mesos: "1-task-healthy",
-      nodeHealth: true,
-    });
+    cy.configureCluster({ mesos: "1-task-healthy", nodeHealth: true });
   });
 
   context("Navigate to tab [0fb]", () => {


### PR DESCRIPTION
due to the former implementation calculating resource limits in a couple places
there were inconsistencies in display.
we now calculate and display the allocated resource along with its aggregated
limit (as we formerly ignored the number of instances in one place and did not
properly multiply it in another case...).

also i could not help it and added a couple signatures to reduce the number of
type errors.

closes D2IQ-66986