### PR TITLE
chore: use latest stable release of cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN set -x \
   && apt-get update \
   && apt-get install -y awscli lsof wget jq curl rsync openssh-client \
   && apt-get clean \
-  && curl -o /usr/local/bin/dcos https://downloads.dcos.io/cli/testing/binaries/dcos/linux/x86-64/master/dcos \
+  && curl -o /usr/local/bin/dcos https://downloads.dcos.io/cli/releases/binaries/dcos/linux/x86-64/latest/dcos \
   && chmod +x /usr/local/bin/dcos \
   && npm install -g dogapi
 


### PR DESCRIPTION
currently seeing errors on CI like these:

```
dcos cluster setup http://ui-ee-PR4659-1-184060763.us-west-2.elb.amazonaws.com --provider=dcos-users --insecure

Continuing cluster setup with: http://ui-ee-pr4659-1-184060763.us-west-2.elb.amazonaws.com

Error: no cluster is attached
```

this is trying to fix that.
