### PR TITLE
fix: actually hide cpu limits removed via the forms

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/resourceLimits.ts
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/resourceLimits.ts
@@ -5,21 +5,21 @@ const resourceLimitReducer = (resourceField: string, parseFn = parseInt) => {
     // so limit is becoming in an ideal case `limits` and resource is becoming `cpus`
     const [limit, resource] =
       path.slice(-3)[0] === "limits" ? path.slice(-3) : path.slice(-2);
-    const numberValue = parseFn(value);
 
     // if the fields are not what we are looking for exit early.
     if (limit !== "limits" || resourceField !== resource) {
       return state;
     }
+
+    const unlimited = value === "unlimited" || value === true;
+    // display the cached value if unlimited was selected in the meantime
+    let numberValue: number | null = unlimited ? state?.value : parseFn(value);
+    // restore the cached value when deselecting unlimited
+    numberValue = value === false ? state?.value : numberValue;
+    numberValue = isNaN(numberValue) ? null : numberValue;
+
     // if the value is a number (not NaN) we return the new value and unlimited false.
-    return !isNaN(numberValue)
-      ? { value: numberValue, unlimited: false }
-      : // if the value is NaN it is either a bool or a string containing `unlimited` in that
-        // in that case we do return the old nummeric value and set unlimited to a boolean.
-        {
-          value: state?.value || null,
-          unlimited: value === "unlimited" || value === true,
-        };
+    return { value: numberValue, unlimited };
   };
 };
 


### PR DESCRIPTION
if you deleted a cpu limit via the service form it would actually be removed
from the JSON but the value cached in the form state would still re-appear
again.

i consider this an ugly, yet the only feasible (due to time constraints)
solution as we don't have a proper representation of the form within the "state"
(which is called a "Batch" holding "Transactions"). thus we now
figure out that while reducing a new state, we're at a "Transaction" that represents unchecking the "unlimited" checkbox (that's what
`value === false` represents). only in this case we'll now reintroduce the value
that's been stored in the state - which has formerly been put in whenever the parsing function did not succeed - like when you want to delete a value from the form.

what i actually want to say here is that our forms are accidentally complex -
and i mean as complex as having to follow the dataflow through 8 files upwards
(while evaluating some conditionals in order to figure out what file to go
through next) to find this place which is only responsible to calculate the
value to be shown in the form field from the aforementioned "Batch".

closes COPS-6202

----------

here's a video of our new-won freedom to delete the cpu limit in the form: 

![screencast 2020-06-03 20-29-21](https://user-images.githubusercontent.com/300861/83675322-178fae80-a5d9-11ea-92e7-7e35fd65813b.gif)

much wow!