### PR TITLE
fix: invalid CLI download URL

### DIFF
--- a/src/js/components/modals/CliInstallModal.tsx
+++ b/src/js/components/modals/CliInstallModal.tsx
@@ -73,8 +73,7 @@ class CliInstallModal extends React.Component {
     const dcosVersion = MetadataStore.parsedVersion;
     const cliVersion =
       dcosVersion.substring(0, 2) === "1." ? `dcos-${dcosVersion}` : "latest";
-
-    const downloadUrl = `https://downloads.dcos.io/cli/releases/binaries/dcos/${osTypes[selectedOS]}/x86-64/${cliVersion}/dcos`;
+    const downloadUrl = `https://downloads.dcos.io/binaries/cli/${osTypes[selectedOS]}/x86-64/${cliVersion}/dcos`;
     if (selectedOS === "Windows") {
       return this.getWindowsInstallInstruction(clusterUrl, downloadUrl);
     }


### PR DESCRIPTION
Bug was introduced in 00a2d7ca33a5fdb16322b4a7abb951c2ee183689 (#4133)
because download path was changed to not backward compatible path.

https://jira.d2iq.com/browse/COPS-6360

## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
