### PR TITLE
D2IQ-69177 fix: restore limits when editing a service

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/resourceLimits.ts
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/resourceLimits.ts
@@ -14,24 +14,24 @@ function resourceLimitReducer(resourceField: string, parseFn = parseInt) {
     const [limit, resource] =
       path.slice(-3)[0] === "limits" ? path.slice(-3) : path.slice(-2);
 
-    const numberValue =
-      typeof value === "string" && value !== "unlimited"
-        ? parseFn(value)
-        : null;
-
     // if the fields are not what we are looking for exit early.
     if (limit !== "limits" || resourceField !== resource) {
       return state;
     }
+
+    const unlimited = value === "unlimited" || value === true;
+    // display the cached value if unlimited was selected in the meantime
+    let numberValue: number | null = unlimited ? this.cache : parseFn(value);
+    // restore the cached value when deselecting unlimited
+    numberValue = value === false ? this.cache : numberValue;
+    numberValue = isNaN(numberValue) ? null : numberValue;
 
     // if the value is not a number we return either null or `"unlimited"`.
     // This is necessary to since the type is `number | "unlimited"`
     // if the value is a `false` this means that unlimited was disabled and we use the old
     // number from the cache. This is a toggle functionality.
     if (typeof value === "boolean" || value === "unlimited") {
-      return value === false
-        ? this.cache || null
-        : (value === "unlimited" || value === true) && "unlimited";
+      return value === false ? this.cache || null : "unlimited";
     }
 
     // If the value is a number which cache it and return the cache.

--- a/src/js/__tests__/__snapshots__/typecheck-test.ts.snap
+++ b/src/js/__tests__/__snapshots__/typecheck-test.ts.snap
@@ -4070,6 +4070,10 @@ plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Containers-t
 plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Containers-test.ts: error TS2769: No overload matches this call.
 plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Containers-test.ts: error TS2769: No overload matches this call.
 plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Containers-test.ts: error TS2769: No overload matches this call.
+plugins/services/src/js/reducers/serviceForm/JSONReducers/resourceLimits.ts: error TS2345: Argument of type * is not assignable to parameter of type 'string'.
+plugins/services/src/js/reducers/serviceForm/JSONReducers/resourceLimits.ts: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/reducers/serviceForm/JSONReducers/resourceLimits.ts: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/reducers/serviceForm/JSONReducers/resourceLimits.ts: error TS2345: Argument of type * is not assignable to parameter of type 'number'.
 plugins/services/src/js/reducers/serviceForm/MultiContainerConstraints.ts: error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
 plugins/services/src/js/reducers/serviceForm/MultiContainerHealthChecks.ts: error TS2345: Argument of type 'Transaction' is not assignable to parameter of type 'never'.
 plugins/services/src/js/reducers/serviceForm/MultiContainerHealthChecks.ts: error TS2345: Argument of type 'Transaction' is not assignable to parameter of type 'never'.


### PR DESCRIPTION
while the form would show you the resource limits you set for a service, the
JSON editor is not picking those up. this ultimately leads to those values being
forgotten if you just hit "edit service" -> "save".

this change helps the JSON editor pick up the current values.
