### PR TITLE
chore: fix yet another common flake

### DIFF
--- a/system-tests/services/_scripts/teardown
+++ b/system-tests/services/_scripts/teardown
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Remove the service group for the test
-dcos marathon group remove --force /$TEST_UUID
+dcos marathon group remove --force /

--- a/system-tests/universe/_scripts/teardown
+++ b/system-tests/universe/_scripts/teardown
@@ -7,9 +7,5 @@ from subprocess import check_output
 packages = json.loads(check_output('dcos package list --json', shell=True).decode('utf-8'))
 for package in packages:
   for appId in package['apps']:
-    if appId.startswith(("/%s" % os.environ['TEST_UUID'])):
-      print("Removing package %s" % appId)
-      check_output('dcos package uninstall %s --app-id=%s --yes' % (package['name'], appId), shell=True)
-    elif appId == '/confluent-kafka' or appId == '/bitbucket':
-      print("Removing package %s" % appId)
-      check_output('dcos package uninstall %s --app-id=%s --yes' % (package['name'], appId), shell=True)
+    print("Removing package %s" % appId)
+    check_output('dcos package uninstall %s --app-id=%s --yes' % (package['name'], appId), shell=True)


### PR DESCRIPTION
as we try to install the same services multiple times, there are race
conditions.

also there's a common error when trying to look at the plan. therefore we now
install confluent-kafka right in the first step, so it has some time to spin up
before the test.

