### PR TITLE
feat: display dependencies on job list and detail view

### DIFF
--- a/plugins/jobs/src/js/JobDetailPageContainer.tsx
+++ b/plugins/jobs/src/js/JobDetailPageContainer.tsx
@@ -43,6 +43,9 @@ const getGraphQL = (id) =>
           path
           command
           schedules
+          dependencies {
+            id
+          }
           cpus
           description
           mem

--- a/plugins/jobs/src/js/components/JobsFormConfig.tsx
+++ b/plugins/jobs/src/js/components/JobsFormConfig.tsx
@@ -13,6 +13,7 @@ import ParametersConfigSection from "./config/ParametersConfigSection";
 import ScheduleConfigSection from "./config/ScheduleConfigSection";
 import LabelsConfigSection from "./config/LabelsConfigSection";
 import EnvVarConfigSection from "./config/EnvVarConfigSection";
+import DependenciesConfigSection from "./config/DependenciesConfigSection";
 
 const PRIORITIES_PAD_NUMBER = 100;
 const DEFAULT_DISPLAY_COMPONENTS = [
@@ -25,6 +26,7 @@ const DEFAULT_DISPLAY_COMPONENTS = [
       ScheduleConfigSection,
       LabelsConfigSection,
       EnvVarConfigSection,
+      DependenciesConfigSection,
     ],
   },
 ];

--- a/plugins/jobs/src/js/components/config/DependenciesConfigSection.tsx
+++ b/plugins/jobs/src/js/components/config/DependenciesConfigSection.tsx
@@ -1,0 +1,38 @@
+import * as React from "react";
+import { Trans } from "@lingui/macro";
+
+import BaseConfig, { Value } from "#SRC/js/components/BaseConfig";
+import { JobOutput } from "../form/helpers/JobFormData";
+import { BorderedList } from "@dcos/ui-kit";
+import { Link } from "react-router";
+
+export default class DependenciesConfigSection extends BaseConfig<JobOutput> {
+  shouldExcludeItem(_: Value<JobOutput>) {
+    return false && !!this.props.config.dependencies?.length;
+  }
+
+  getMountType() {
+    return "CreateJob:JobConfigDisplay:App:Dependencies";
+  }
+
+  getDefinition() {
+    return {
+      tabViewID: "dependencies",
+      values: [
+        { heading: <Trans id="Dependencies" />, headingLevel: 1 },
+        {
+          key: "dependencies",
+          render: (deps: Array<{ id: string }>) => (
+            <BorderedList tag="ul">
+              {deps.map(({ id }) => (
+                <li key={id}>
+                  <Link to={`/jobs/detail/${id}`}>{id}</Link>
+                </li>
+              ))}
+            </BorderedList>
+          ),
+        },
+      ],
+    };
+  }
+}

