### PR TITLE
chore: fix another flake

### DIFF
--- a/tests/enterprise-plugins/organization/service-accounts/ServiceAccounts-cy.js
+++ b/tests/enterprise-plugins/organization/service-accounts/ServiceAccounts-cy.js
@@ -88,27 +88,13 @@ describe("Service Accounts", () => {
           mesos: "1-task-healthy",
           plugins: "organization",
         });
-
-        cy.route(
-          "DELETE",
-          /acs\/api\/v1\/users\/myserviceaccount(\?_timestamp=[0-9]+)?$/,
-          ""
-        );
-
-        cy.route(
-          "PUT",
-          /acs\/api\/v1\/users\/myserviceaccount(\?_timestamp=[0-9]+)?$/,
-          ""
-        );
       });
 
       it("Shows unanchored errors for unknown secret errors", () => {
         cy.visitUrl({ url: "/organization/service-accounts" });
 
         cy.get("button.button-primary-link").click();
-
         cy.get('.form-control[name="uid"]').type("myserviceaccount");
-
         cy.get(".modal-footer button.button-primary")
           .contains("Create")
           .click();


### PR DESCRIPTION
in case the account or secret could not be created, we show a generic error.
if the account could be created but the secret creation fails with a 404, we get
a more specific error (which we don't want here!).

now we always fail with the account creation right away.

the test was failing for good reason - i wonder how that can be a flake.
i suspect the nested beforeEach-blocks that override each others routes may be
troublesome and "broke" because of the recent cypress update. i saw a note about
fixtures now being loaded async. maybe that effects the order in which the
route-calls register. last one wins :/

