### PR TITLE
chore: try to fix ci

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,10 +108,18 @@ pipeline {
             TF_VAR_cluster_name = "ui-oss-${cluster_suffix}-${BUILD_NUMBER}"
             TF_VAR_custom_dcos_download_path = "https://downloads.dcos.io/dcos/testing/master/dcos_generate_config.sh"
             TF_VAR_variant = "open"
+            DCOS_VERBOSITY = "2"
           }
           steps {
             withCredentials([ aws_id, aws_key ]) {
-              sh '''
+              sh '''#!/bin/bash
+                dcos --version
+                echo "--------------------"
+                dcos --version
+                dcos --version
+                dcos --version
+                dcos --version
+                dcos --version
                 export CLUSTER_URL=$(cd scripts/terraform && ./up.sh | tail -n1)
 
                 . scripts/utils/load_auth_env_vars
@@ -146,7 +154,7 @@ pipeline {
           }
           steps {
             withCredentials([ aws_id, aws_key, string(credentialsId: "8667643a-6ad9-426e-b761-27b4226983ea", variable: "TF_VAR_license_key")]) {
-              sh '''
+              sh '''#!/bin/bash
                 rsync -aH ./system-tests/ ./system-tests-ee/
                 rsync -aH ./scripts/terraform/ ./scripts/terraform-ee/
                 export CLUSTER_URL=$(cd scripts/terraform-ee && ./up.sh | tail -n1)

--- a/system-tests-ee/ee-ldap-users/_scripts/setup
+++ b/system-tests-ee/ee-ldap-users/_scripts/setup
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 if [ -z "$(dcos package list | grep dcos-enterprise-cli)" ]; then
-  dcos package install --cli dcos-enterprise-cli --yes
+  dcos package install dcos-enterprise-cli --yes
 fi

--- a/system-tests-ee/ee-services/_scripts/setup
+++ b/system-tests-ee/ee-services/_scripts/setup
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ -z "$(dcos package list | grep dcos-enterprise-cli)" ]; then
-  dcos package install --cli dcos-enterprise-cli --yes
+  dcos package install dcos-enterprise-cli --yes
 fi
 
 # Create a service group for the test

--- a/system-tests-ee/ee-services/_scripts/teardown
+++ b/system-tests-ee/ee-services/_scripts/teardown
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Remove the service group for the test
-dcos marathon group remove --force /$TEST_UUID
+dcos marathon group remove /$TEST_UUID
 
 # Remove the secret with this UUID (and don't fail if it doesn't exist)
 dcos security secrets delete /$TEST_UUID-secret || exit 0

--- a/system-tests/dashboard/_scripts/teardown
+++ b/system-tests/dashboard/_scripts/teardown
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Remove the service group for the test
-dcos marathon group remove --force /$TEST_UUID
+dcos marathon group remove /$TEST_UUID

--- a/system-tests/services/_scripts/teardown
+++ b/system-tests/services/_scripts/teardown
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Remove the service group for the test
-dcos marathon group remove --force /$TEST_UUID
+dcos marathon group remove /$TEST_UUID


### PR DESCRIPTION
progress: 
- seems to make things better... the actual error is gone and tests now seem to be running somewhat.
- dcos-cli tries to download `https://downloads.dcos.io/cli/testing/plugins/dcos-core-cli/linux/x86-64/dcos-core-cli-2.2-patch.x.zip` which gives access denied. there's a 2.1 version though 🤔 
- tried to convince CLI's CI to place according releases to the places dcos-cli is looking for them.