### PR TITLE
fix: quickfix COPS-6085

### DIFF
--- a/plugins/secrets/reducers/Container.ts
+++ b/plugins/secrets/reducers/Container.ts
@@ -1,8 +1,7 @@
 import Transaction from "#SRC/js/structs/Transaction";
-
 import { JSONSingleContainerReducer as volumesReducer } from "./Volumes";
-
 import { ContainerDefinition, SingleContainerReducerContext } from "./types";
+import { uniqBy } from "lodash";
 
 export function JSONSingleContainerReducer(
   this: SingleContainerReducerContext,
@@ -16,10 +15,8 @@ export function JSONSingleContainerReducer(
     this.secrets = [];
   }
   const secretVolumes = volumesReducer.call(this, state, action);
-  const existingVolumes =
-    state != null && state.volumes != null ? state.volumes : [];
-  return {
-    ...state,
-    volumes: existingVolumes.concat(secretVolumes),
-  };
+  const existingVolumes = state?.volumes || [];
+  const volumes = existingVolumes.concat(secretVolumes);
+
+  return { ...state, volumes: uniqBy(volumes, "containerPath") };
 }


### PR DESCRIPTION
the JSON-editor somehow shows duplicated volumes in the production environment.
yes, that's right: you can't reproduce this in the usual development setup.

you could (currently) run a prod build locally on port 4201 like so:

```
npm run build && cd dist && npx http-server -sp "4201" --proxy "http://localhost:4200" --proxy-secure=false
```

to reproduce, create a file based secret with the name "keytab" and start the
following service:

```
{
    "id": "secret-file",
    "cmd": "cat $MESOS_SANDBOX/secret_file ; sleep 600; echo ''",
    "container": {
        "type": "MESOS",
        "volumes": [
            {
                "containerPath": "secret_file",
                "secret": "super_secret"
            }
        ]
    },
    "secrets": {
        "super_secret": {
            "source": "keytab"
        }
    }
}
```


------------------------------

this fixes the issue by deduping the volumes by `containerPath` (as at a single
path there should only be a single volume, right?).

i'd like a better that completely overhauled the form-architecture. currently there are "contexts" on reducers (`.call(this, [...])`) and their behaviour seems to differ in dev/prod for minification/uglification-reasons. we should at least get rid of those contexts that are obsolete now that we merged all enterprise-plugins into the codebase and can add them conditionally more easily. 

We could also get rid of the "Batch" (which effectively duplicates redux' behaviour and causes trouble if you edit form elements really often) along those efforts.

closes COPS-6085 D2IQ-67819

