### PR TITLE
fix: add no-cache to dcos-version request

### DIFF
--- a/src/js/stores/dcos-version.ts
+++ b/src/js/stores/dcos-version.ts
@@ -22,9 +22,9 @@ type DCOSData = {
   hasQuotaSupport: boolean;
 };
 
-export default fromFetch(
-  `${Config.rootUrl}/dcos-metadata/dcos-version.json`
-).pipe(
+export default fromFetch(`${Config.rootUrl}/dcos-metadata/dcos-version.json`, {
+  cache: "no-cache",
+}).pipe(
   switchMap((response) =>
     from(
       response.json().then((json) => ({


### PR DESCRIPTION
we used to add a `?ts=UNIX_TIMESTAMP` to every request that's routed through
request-util. by changing implementation to use rxjs we removed that and now had
an instance of a caching-issue while updating a soak-cluster.

to fix the issue, we add a no-cache in this place (which is the only place for
now) and will extract a new request-utility to handle cache-invalidation for all
requests.
