### PR TITLE
fix: don't make up job-groups

### DIFF
--- a/plugins/jobs/src/js/types/JobConnection.ts
+++ b/plugins/jobs/src/js/types/JobConnection.ts
@@ -38,7 +38,7 @@ export function JobConnectionTypeResolver(
 
   const namespacedResponse: MetronomeJobResponse[] =
     path.length > 0
-      ? response.filter(({ id }) => id.startsWith(path.join(".")))
+      ? response.filter(({ id }) => id.startsWith(path.join(".") + "."))
       : response;
 
   const filteredResponse: MetronomeJobResponse[] =

--- a/tests/_fixtures/metronome/jobs.json
+++ b/tests/_fixtures/metronome/jobs.json
@@ -334,5 +334,108 @@
         ]
       }
     ]
+  },
+  {
+    "id": "some.group.foo",
+    "description": "Foo Description",
+    "labels": {},
+    "schedules": [],
+    "run": {
+      "cpus": 1,
+      "mem": 1,
+      "disk": 1,
+      "artifacts": [],
+      "cmd": "/beta",
+      "args": [],
+      "user": "marathon",
+      "env": {},
+      "docker": {
+        "image": "mesosphere/beta"
+      },
+      "volumes": [],
+      "restart": {
+        "policy": "NEVER",
+        "activeDeadlineSeconds": 120
+      }
+    },
+    "historySummary": {
+      "successCount": 1,
+      "failureCount": 1,
+      "lastSuccessAt": "1990-01-02T00:00:00Z",
+      "lastFailureAt": "1989-03-01T00:10:15.957Z"
+    },
+    "activeRuns": [
+      {
+        "id": "beta.1990-01-03t00:00:00z-1",
+        "jobId": "beta",
+        "status": "ACTIVE",
+        "createdAt": "1990-01-03t00:00:00z-1",
+        "tasks": [
+          {
+            "id": "beta.1990-01-03t00:00:00z-1.68d65242-1838-11e6-8d2d-5ec97000bce0",
+            "startedAt": "1990-01-03T00:00:04.919Z",
+            "status": "TASK_STARTED"
+          },
+          {
+            "id": "dbeta.1990-01-03t00:00:00z-1.68d65242-1838-11e6-8d2d-5ec97000bce0",
+            "startedAt": "1990-01-03T00:00:04.919Z",
+            "completedAt": "1990-01-03T00:00:09.919Z",
+            "status": "TASK_FAILED"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "some.groupzi.woops",
+    "description": "woops should not appear when looking at `some.group`",
+    "labels": {},
+    "schedules": [],
+    "run": {
+      "cpus": 1,
+      "mem": 1,
+      "disk": 1,
+      "artifacts": [],
+      "placement": {},
+      "cmd": "/beta",
+      "args": [],
+      "user": "marathon",
+      "env": {},
+      "docker": {
+        "image": "mesosphere/beta"
+      },
+      "volumes": [],
+      "restart": {
+        "policy": "NEVER",
+        "activeDeadlineSeconds": 120
+      }
+    },
+    "historySummary": {
+      "successCount": 1,
+      "failureCount": 1,
+      "lastSuccessAt": "1990-01-02T00:00:00Z",
+      "lastFailureAt": "1989-03-01T00:10:15.957Z"
+    },
+    "activeRuns": [
+      {
+        "id": "beta.1990-01-03t00:00:00z-1",
+        "jobId": "beta",
+        "status": "ACTIVE",
+        "createdAt": "1990-01-03t00:00:00z-1",
+        "tasks": [
+          {
+            "id": "beta.1990-01-03t00:00:00z-1.68d65242-1838-11e6-8d2d-5ec97000bce0",
+            "startedAt": "1990-01-03T00:00:04.919Z",
+            "status": "TASK_STARTED"
+          },
+          {
+            "id": "dbeta.1990-01-03t00:00:00z-1.68d65242-1838-11e6-8d2d-5ec97000bce0",
+            "startedAt": "1990-01-03T00:00:04.919Z",
+            "completedAt": "1990-01-03T00:00:09.919Z",
+            "status": "TASK_FAILED"
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/tests/pages/jobs/JobsFilter-cy.js
+++ b/tests/pages/jobs/JobsFilter-cy.js
@@ -1,17 +1,14 @@
 describe("Job Search Filters", () => {
   context("Filters jobs table", () => {
     beforeEach(() => {
-      cy.configureCluster({
-        mesos: "1-for-each-health",
-        nodeHealth: true,
-      });
+      cy.configureCluster({ mesos: "1-for-each-health", nodeHealth: true });
       cy.visitUrl({ url: "/jobs/overview" });
     });
 
     it("filters correctly on search string", () => {
-      cy.get("tbody tr:visible").should("to.have.length", 3);
+      cy.get("tbody tr:visible").should("to.have.length", 4);
       cy.get(".filter-input-text").type("foo");
-      cy.get("tbody tr:visible").should("to.have.length", 1);
+      cy.get("tbody tr:visible").should("to.have.length", 2);
     });
 
     it("sets the correct search string filter query params", () => {
@@ -33,7 +30,7 @@ describe("Job Search Filters", () => {
           const queries = href.split("?")[1];
           expect(queries).to.equal(undefined);
         });
-      cy.get("tbody tr:visible").should("to.have.length", 3);
+      cy.get("tbody tr:visible").should("to.have.length", 4);
     });
   });
 });

--- a/tests/pages/jobs/JobsOverview-cy.js
+++ b/tests/pages/jobs/JobsOverview-cy.js
@@ -1,15 +1,14 @@
 describe("Jobs Overview", () => {
+  beforeEach(() => {
+    cy.configureCluster({ mesos: "1-for-each-health", nodeHealth: true });
+  });
   context("Jobs page loads correctly", () => {
     beforeEach(() => {
-      cy.configureCluster({
-        mesos: "1-for-each-health",
-        nodeHealth: true,
-      });
       cy.visitUrl({ url: "/jobs/overview" });
     });
 
     it("displays jobs overview page", () => {
-      cy.get("tbody tr:visible").should("to.have.length", 3);
+      cy.get("tbody tr:visible").should("to.have.length", 4);
     });
 
     it("does not show status or last run for groups", () => {
@@ -21,15 +20,15 @@ describe("Jobs Overview", () => {
 
     it("displays the proper job status", () => {
       cy.get("tbody tr:visible").should(($tableRows) => {
-        expect($tableRows[1].children[1].textContent).to.equal("Scheduled");
-        expect($tableRows[2].children[1].textContent).to.equal("Running");
+        expect($tableRows[2].children[1].textContent).to.equal("Scheduled");
+        expect($tableRows[3].children[1].textContent).to.equal("Running");
       });
     });
 
     it("displays the proper last run status", () => {
       cy.get("tbody tr:visible").should(($tableRows) => {
-        expect($tableRows[1].children[2].textContent).to.equal("Failed");
-        expect($tableRows[2].children[2].textContent).to.equal("Success");
+        expect($tableRows[2].children[2].textContent).to.equal("Failed");
+        expect($tableRows[3].children[2].textContent).to.equal("Success");
       });
     });
 
@@ -39,5 +38,11 @@ describe("Jobs Overview", () => {
       // but not group-foo.
       cy.get("tbody tr:visible").should("to.have.length", 2);
     });
+  });
+
+  it("does not make up group names (COPS-6139)", () => {
+    cy.visitUrl({ url: "/jobs/overview/some.group" });
+    cy.get("tbody tr:visible").contains("foo");
+    cy.get("tbody tr:visible").should("not.contain", "woops");
   });
 });


### PR DESCRIPTION
before we render jobs, we expect our graphql-server to only give us jobs that
are considered to be within the group we're currently looking at. we're grouping
by spliting job-ids by "." - everything except for the last segment is a group,
while the last segment is the jobs "name" (in the context of this code).

unfortunately our graphql-server (yes, we have a graphql-server bundled with our
application. i don't think it's making code more maintainable btw) filtered jobs
like so:

imagine there're the jobs `foo.bar.baz.blorgh` and `foo.barbar.blorgh` and we're
currently looking at the `foo.bar` group. we're now filtering out all jobs that
don't start with that `path` (`["foo", "bar"]`). we did that with a
`startsWith`, so `foo.barbar.blorgh` was be considered to be in that group. now
the rendering takes over and displays all the "third-level" groups and jobs. in
this case we'd see `baz` (being the third-level of `foo.bar.baz.blorgh`) AND
`blorgh` (being the third-level of `foo.barbar.blorgh`), while we actually don't
want that group to show up.

in code:
```
foo.bar
foo.bar.baz.blorgh <- starts with foo.bar
foo.barbar.blorgh  <- starts with foo.bar (the error)

```

this fix seeks to compare differently:

```
foo.bar.           <- notice the dot at the end
foo.bar.baz.blorgh <- starts with foo.bar.
foo.barbar.blorgh  <- does not start with foo.bar. :woohoo:

```

closes COPS-6139

## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
