### PR TITLE
fix: don't display deps when there are none

### DIFF
--- a/plugins/jobs/src/js/components/config/DependenciesConfigSection.tsx
+++ b/plugins/jobs/src/js/components/config/DependenciesConfigSection.tsx
@@ -8,7 +8,7 @@ import { Link } from "react-router";
 
 export default class DependenciesConfigSection extends BaseConfig<JobOutput> {
   shouldExcludeItem(_: Value<JobOutput>) {
-    return false && !!this.props.config.dependencies?.length;
+    return !this.props.config.dependencies?.length;
   }
 
   getMountType() {


### PR DESCRIPTION
removing something that used to be a debug-statement.