--- a/plugins/jobs/src/js/components/config/EnvVarConfigSection.tsx
+++ b/plugins/jobs/src/js/components/config/EnvVarConfigSection.tsx
@@ -19,10 +19,7 @@ interface KeyValue {
 
 class EnvVarConfigSection extends BaseConfig<JobOutput> {
   public shouldExcludeItem(_: Value<JobOutput>) {
-    const {
-      run: { env },
-    } = this.props.config;
-
+    const { env } = this.props.config.run;
     return (
       env == null ||
       Object.keys(env).filter((key) => typeof env[key] !== "object").length ===

--- a/plugins/jobs/src/js/components/form/helpers/JobFormData.ts
+++ b/plugins/jobs/src/js/components/form/helpers/JobFormData.ts
@@ -35,6 +35,7 @@ export type JobOutputData = Job<JobLabels, JobEnv, JobSecrets>;
 
 export interface JobOutput extends JobOutputData {
   schedules?: JobSchedule[];
+  dependencies?: Array<{ id: string }>;
 }
 export interface JobAPIOutput {
   job: JobOutputData;

--- a/plugins/jobs/src/js/types/Job.ts
+++ b/plugins/jobs/src/js/types/Job.ts
@@ -42,6 +42,7 @@ export interface Job {
   command: string;
   cpus: number;
   description: string | null;
+  dependencies?: Array<{ id: string }>;
   disk: number;
   docker: JobDocker | null;
   id: string;
@@ -66,6 +67,10 @@ ${JobStatusSchema}
 ${JobDockerSchema}
 ${JobScheduleConnectionSchema}
 
+type Dependency {
+  id: String!
+}
+
 type Job {
   activeRuns: JobRunConnection
   command: String!
@@ -83,6 +88,7 @@ type Job {
   name: String!
   path: [String]!
   schedules: ScheduleConnection!
+  dependencies: [Dependency]
   scheduleStatus: JobStatus!
 }
 `;
@@ -94,6 +100,7 @@ export function JobTypeResolver(job: MetronomeGenericJobResponse): Job {
       : null,
     command: job.run.cmd,
     cpus: job.run.cpus,
+    dependencies: job.dependencies,
     description: isMetronomeJobDetailResponse(job) ? job.description : null,
     disk: job.run.disk,
     docker:

--- a/src/js/events/MetronomeClient.ts
+++ b/src/js/events/MetronomeClient.ts
@@ -13,6 +13,7 @@ export interface GenericJobResponse {
   id: string;
   labels: Record<string, string>;
   activeRuns?: ActiveJobRun[];
+  dependencies?: Array<{ id: string }>;
   run: {
     cpus: number;
     mem: number;

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -18,7 +18,8 @@ setupWorker(
   rest.get("/mesos/master/state-summary", fx("marathon-1-task/summary")),
   rest.get("/metadata", fx("dcos/metadata")),
   rest.get("/navstar/lashup/key", (_, res, ctx) => res(ctx.json({}))),
-  rest.get("/service/metronome/v1/jobs", fx("metronome/jobs"))
+  rest.get("/service/metronome/v1/jobs", fx("metronome/jobs")),
+  rest.get("/service/metronome/v1/jobs/:id", fx("metronome/job"))
 ).start();
 
 document.cookie =

--- a/src/styles/components/list/styles.less
+++ b/src/styles/components/list/styles.less
@@ -1,3 +1,11 @@
+[data-cy='borderedList'] li {
+  padding: 0.5em 0 !important;
+  margin: 0 !important;
+  &:before {
+    display: none;
+  }
+}
+
 & when (@list-enabled) {
 
   .list {

--- a/tests/_fixtures/metronome/job.json
+++ b/tests/_fixtures/metronome/job.json
@@ -18,6 +18,7 @@
       "nextRunAt": "1990-01-02T00:00:00Z"
     }
   ],
+  "dependencies": [{ "id": "depA" }, { "id": "depB" }],
   "run": {
     "cpus": 1,
     "mem": 32,

--- a/tests/_fixtures/metronome/jobs.json
+++ b/tests/_fixtures/metronome/jobs.json
@@ -19,6 +19,10 @@
         "nextRunAt": "1990-01-02T00:00:00Z"
       }
     ],
+    "dependencies": [
+      { "id": "dependency_a" },
+      { "id": "some.dependency.in.a.group" }
+    ],
     "run": {
       "cpus": 1,
       "mem": 1,


### PR DESCRIPTION
this paves the way to display dependencies on the job-list and job-details view.
we currently display those and while i'm almost happy with the links in the
config-map (a.k.a. the detail view), i think we'll need to make another pass on
the list-view.

choosing to go with another icon here seemed reasonable for two reasons:
* ease of implementation: we only show this icon when a job brings dependencies,
which it only can do on a dcos >= 2.2. thus we don't need to introduce
feature-flagging here.
* we don't waste table-space in case a customer does not work with dependencies.

i'm totally open to changing this to a separate column that is only shown on
clusters >= 2.2 OR if at least one job is configured to have a dependency.

## Reviewing

in order to play around with the changes in here, you'll want to start via `npm start` without specifying a `CLUSTER_URL`. that way our new mock-server kicks in and will provide some job-fixtures that have dependencies specified as we don't have a dcos-build with the according metronome changes we need to test this end-to-end yet.

## Screenshots

Here's the "detail view".

Adding a "Dependencies" section that shows all dependencies as a bordered list. Each entry links to the according job.
<img width="713" alt="detail" src="https://user-images.githubusercontent.com/300861/91769807-5933f380-ebe0-11ea-8c57-3d4ca81f80f3.png">

The list view. I'm not yet happy with this but requested help from UX. While i like the idea of "just" adding a an icon in the name-column, i think we need a different icon (@danielone please!). also i think we could change the tooltip [to a popover](https://dcos-labs.github.io/ui-kit/?path=/story/overlays-popover--default) and also display the entries as a list of links. possibly with the according state (e.g. running, pending).

<img width="731" alt="list" src="https://user-images.githubusercontent.com/300861/91769810-5afdb700-ebe0-11ea-9457-8e15f20d2345.png">
