### PR TITLE
chore: get rid of most common flake

### DIFF
--- a/system-tests/_support/index.js
+++ b/system-tests/_support/index.js
@@ -64,7 +64,7 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add("retype", { prevSubject: true }, (subject, text) =>
-  cy.wrap(subject).type(`{selectall}${text}`)
+  cy.wrap(subject).type(`{selectall}{backspace}${text}`)
 );
 
 /**

--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -92,7 +92,9 @@ describe("Service Actions", () => {
 
       cy.log("opens confirm after edits");
       clickHeaderAction("Edit");
-      cy.get('.modal .menu-tabbed-container input[name="name"]').type("elast");
+      cy.get('.modal .menu-tabbed-container input[name="name"]').retype(
+        "elast"
+      );
       cancel();
       cy.get(".modal-small").should("to.have.length", 1);
       discard();
@@ -100,7 +102,9 @@ describe("Service Actions", () => {
 
       cy.log("it stays in the edit modal after cancelling confirmation");
       clickHeaderAction("Edit");
-      cy.get('.modal .menu-tabbed-container input[name="name"]').type("elast");
+      cy.get('.modal .menu-tabbed-container input[name="name"]').retype(
+        "elast"
+      );
       cancel();
       cy.get(".modal-small button").contains("Cancel").click();
 
@@ -159,10 +163,9 @@ describe("Service Actions", () => {
         .should("to.have.length", 1);
 
       cy.log("change JSON editor contents when form content change");
-      cy.get('.modal .menu-tabbed-container input[name="name"]').type(
-        `{selectall}elast`
+      cy.get('.modal .menu-tabbed-container input[name="name"]').retype(
+        `elast`
       );
-
       cy.get(".modal .modal-full-screen-side-panel .ace_line")
         .contains("elast")
         .should("to.have.length", 1);


### PR DESCRIPTION
we're seeing weird test results stating that cypress sees things like "east"
instead of "elast". let's try to clear the input every time before entering
something new. it should not make a difference with missed characters but the
past has proven that it does... cypress... :shrug:
