### PR TITLE
Improve Type Safety

### DIFF
--- a/packages/foundation-ui/src/mount/Mount.tsx
+++ b/packages/foundation-ui/src/mount/Mount.tsx
@@ -35,14 +35,8 @@ class Mount extends React.Component {
     type: PropTypes.string.isRequired,
     wrapper: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   };
-  constructor(props) {
-    super(props);
 
-    // Get components and init state
-    this.state = {
-      components: MountService.findComponentsWithType(this.props.type),
-    };
-  }
+  state = { components: MountService.findComponentsWithType(this.props.type) };
 
   UNSAFE_componentWillMount() {
     MountService.addListener(CHANGE, this.onMountServiceChange);

--- a/packages/foundation-ui/src/mount/MountService.ts
+++ b/packages/foundation-ui/src/mount/MountService.ts
@@ -5,8 +5,8 @@ import { CHANGE } from "./MountEvent";
  * MountService
  */
 class MountService extends EventEmitter {
-  constructor(...args) {
-    super(...args);
+  constructor() {
+    super();
 
     /**
      * Private Context

--- a/plugins/auth-providers/components/AuthProviderDetailTab.tsx
+++ b/plugins/auth-providers/components/AuthProviderDetailTab.tsx
@@ -19,13 +19,9 @@ class AuthProviderDetailTab extends React.Component {
   static propTypes = {
     provider: PropTypes.object,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      hideSecret: true,
-    };
-  }
+  state = { hideSecret: true };
+
   handleSecretToggle = () => {
     const { hideSecret } = this.state;
     this.setState({ hideSecret: !hideSecret });

--- a/plugins/auth-providers/components/AuthProvidersModal.tsx
+++ b/plugins/auth-providers/components/AuthProvidersModal.tsx
@@ -16,15 +16,13 @@ class AuthProvidersModal extends React.Component {
     open: PropTypes.bool.isRequired,
     provider: PropTypes.instanceOf(AuthProvider),
   };
-  constructor(...args) {
-    super(...args);
 
-    this.triggerFormSubmit = () => {};
+  state = {
+    selectedProviderType: null,
+  };
 
-    this.state = {
-      selectedProviderType: null,
-    };
-  }
+  triggerFormSubmit = () => {};
+
   handleIdentitySelection = (selectedProviderType) => {
     this.setState({ selectedProviderType });
   };

--- a/plugins/auth-providers/components/AuthProvidersModalForm.tsx
+++ b/plugins/auth-providers/components/AuthProvidersModalForm.tsx
@@ -25,20 +25,17 @@ class AuthProvidersModalForm extends mixin(StoreMixin) {
     providerType: PropTypes.string,
     triggerSubmit: PropTypes.func,
   };
-  constructor(...args) {
-    super(...args);
 
-    // prettier-ignore
-    this.store_listeners = [
-      { name: "authProvider", events: ["createSuccess", "createError", "updateSuccess", "updateError"], suppressUpdate: true }
-    ];
+  // prettier-ignore
+  store_listeners = [
+    { name: "authProvider", events: ["createSuccess", "createError", "updateSuccess", "updateError"], suppressUpdate: true }
+  ];
 
-    this.state = {
-      disableSubmit: false,
-      errorCode: false,
-      errorMsg: false,
-    };
-  }
+  state = {
+    disableSubmit: false,
+    errorCode: false,
+    errorMsg: false,
+  };
   onAuthProviderStoreCreateSuccess = () => {
     this.setState({
       disableSubmit: false,

--- a/plugins/auth-providers/components/AuthProvidersTable.tsx
+++ b/plugins/auth-providers/components/AuthProvidersTable.tsx
@@ -12,9 +12,6 @@ class AuthProvidersTable extends React.Component {
   static propTypes = {
     data: PropTypes.array,
   };
-  constructor(...args) {
-    super(...args);
-  }
 
   getClassName(prop, sortBy, row) {
     return classNames({

--- a/plugins/auth-providers/components/LoginModalProviders.tsx
+++ b/plugins/auth-providers/components/LoginModalProviders.tsx
@@ -21,16 +21,13 @@ class LoginModalProviders extends mixin(StoreMixin) {
     onUpdate: PropTypes.func,
     target: PropTypes.string,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = { showAllProviders: false };
+  state = { showAllProviders: false };
 
-    this.store_listeners = [{ name: "authProviders", events: ["change"] }];
-  }
+  store_listeners = [{ name: "authProviders", events: ["change"] }];
 
-  componentDidMount(...args) {
-    super.componentDidMount(...args);
+  componentDidMount() {
+    super.componentDidMount();
     AuthProvidersStore.fetch();
   }
   handleViewAllClick = () => {

--- a/plugins/auth-providers/pages/AuthProviderDetailPage.tsx
+++ b/plugins/auth-providers/pages/AuthProviderDetailPage.tsx
@@ -51,23 +51,19 @@ const AuthProviderDetailBreadcrumbs = ({ provider }) => {
 };
 
 class AuthProviderDetailPage extends mixin(StoreMixin) {
-  constructor(...args) {
-    super(...args);
+  state = {
+    deleteUpdateError: null,
+    fetchedDetailsError: false,
+    openDeleteConfirmation: false,
+    openEditFormModal: false,
+    pendingRequest: false,
+  };
 
-    this.state = {
-      deleteUpdateError: null,
-      fetchedDetailsError: false,
-      openDeleteConfirmation: false,
-      openEditFormModal: false,
-      pendingRequest: false,
-    };
-
-    // prettier-ignore
-    this.store_listeners = [
-      {name: "authProvider", events: ["success", "error", "deleteSuccess", "deleteError", "callbackUrlSuccess", "updateSuccess"], suppressUpdate: true},
-      {name: "summary", events: ["success"], unmountWhen: (store, event) => event === "success" && store.get("statesProcessed") }
-    ];
-  }
+  // prettier-ignore
+  store_listeners = [
+    {name: "authProvider", events: ["success", "error", "deleteSuccess", "deleteError", "callbackUrlSuccess", "updateSuccess"], suppressUpdate: true},
+    {name: "summary", events: ["success"], unmountWhen: (store, event) => event === "success" && store.get("statesProcessed") }
+  ];
 
   componentDidMount(...args) {
     super.componentDidMount(...args);

--- a/plugins/auth-providers/pages/AuthProvidersTab.tsx
+++ b/plugins/auth-providers/pages/AuthProvidersTab.tsx
@@ -37,20 +37,14 @@ const AuthProvidersBreadcrumbs = () => {
 };
 
 class AuthProvidersTab extends mixin(StoreMixin) {
-  constructor(...args) {
-    super(...args);
+  store_listeners = [{ name: "authProviders", events: ["change", "error"] }];
 
-    this.store_listeners = [
-      { name: "authProviders", events: ["change", "error"] },
-    ];
-
-    this.state = {
-      openNewItemModal: false,
-      searchString: "",
-      storeFetchError: false,
-      storeFetchSuccess: false,
-    };
-  }
+  state = {
+    openNewItemModal: false,
+    searchString: "",
+    storeFetchError: false,
+    storeFetchSuccess: false,
+  };
 
   componentDidMount() {
     super.componentDidMount();

--- a/plugins/auth/components/LoginModal.tsx
+++ b/plugins/auth/components/LoginModal.tsx
@@ -21,22 +21,15 @@ export default withI18n()(
       router: routerShape,
     };
 
-    constructor() {
-      super();
+    state = { disableLogin: false, errorMsg: false };
 
-      this.state = {
-        disableLogin: false,
-        errorMsg: false,
-      };
-
-      // prettier-ignore
-      this.store_listeners = [
+    // prettier-ignore
+    store_listeners = [
       {name: "auth", events: ["success", "error"]},
       // We need to listen for this event so that the component will update when
       // the providers are received.
       {name: "authProviders", events: ["change"]}
     ];
-    }
 
     onAuthStoreError(errorMsg, xhr) {
       const { i18n } = this.props;

--- a/plugins/bootstrap-config/components/BootstrapConfigHashMap.tsx
+++ b/plugins/bootstrap-config/components/BootstrapConfigHashMap.tsx
@@ -21,10 +21,9 @@ const userHasCapability = Hooks.applyFilter.bind(
 );
 
 class BootstrapConfigHashMap extends React.Component {
+  state = { loaded: false };
   constructor(...args) {
     super(...args);
-
-    this.state = { loaded: false };
 
     BootstrapConfigStore.addChangeListener(
       BOOTSTRAP_CONFIG_SUCCESS,

--- a/plugins/catalog/src/js/repositories/components/AddRepositoryFormModal.tsx
+++ b/plugins/catalog/src/js/repositories/components/AddRepositoryFormModal.tsx
@@ -15,9 +15,6 @@ class AddRepositoryFormModal extends React.Component {
     open: PropTypes.bool,
     addRepository: PropTypes.func.isRequired,
   };
-  constructor() {
-    super();
-  }
   handleAddRepository = (model) => {
     this.props.addRepository(model);
   };

--- a/plugins/catalog/src/js/repositories/components/RepositoriesTabUI.tsx
+++ b/plugins/catalog/src/js/repositories/components/RepositoriesTabUI.tsx
@@ -10,13 +10,8 @@ import RepositoriesTable from "./RepositoriesTable";
 import RepositoriesAdd from "../RepositoriesAdd";
 
 class RepositoriesTabUI extends React.Component {
-  constructor() {
-    super();
+  state = { addRepositoryModalOpen: false };
 
-    this.state = {
-      addRepositoryModalOpen: false,
-    };
-  }
   handleCloseAddRepository = () => {
     this.setState({ addRepositoryModalOpen: false });
   };

--- a/plugins/catalog/src/js/repositories/components/RepositoriesTable.tsx
+++ b/plugins/catalog/src/js/repositories/components/RepositoriesTable.tsx
@@ -24,13 +24,9 @@ class RepositoriesTable extends React.Component {
     repositoryRemoveError: PropTypes.string,
     pendingRequest: PropTypes.bool.isRequired,
   };
-  constructor() {
-    super();
 
-    this.state = {
-      repositoryToRemove: null,
-    };
-  }
+  state = { repositoryToRemove: null };
+
   handleOpenConfirm = (repositoryToRemove) => {
     this.setState({ repositoryToRemove });
   };

--- a/plugins/cluster-linking/components/ClusterLinkingModalTrigger.tsx
+++ b/plugins/cluster-linking/components/ClusterLinkingModalTrigger.tsx
@@ -4,10 +4,7 @@ import ClusterLinkingStore from "../stores/ClusterLinkingStore";
 import { CLUSTER_LIST_SUCCESS } from "../constants/EventTypes";
 
 export default class ClusterLinkingModalTrigger extends React.Component {
-  constructor() {
-    super();
-    this.state = { clusterList: ClusterLinkingStore.getLinkedClusters() };
-  }
+  state = { clusterList: ClusterLinkingStore.getLinkedClusters() };
 
   componentDidMount() {
     ClusterLinkingStore.addListener(

--- a/plugins/cluster-linking/pages/LinkedClustersPage.tsx
+++ b/plugins/cluster-linking/pages/LinkedClustersPage.tsx
@@ -64,13 +64,7 @@ const EmptyLinkedClustersAlert = () => (
 );
 
 class LinkedClustersPage extends React.Component {
-  constructor() {
-    super();
-    this.state = {
-      clusters: [],
-      loading: true,
-    };
-  }
+  state = { clusters: [], loading: true };
   componentDidMount() {
     ClusterLinkingStore.addListener(
       CLUSTER_LIST_SUCCESS,

--- a/plugins/jobs/src/js/components/JobsForm.tsx
+++ b/plugins/jobs/src/js/components/JobsForm.tsx
@@ -88,10 +88,9 @@ class JobsForm extends React.Component<JobsFormProps, JobsFormState> {
     { id: "runconfig", key: "runConfig", label: i18nMark("Run Configuration") },
   ];
 
+  state = { editorWidth: undefined };
   constructor(props: Readonly<JobsFormProps>) {
     super(props);
-
-    this.state = { editorWidth: undefined };
 
     this.onInputChange = this.onInputChange.bind(this);
     this.handleJSONChange = this.handleJSONChange.bind(this);

--- a/plugins/jobs/src/js/components/JobsOverviewList.tsx
+++ b/plugins/jobs/src/js/components/JobsOverviewList.tsx
@@ -27,12 +27,9 @@ class JobsOverviewList extends React.PureComponent<
   JobsOverviewListProps,
   JobsOverviewListState
 > {
+  state = { isJobFormModalOpen: false };
   constructor(props: Readonly<JobsOverviewListProps>) {
     super(props);
-
-    this.state = {
-      isJobFormModalOpen: false,
-    };
 
     this.handleCloseJobFormModal = this.handleCloseJobFormModal.bind(this);
     this.handleOpenJobFormModal = this.handleOpenJobFormModal.bind(this);

--- a/plugins/jobs/src/js/components/form/ArgsSection.tsx
+++ b/plugins/jobs/src/js/components/form/ArgsSection.tsx
@@ -25,10 +25,6 @@ interface ArgsSectionProps {
 }
 
 class ArgsSection extends React.Component<ArgsSectionProps> {
-  constructor(props: ArgsSectionProps) {
-    super(props);
-  }
-
   public getArgsInputs() {
     const {
       formData: { args },

--- a/plugins/jobs/src/js/components/form/ContainerFormSection.tsx
+++ b/plugins/jobs/src/js/components/form/ContainerFormSection.tsx
@@ -21,10 +21,6 @@ interface ContainerSectionProps {
 }
 
 class ContainerFormSection extends React.Component<ContainerSectionProps> {
-  constructor(props: ContainerSectionProps) {
-    super(props);
-  }
-
   public getDisabledBanner() {
     const { formData } = this.props;
     const message = (

--- a/plugins/jobs/src/js/components/form/ParametersSection.tsx
+++ b/plugins/jobs/src/js/components/form/ParametersSection.tsx
@@ -26,10 +26,6 @@ class ParametersSection extends React.Component<
   ParametersSectionProps,
   object
 > {
-  constructor(props: ParametersSectionProps) {
-    super(props);
-  }
-
   public getParamsInputs() {
     const {
       formData: { dockerParams },

--- a/plugins/jobs/src/js/components/form/RunConfigFormSection.tsx
+++ b/plugins/jobs/src/js/components/form/RunConfigFormSection.tsx
@@ -28,10 +28,6 @@ interface RunConfigSectionProps {
 }
 
 class RunConfigFormSection extends React.Component<RunConfigSectionProps> {
-  constructor(props: RunConfigSectionProps) {
-    super(props);
-  }
-
   public render() {
     const {
       formData,

--- a/plugins/jobs/src/js/components/form/ScheduleFormSection.tsx
+++ b/plugins/jobs/src/js/components/form/ScheduleFormSection.tsx
@@ -23,10 +23,6 @@ interface ScheduleSectionProps {
 }
 
 class ScheduleFormSection extends React.Component<ScheduleSectionProps> {
-  constructor(props: ScheduleSectionProps) {
-    super(props);
-  }
-
   public render() {
     const { formData, showErrors, errors } = this.props;
     const idTooltipContent = (

--- a/plugins/jobs/src/js/components/form/VolumesFormSection.tsx
+++ b/plugins/jobs/src/js/components/form/VolumesFormSection.tsx
@@ -38,10 +38,6 @@ function isFBS(volume: JobVolume | SecretVolume): volume is SecretVolume {
 }
 
 class VolumesFormSection extends React.Component<VolumesSectionProps> {
-  constructor(props: VolumesSectionProps) {
-    super(props);
-  }
-
   public getVolumesLines() {
     const {
       formData: { volumes = [] },

--- a/plugins/jobs/src/js/pages/JobRunHistoryTable.tsx
+++ b/plugins/jobs/src/js/pages/JobRunHistoryTable.tsx
@@ -59,13 +59,9 @@ class JobRunHistoryTable extends React.Component<{ job: { id: string } }> {
   static propTypes = {
     params: PropTypes.object,
   };
+  state = { selectedID: null, mesosStateStoreLoaded: false };
   constructor(props) {
     super(props);
-
-    this.state = {
-      selectedID: null,
-      mesosStateStoreLoaded: false,
-    };
 
     MesosStateStore.ready.then(() => {
       this.setState({ mesosStateStoreLoaded: true });

--- a/plugins/licensing/components/LicensingBanner.tsx
+++ b/plugins/licensing/components/LicensingBanner.tsx
@@ -6,13 +6,7 @@ import LicensingStore from "../stores/LicensingStore";
 import { LICENSING_SUMMARY_SUCCESS } from "../constants/EventTypes";
 
 class LicensingBanner extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      licensingSummary: LicensingStore.getLicensingSummary(),
-    };
-  }
+  state = { licensingSummary: LicensingStore.getLicensingSummary() };
 
   componentDidMount() {
     LicensingStore.addChangeListener(

--- a/plugins/licensing/components/LicensingExpirationRow.tsx
+++ b/plugins/licensing/components/LicensingExpirationRow.tsx
@@ -11,13 +11,7 @@ import LicensingStore from "../stores/LicensingStore";
 import { LICENSING_SUMMARY_SUCCESS } from "../constants/EventTypes";
 
 class LicensingExpirationRow extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      licensingSummary: LicensingStore.getLicensingSummary(),
-    };
-  }
+  state = { licensingSummary: LicensingStore.getLicensingSummary() };
 
   componentDidMount() {
     LicensingStore.addChangeListener(

--- a/plugins/licensing/components/LicensingNodeCapacityRow.tsx
+++ b/plugins/licensing/components/LicensingNodeCapacityRow.tsx
@@ -16,13 +16,7 @@ import LicensingConfig from "../config/LicensingConfig";
 import { LICENSING_SUMMARY_SUCCESS } from "../constants/EventTypes";
 
 class LicensingNodeCapacityRow extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      licensingSummary: LicensingStore.getLicensingSummary(),
-    };
-  }
+  state = { licensingSummary: LicensingStore.getLicensingSummary() };
 
   componentDidMount() {
     LicensingStore.addChangeListener(

--- a/plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx
+++ b/plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx
@@ -70,25 +70,21 @@ const BackendBreadcrumbs = ({ params }) => {
 };
 
 class BackendDetailPage extends mixin(StoreMixin) {
-  constructor(...args) {
-    super(...args);
+  store_listeners = [
+    { name: "networkingBackendConnections", events: ["success", "error"] },
+  ];
 
-    this.store_listeners = [
-      { name: "networkingBackendConnections", events: ["success", "error"] },
-    ];
+  tabs_tabs = {
+    clients: i18nMark("Clients"),
+  };
 
-    this.tabs_tabs = {
-      clients: i18nMark("Clients"),
-    };
+  state = {
+    currentTab: Object.keys(this.tabs_tabs).shift(),
+    selectedDropdownItem: "success",
+  };
 
-    this.state = {
-      currentTab: Object.keys(this.tabs_tabs).shift(),
-      selectedDropdownItem: "success",
-    };
-
-    this.backendConnectionRequestSuccess = false;
-    this.backendConnectionRequestErrorCount = 0;
-  }
+  backendConnectionRequestSuccess = false;
+  backendConnectionRequestErrorCount = 0;
 
   componentDidMount() {
     super.componentDidMount();

--- a/plugins/networking/submodules/internal-load-balancing/components/BackendsTable.tsx
+++ b/plugins/networking/submodules/internal-load-balancing/components/BackendsTable.tsx
@@ -31,13 +31,7 @@ const RIGHT_ALIGNED_TABLE_CELLS = [
 ];
 
 class BackendsTable extends React.Component {
-  constructor() {
-    super();
-
-    this.state = {
-      searchString: "",
-    };
-  }
+  state = { searchString: "" };
 
   componentDidMount() {
     this.mountedAt = Date.now();

--- a/plugins/networking/submodules/internal-load-balancing/components/ClientsTable.tsx
+++ b/plugins/networking/submodules/internal-load-balancing/components/ClientsTable.tsx
@@ -11,13 +11,7 @@ import StringUtil from "#SRC/js/utils/StringUtil";
 const RIGHT_ALIGNED_TABLE_CELLS = ["p99Latency"];
 
 class ClientsTable extends React.Component {
-  constructor() {
-    super();
-
-    this.state = {
-      searchString: "",
-    };
-  }
+  state = { searchString: "" };
 
   componentDidMount() {
     this.mountedAt = Date.now();

--- a/plugins/networking/submodules/internal-load-balancing/components/LineChart.tsx
+++ b/plugins/networking/submodules/internal-load-balancing/components/LineChart.tsx
@@ -37,15 +37,9 @@ class LineChart extends React.Component {
     data: PropTypes.arrayOf(PropTypes.array.isRequired).isRequired,
     chartOptions: PropTypes.object,
   };
-  constructor() {
-    super();
 
-    this.state = {
-      disabledSeries: {},
-    };
-
-    this.chartRef = React.createRef();
-  }
+  state = { disabledSeries: {} };
+  chartRef = React.createRef<HTMLDivElement>();
 
   componentDidMount() {
     const options = this.getOptions();

--- a/plugins/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.tsx
+++ b/plugins/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.tsx
@@ -40,19 +40,15 @@ const LoadBalancingBreadcrumbs = () => {
 };
 
 class LoadBalancingTabContent extends mixin(StoreMixin) {
-  constructor() {
-    super();
+  state = {
+    receivedVIPSummaries: false,
+    searchString: "",
+    vipSummariesErrorCount: 0,
+  };
 
-    this.state = {
-      receivedVIPSummaries: false,
-      searchString: "",
-      vipSummariesErrorCount: 0,
-    };
-
-    this.store_listeners = [
-      { name: "networkingVIPSummaries", events: ["success", "error"] },
-    ];
-  }
+  store_listeners = [
+    { name: "networkingVIPSummaries", events: ["success", "error"] },
+  ];
 
   componentDidMount() {
     super.componentDidMount();

--- a/plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx
+++ b/plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx
@@ -53,25 +53,21 @@ const VIPBreadcrumbs = ({ vip: { vip, port, protocol } }) => {
 };
 
 class VIPDetail extends mixin(StoreMixin) {
-  constructor(...args) {
-    super(...args);
+  store_listeners = [
+    { name: "networkingVIPs", events: ["detailSuccess", "detailError"] },
+  ];
 
-    this.store_listeners = [
-      { name: "networkingVIPs", events: ["detailSuccess", "detailError"] },
-    ];
+  tabs_tabs = {
+    backends: i18nMark("Backends"),
+  };
 
-    this.tabs_tabs = {
-      backends: i18nMark("Backends"),
-    };
+  state = {
+    currentTab: Object.keys(this.tabs_tabs).shift(),
+    selectedDropdownItem: "success",
+  };
 
-    this.state = {
-      currentTab: Object.keys(this.tabs_tabs).shift(),
-      selectedDropdownItem: "success",
-    };
-
-    this.vipDetailSuccess = false;
-    this.vipDetailErrorCount = 0;
-  }
+  vipDetailSuccess = false;
+  vipDetailErrorCount = 0;
 
   componentDidMount(...args) {
     super.componentDidMount(...args);

--- a/plugins/nodes/src/js/components/HealthTab.tsx
+++ b/plugins/nodes/src/js/components/HealthTab.tsx
@@ -19,14 +19,9 @@ class HealthTab extends React.PureComponent {
     units: PropTypes.object.isRequired,
     params: PropTypes.object.isRequired,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      healthFilter: "all",
-      searchString: "",
-    };
-  }
+  state = { healthFilter: "all", searchString: "" };
+
   handleHealthSelection = (selectedHealth) => {
     this.setState({ healthFilter: selectedHealth.id });
   };

--- a/plugins/nodes/src/js/components/NodesTable.tsx
+++ b/plugins/nodes/src/js/components/NodesTable.tsx
@@ -69,25 +69,15 @@ const sorter = (
     reverse: sortDirection !== "ASC",
   });
 };
-export default class NodesTable extends React.Component<
-  NodesTableProps,
-  NodesTableState
-> {
-  // This workaround will be removed in DCOS-39332
-  private readonly regionRenderer: (data: Node) => React.ReactNode;
+export default class NodesTable extends React.Component<NodesTableProps> {
+  state: NodesTableState = {
+    data: null,
+    sortColumn: "health",
+    sortDirection: "ASC",
+  };
 
-  constructor(props: Readonly<NodesTableProps>) {
-    super(props);
-
-    this.state = {
-      data: null,
-      sortColumn: "health",
-      sortDirection: "ASC",
-    };
-
-    this.regionRenderer = (data: Node) =>
-      regionRenderer(this.props.masterRegion, data);
-  }
+  regionRenderer = (data: Node) =>
+    regionRenderer(this.props.masterRegion, data);
 
   public sorterFor(sortColumn: string): (a: Node, b: Node) => number {
     switch (sortColumn) {

--- a/plugins/nodes/src/js/data/MesosMasters.tsx
+++ b/plugins/nodes/src/js/data/MesosMasters.tsx
@@ -47,12 +47,8 @@ export function combineMasterData(leaderDataSource, mesosMastersHealth) {
 // This is an attempt of the mediator pattern without componentFromStream
 export function connectMasterComponent(initialState, stream) {
   class MesosMasters extends React.Component {
-    constructor(...args) {
-      super(...args);
-
-      this.stream = this.props.stream();
-      this.state = this.props.initialState();
-    }
+    stream = this.props.stream();
+    state = this.props.initialState();
 
     componentDidMount() {
       this.subscription = this.stream.subscribe(this.setState.bind(this));

--- a/plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.tsx
+++ b/plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.tsx
@@ -50,23 +50,18 @@ class HostsPageContent extends React.PureComponent {
     totalNodeCount: PropTypes.number.isRequired,
     viewTypeRadioButtons: PropTypes.node.isRequired,
   };
-  constructor(...args) {
-    super(...args);
 
-    const filters = [
+  state = {
+    expression: "",
+    filterExpression: new DSLExpression(""),
+    filters: [
       new NodesHealthFilter(),
       new NodesTextFilter(),
       new NodesTypeFilter(),
       NodesStatusFilter,
-    ];
-
-    this.state = {
-      expression: "",
-      filterExpression: new DSLExpression(""),
-      filters,
-      defaultFilterData: { regions: [], zones: [] },
-    };
-  }
+    ],
+    defaultFilterData: { regions: [], zones: [] },
+  };
 
   UNSAFE_componentWillMount() {
     this.propsToState(this.props);

--- a/plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx
+++ b/plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx
@@ -19,21 +19,20 @@ import NodeBreadcrumbs from "../../components/NodeBreadcrumbs";
 import NodeHealthStore from "../../stores/NodeHealthStore";
 
 class NodeDetailPage extends mixin(StoreMixin) {
+  // prettier-ignore
+  store_listeners = [
+    { name: "summary", events: ["success"], suppressUpdate: true },
+    { name: "state", events: ["success"], suppressUpdate: true },
+    { name: "nodeHealth", events: ["nodeSuccess", "nodeError", "unitsSuccess", "unitsError"], suppressUpdate: true }
+  ];
+
+  state = {
+    mesosStateLoaded: false,
+    selectedNodeToDrain: null,
+    selectedNodeToDeactivate: null,
+  };
   constructor(...args) {
     super(...args);
-
-    // prettier-ignore
-    this.store_listeners = [
-      { name: "summary", events: ["success"], suppressUpdate: true },
-      { name: "state", events: ["success"], suppressUpdate: true },
-      {name: "nodeHealth", events: ["nodeSuccess", "nodeError", "unitsSuccess", "unitsError"], suppressUpdate: true}
-    ];
-
-    this.state = {
-      mesosStateLoaded: false,
-      selectedNodeToDrain: null,
-      selectedNodeToDeactivate: null,
-    };
 
     this.handleNodeAction = this.handleNodeAction.bind(this);
     this.handleCloseModal = this.handleCloseModal.bind(this);

--- a/plugins/nodes/src/js/pages/nodes/NodeDetailTab.tsx
+++ b/plugins/nodes/src/js/pages/nodes/NodeDetailTab.tsx
@@ -26,14 +26,11 @@ class NodeDetailTab extends React.PureComponent {
   static propTypes = {
     node: PropTypes.instanceOf(Node),
   };
+  state = { masterRegion: null };
   constructor(...args) {
     super(...args);
 
     this.onMesosStateChange = this.onMesosStateChange.bind(this);
-
-    this.state = {
-      masterRegion: null,
-    };
   }
 
   componentDidMount() {

--- a/plugins/nodes/src/js/pages/nodes/NodeDetailTaskTab.tsx
+++ b/plugins/nodes/src/js/pages/nodes/NodeDetailTaskTab.tsx
@@ -8,14 +8,7 @@ import MesosStateStore from "#SRC/js/stores/MesosStateStore";
 import TasksContainer from "../../../../../services/src/js/containers/tasks/TasksContainer";
 
 class NodeDetailTaskTab extends React.Component {
-  constructor(...args) {
-    super(...args);
-
-    this.state = {
-      isLoading: true,
-      lastUpdate: 0,
-    };
-  }
+  state = { isLoading: true, lastUpdate: 0 };
 
   componentDidMount() {
     DCOSStore.addChangeListener(DCOS_CHANGE, this.onStoreChange);

--- a/plugins/nodes/src/js/pages/nodes/NodesTaskDetailPage.tsx
+++ b/plugins/nodes/src/js/pages/nodes/NodesTaskDetailPage.tsx
@@ -19,14 +19,11 @@ class NodesTaskDetailPage extends mixin(StoreMixin) {
     params: PropTypes.object,
     routes: PropTypes.array,
   };
-  constructor(...args) {
-    super(...args);
 
-    // prettier-ignore
-    this.store_listeners = [
-      { name: "summary", events: ["success"], unmountWhen: (store, event) => event === "success" && store.get("statesProcessed") }
-    ];
-  }
+  // prettier-ignore
+  store_listeners = [
+    { name: "summary", events: ["success"], unmountWhen: (store, event) => event === "success" && store.get("statesProcessed") }
+  ];
 
   render() {
     const { location, params, routes, node } = this.props;

--- a/plugins/nodes/src/js/pages/nodes/NodesUnitsHealthDetailPage.tsx
+++ b/plugins/nodes/src/js/pages/nodes/NodesUnitsHealthDetailPage.tsx
@@ -10,13 +10,9 @@ import { withNode } from "#SRC/js/stores/MesosSummaryFetchers";
 import NodeBreadcrumbs from "../../components/NodeBreadcrumbs";
 
 class NodesUnitsHealthDetailPage extends mixin(StoreMixin) {
-  constructor(...args) {
-    super(...args);
-
-    this.store_listeners = [
-      { name: "unitHealth", events: ["unitSuccess", "nodeSuccess"] },
-    ];
-  }
+  store_listeners = [
+    { name: "unitHealth", events: ["unitSuccess", "nodeSuccess"] },
+  ];
 
   componentDidMount(...args) {
     super.componentDidMount(...args);

--- a/plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.tsx
+++ b/plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.tsx
@@ -15,26 +15,22 @@ const MAX_SERVICES_TO_SHOW = 32;
 const OTHER_SERVICES_COLOR = 32;
 
 class NodesGridContainer extends mixin(StoreMixin) {
-  constructor(...args) {
-    super(...args);
-
-    this.state = {
-      filteredNodes: new NodesList([]),
-      filters: { health: "all", name: "", service: null },
-      hasLoadingError: false,
-      hiddenServices: [],
-      mesosStateErrorCount: 0,
-      receivedEmptyMesosState: true,
-      receivedNodeHealthResponse: false,
-      resourcesByFramework: {},
-      serviceColors: {},
-    };
-    // prettier-ignore
-    this.store_listeners = [
-      {events: ["success"], name: "nodeHealth", suppressUpdate: true},
-      {events: ["success", "error"], name: "state", suppressUpdate: true}
-    ];
-  }
+  state = {
+    filteredNodes: new NodesList([]),
+    filters: { health: "all", name: "", service: null },
+    hasLoadingError: false,
+    hiddenServices: [],
+    mesosStateErrorCount: 0,
+    receivedEmptyMesosState: true,
+    receivedNodeHealthResponse: false,
+    resourcesByFramework: {},
+    serviceColors: {},
+  };
+  // prettier-ignore
+  store_listeners = [
+    { events: ["success"], name: "nodeHealth", suppressUpdate: true },
+    { events: ["success", "error"], name: "state", suppressUpdate: true }
+  ];
 
   UNSAFE_componentWillReceiveProps(props) {
     const {

--- a/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx
+++ b/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx
@@ -18,22 +18,22 @@ import NodeMaintenanceActions from "#PLUGINS/nodes/src/js/actions/NodeMaintenanc
 import StoreMixin from "#SRC/js/mixins/StoreMixin";
 
 class NodesTableContainer extends mixin(StoreMixin) {
+  state = {
+    filteredNodes: null,
+    filters: { health: "all", name: "", service: null },
+    masterRegion: null,
+    selectedNodeToDrain: null,
+    selectedNodeToDeactivate: null,
+    reactivateNetworkError: false,
+  };
+
+  store_listeners = [
+    { events: ["success"], name: "nodeHealth", suppressUpdate: true },
+    { name: "state", events: ["success"], suppressUpdate: true },
+  ];
+
   constructor(...args) {
     super(...args);
-
-    this.state = {
-      filteredNodes: null,
-      filters: { health: "all", name: "", service: null },
-      masterRegion: null,
-      selectedNodeToDrain: null,
-      selectedNodeToDeactivate: null,
-      reactivateNetworkError: false,
-    };
-
-    this.store_listeners = [
-      { events: ["success"], name: "nodeHealth", suppressUpdate: true },
-      { name: "state", events: ["success"], suppressUpdate: true },
-    ];
 
     this.handleNodeAction = this.handleNodeAction.bind(this);
     this.handleCloseModal = this.handleCloseModal.bind(this);

--- a/plugins/organization/components/AccountDetailPage.tsx
+++ b/plugins/organization/components/AccountDetailPage.tsx
@@ -36,30 +36,29 @@ class AccountDetailPage extends mixin(StoreMixin) {
   static propTypes = {
     params: PropTypes.object,
   };
+  tabs_tabs = {
+    advancedACLs: i18nMark("Permissions"),
+    membership: i18nMark("Group Membership"),
+    details: i18nMark("Details"),
+  };
+
+  state = {
+    currentTab: Object.keys(this.tabs_tabs).shift(),
+    deleteUpdateError: null,
+    fetchedDetailsError: false,
+    openDeleteConfirmation: false,
+    openEditFormModal: false,
+    pendingRequest: false,
+  };
+
+  // prettier-ignore
+  store_listeners = [
+    { name: "acl", events: ["userGrantSuccess", "userRevokeSuccess"] },
+    { name: "aclGroup", events: ["addUserSuccess", "deleteUserSuccess"], suppressUpdate: true },
+    { name: "summary", events: ["success"], unmountWhen: (store, event) => event === "success" && store.get("statesProcessed") }
+  ];
   constructor(...args) {
     super(...args);
-
-    this.tabs_tabs = {
-      advancedACLs: i18nMark("Permissions"),
-      membership: i18nMark("Group Membership"),
-      details: i18nMark("Details"),
-    };
-
-    this.state = {
-      currentTab: Object.keys(this.tabs_tabs).shift(),
-      deleteUpdateError: null,
-      fetchedDetailsError: false,
-      openDeleteConfirmation: false,
-      openEditFormModal: false,
-      pendingRequest: false,
-    };
-
-    // prettier-ignore
-    this.store_listeners = [
-      { name: "acl", events: ["userGrantSuccess", "userRevokeSuccess"] },
-      { name: "aclGroup", events: ["addUserSuccess", "deleteUserSuccess"], suppressUpdate: true },
-      { name: "summary", events: ["success"], unmountWhen: (store, event) => event === "success" && store.get("statesProcessed") }
-    ];
 
     EXTERNAL_CHANGE_EVENTS.forEach((event) => {
       // #onACLChange is defined in the child component after this runs

--- a/plugins/organization/components/AccountGroupMembershipTab.tsx
+++ b/plugins/organization/components/AccountGroupMembershipTab.tsx
@@ -20,24 +20,21 @@ class AccountGroupMembershipTab extends mixin(StoreMixin) {
     accountID: PropTypes.string.isRequired,
     getAccountDetails: PropTypes.func.isRequired,
   };
-  constructor() {
-    super();
 
-    this.state = {
-      pendingRequest: false,
-      requestGroupsSuccess: false,
-      requestGroupsError: false,
-      searchString: "",
-      selectedGroup: [],
-      userUpdateError: null,
-    };
+  state = {
+    pendingRequest: false,
+    requestGroupsSuccess: false,
+    requestGroupsError: false,
+    searchString: "",
+    selectedGroup: [],
+    userUpdateError: null,
+  };
 
-    // prettier-ignore
-    this.store_listeners = [
-      { name: "aclGroup", events: ["deleteUserSuccess", "deleteUserError", "addUserSuccess"] },
-      { name: "aclGroups", events: ["success", "error"] }
-    ];
-  }
+  // prettier-ignore
+  store_listeners = [
+    { name: "aclGroup", events: ["deleteUserSuccess", "deleteUserError", "addUserSuccess"] },
+    { name: "aclGroups", events: ["success", "error"] }
+  ];
 
   componentDidMount() {
     super.componentDidMount();

--- a/plugins/organization/components/AccountGroupTable.tsx
+++ b/plugins/organization/components/AccountGroupTable.tsx
@@ -17,23 +17,20 @@ class AccountGroupTable extends mixin(StoreMixin) {
   static propTypes = {
     getAccountDetails: PropTypes.func.isRequired,
   };
-  constructor() {
-    super();
 
-    this.state = {
-      groupID: null,
-      openConfirm: false,
-      pendingRequest: false,
-      requestGroupsSuccess: false,
-      requestGroupsError: false,
-      userUpdateError: null,
-    };
+  state = {
+    groupID: null,
+    openConfirm: false,
+    pendingRequest: false,
+    requestGroupsSuccess: false,
+    requestGroupsError: false,
+    userUpdateError: null,
+  };
 
-    // prettier-ignore
-    this.store_listeners = [
-      { name: "aclGroup", events: ["deleteUserSuccess", "deleteUserError", "usersSuccess"] }
-    ];
-  }
+  // prettier-ignore
+  store_listeners = [
+    { name: "aclGroup", events: ["deleteUserSuccess", "deleteUserError", "usersSuccess"] }
+  ];
 
   handleOpenConfirm = (group) => {
     this.setState({

--- a/plugins/organization/components/AdvancedACLsTab.tsx
+++ b/plugins/organization/components/AdvancedACLsTab.tsx
@@ -28,26 +28,23 @@ class AdvancedACLsTab extends mixin(StoreMixin) {
   static propTypes = {
     itemID: PropTypes.string.isRequired,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      aclsRequestErrors: 0,
-      aclsRequestSuccess: false,
-      aclsToBeCreated: 0,
-      aclsToBeCreatedDupes: [],
-      aclsToBeCreatedErrors: [],
-      aclsToBeCreatedSuccess: 0,
-      itemPermissionsRequestErrors: 0,
-      itemPermissionsRequestSuccess: false,
-      permissionBuilderOpen: false,
-      permissionBuilderView: "builder", // [builder, bulk]
-    };
+  state = {
+    aclsRequestErrors: 0,
+    aclsRequestSuccess: false,
+    aclsToBeCreated: 0,
+    aclsToBeCreatedDupes: [],
+    aclsToBeCreatedErrors: [],
+    aclsToBeCreatedSuccess: 0,
+    itemPermissionsRequestErrors: 0,
+    itemPermissionsRequestSuccess: false,
+    permissionBuilderOpen: false,
+    permissionBuilderView: "builder", // [builder, bulk]
+  };
 
-    this.store_listeners = [
-      { name: "acl", events: ["fetchResourceSuccess", "fetchResourceError"] },
-    ];
-  }
+  store_listeners = [
+    { name: "acl", events: ["fetchResourceSuccess", "fetchResourceError"] },
+  ];
 
   UNSAFE_componentWillMount() {
     ACLStore.fetchACLs();

--- a/plugins/organization/components/OrganizationTab.tsx
+++ b/plugins/organization/components/OrganizationTab.tsx
@@ -30,20 +30,17 @@ class OrganizationTab extends React.Component {
     itemID: PropTypes.string.isRequired,
     itemName: PropTypes.string.isRequired,
   };
-  constructor() {
-    super();
 
-    this.state = {
-      checkableCount: 0,
-      checkedCount: 0,
-      showActionDropdown: false,
-      searchFilter: "all",
-      searchString: "",
-      selectedAction: null,
-    };
+  state = {
+    checkableCount: 0,
+    checkedCount: 0,
+    showActionDropdown: false,
+    searchFilter: "all",
+    searchString: "",
+    selectedAction: null,
+  };
 
-    this.selectedIDSet = {};
-  }
+  selectedIDSet = {};
 
   UNSAFE_componentWillMount() {
     this.resetTablewideCheckboxTabulations();

--- a/plugins/organization/components/PermissionBuilderModal.tsx
+++ b/plugins/organization/components/PermissionBuilderModal.tsx
@@ -43,21 +43,18 @@ class PermissionBuilderModal extends mixin(StoreMixin) {
     permissionsAddedCount: PropTypes.number,
     subject: PropTypes.object,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      actions: "",
-      chosenRIDs: [],
-      errorMsg: null,
-      model: {},
-      resource: "",
-    };
+  state = {
+    actions: "",
+    chosenRIDs: [],
+    errorMsg: null,
+    model: {},
+    resource: "",
+  };
 
-    this.store_listeners = [
-      { name: "acl", events: ["fetchSchemaSuccess", "fetchSchemaError"] },
-    ];
-  }
+  store_listeners = [
+    { name: "acl", events: ["fetchSchemaSuccess", "fetchSchemaError"] },
+  ];
 
   UNSAFE_componentWillMount() {
     ACLStore.fetchACLSchema();

--- a/plugins/organization/submodules/directories/components/DirectoryActionButtons.tsx
+++ b/plugins/organization/submodules/directories/components/DirectoryActionButtons.tsx
@@ -11,22 +11,18 @@ import StoreMixin from "#SRC/js/mixins/StoreMixin";
 import ACLDirectoriesStore from "../stores/ACLDirectoriesStore";
 
 class DirectoryActionButtons extends mixin(StoreMixin) {
-  constructor(...args) {
-    super(...args);
+  state = {
+    formModalDisabled: false,
+    formModalOpen: false,
+    successModalOpen: false,
+    deleteConfirm: false,
+    deleteConfirmDisabled: false,
+  };
 
-    this.state = {
-      formModalDisabled: false,
-      formModalOpen: false,
-      successModalOpen: false,
-      deleteConfirm: false,
-      deleteConfirmDisabled: false,
-    };
-
-    // prettier-ignore
-    this.store_listeners = [
-      {name: "aclDirectories", events: ["testSuccess", "testError", "deleteError"]}
-    ];
-  }
+  // prettier-ignore
+  store_listeners = [
+    {name: "aclDirectories", events: ["testSuccess", "testError", "deleteError"]}
+  ];
 
   onAclDirectoriesStoreTestSuccess(data) {
     const { i18n } = this.props;

--- a/plugins/organization/submodules/directories/components/DirectoryFormModal.tsx
+++ b/plugins/organization/submodules/directories/components/DirectoryFormModal.tsx
@@ -37,19 +37,17 @@ class DirectoryFormModal extends React.Component {
     modalOpen: PropTypes.bool.isRequired,
     onFormSubmit: PropTypes.func,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      isCACertRequired: false,
-      formData: {
-        "ssl-tls-configuration": null,
-        "template-bind-type": null,
-      },
-    };
+  state = {
+    isCACertRequired: false,
+    formData: {
+      "ssl-tls-configuration": null,
+      "template-bind-type": null,
+    },
+  };
 
-    this.triggerTabFormSubmit = null;
-  }
+  triggerTabFormSubmit = null;
+
   handleAddDirectoryClick = () => {
     this.triggerTabFormSubmit();
   };

--- a/plugins/organization/submodules/directories/pages/DirectoriesPage.tsx
+++ b/plugins/organization/submodules/directories/pages/DirectoriesPage.tsx
@@ -46,21 +46,17 @@ const DirectoriesBreadcrumbs = () => {
 };
 
 class DirectoriesPage extends mixin(StoreMixin) {
-  constructor(...args) {
-    super(...args);
+  state = {
+    modalEditMode: false,
+    modalDisabled: false,
+    modalOpen: false,
+    showValue: {},
+  };
 
-    this.state = {
-      modalEditMode: false,
-      modalDisabled: false,
-      modalOpen: false,
-      showValue: {},
-    };
-
-    // prettier-ignore
-    this.store_listeners = [
-      {name: "aclDirectories", events: ["fetchSuccess", "addSuccess", "addError", "deleteSuccess"]}
-    ];
-  }
+  // prettier-ignore
+  store_listeners = [
+    {name: "aclDirectories", events: ["fetchSuccess", "addSuccess", "addError", "deleteSuccess"]}
+  ];
 
   componentDidMount(...args) {
     super.componentDidMount(...args);

--- a/plugins/organization/submodules/groups/components/GroupAccountMembershipTab.tsx
+++ b/plugins/organization/submodules/groups/components/GroupAccountMembershipTab.tsx
@@ -24,26 +24,23 @@ class GroupAccountMembershipTab extends mixin(StoreMixin) {
     accountType: PropTypes.string,
     groupID: PropTypes.string,
   };
-  constructor() {
-    super();
 
-    this.state = {
-      groupUpdateError: null,
-      openConfirm: false,
-      pendingRequest: false,
-      requestUsersError: false,
-      requestUsersSuccess: false,
-      searchString: "",
-      selectedUser: [],
-      userID: null,
-    };
+  state = {
+    groupUpdateError: null,
+    openConfirm: false,
+    pendingRequest: false,
+    requestUsersError: false,
+    requestUsersSuccess: false,
+    searchString: "",
+    selectedUser: [],
+    userID: null,
+  };
 
-    this.store_listeners = [
-      { name: "aclGroup", events: ["addUserSuccess"] },
-      { name: "users", events: ["error", "success"] },
-      { name: "aclServiceAccounts", events: ["error", "change"] },
-    ];
-  }
+  store_listeners = [
+    { name: "aclGroup", events: ["addUserSuccess"] },
+    { name: "users", events: ["error", "success"] },
+    { name: "aclServiceAccounts", events: ["error", "change"] },
+  ];
 
   componentDidMount() {
     super.componentDidMount();

--- a/plugins/organization/submodules/groups/components/GroupDetailPage.tsx
+++ b/plugins/organization/submodules/groups/components/GroupDetailPage.tsx
@@ -41,16 +41,15 @@ const GroupDetailBreadcrumbs = ({ groupID }) => {
 };
 
 class GroupDetailPage extends mixin(StoreMixin) {
+  state = {
+    currentTab: "advancedACLs",
+    deleteUpdateError: null,
+    fetchedDetailsError: false,
+    openDeleteConfirmation: false,
+    pendingRequest: false,
+  };
   constructor(...args) {
     super(...args);
-
-    this.state = {
-      currentTab: "advancedACLs",
-      deleteUpdateError: null,
-      fetchedDetailsError: false,
-      openDeleteConfirmation: false,
-      pendingRequest: false,
-    };
 
     // prettier-ignore
     this.store_listeners = [

--- a/plugins/organization/submodules/groups/components/GroupFormModal.tsx
+++ b/plugins/organization/submodules/groups/components/GroupFormModal.tsx
@@ -8,18 +8,11 @@ import StoreMixin from "#SRC/js/mixins/StoreMixin";
 import ACLGroupStore from "../stores/ACLGroupStore";
 
 class GroupFormModal extends mixin(StoreMixin) {
-  constructor() {
-    super();
+  state = { disableNewGroup: false, errorMsg: false };
 
-    this.state = {
-      disableNewGroup: false,
-      errorMsg: false,
-    };
-
-    this.store_listeners = [
-      { name: "aclGroup", events: ["createSuccess", "createError"] },
-    ];
-  }
+  store_listeners = [
+    { name: "aclGroup", events: ["createSuccess", "createError"] },
+  ];
   onAclGroupStoreCreateSuccess = () => {
     this.setState({
       disableNewGroup: false,

--- a/plugins/organization/submodules/groups/components/GroupMemberTable.tsx
+++ b/plugins/organization/submodules/groups/components/GroupMemberTable.tsx
@@ -18,23 +18,20 @@ class GroupMemberTable extends mixin(StoreMixin) {
     accountType: PropTypes.string.isRequired,
     groupID: PropTypes.string.isRequired,
   };
-  constructor() {
-    super();
 
-    this.state = {
-      userID: null,
-      openConfirm: false,
-      pendingRequest: false,
-      requestUsersError: false,
-      requestUsersSuccess: false,
-      groupUpdateError: null,
-    };
+  state = {
+    userID: null,
+    openConfirm: false,
+    pendingRequest: false,
+    requestUsersError: false,
+    requestUsersSuccess: false,
+    groupUpdateError: null,
+  };
 
-    // prettier-ignore
-    this.store_listeners = [
-      {name: "aclGroup", events: ["deleteUserSuccess", "deleteUserError", "usersSuccess", "serviceAccountsSuccess"]}
-    ];
-  }
+  // prettier-ignore
+  store_listeners = [
+    {name: "aclGroup", events: ["deleteUserSuccess", "deleteUserError", "usersSuccess", "serviceAccountsSuccess"]}
+  ];
   handleOpenConfirm = (user) => {
     this.setState({
       userID: user.uid,

--- a/plugins/organization/submodules/groups/components/modals/LDAPGroupFormModal.tsx
+++ b/plugins/organization/submodules/groups/components/modals/LDAPGroupFormModal.tsx
@@ -11,23 +11,19 @@ import StoreMixin from "#SRC/js/mixins/StoreMixin";
 import ACLGroupStore from "../../stores/ACLGroupStore";
 
 class LDAPGroupFormModal extends mixin(StoreMixin) {
-  constructor() {
-    super();
+  state = {
+    disableNewGroup: false,
+    errorMsg: false,
+    successMsg: false,
+    groupnameValue: "",
+  };
 
-    this.state = {
-      disableNewGroup: false,
-      errorMsg: false,
-      successMsg: false,
-      groupnameValue: "",
-    };
+  formModalRef = React.createRef();
 
-    this.formModalRef = React.createRef();
-
-    // prettier-ignore
-    this.store_listeners =  [
-      {name: "aclGroup", events: ["createLDAPSuccess", "createLDAPPartialSuccess", "createLDAPError"]}
-    ];
-  }
+  // prettier-ignore
+  store_listeners =  [
+    {name: "aclGroup", events: ["createLDAPSuccess", "createLDAPPartialSuccess", "createLDAPError"]}
+  ];
   onAclGroupStoreCreateLDAPSuccess = (successMsg) => {
     this.setState({
       disableNewGroup: false,

--- a/plugins/organization/submodules/groups/pages/GroupsPage.tsx
+++ b/plugins/organization/submodules/groups/pages/GroupsPage.tsx
@@ -42,30 +42,23 @@ class GroupsPage extends mixin(StoreMixin) {
   static propTypes = {
     params: PropTypes.object,
   };
+  store_listeners = [
+    { name: "marathon", events: ["success"] },
+    { name: "aclDirectories", events: ["fetchSuccess"] },
+    { name: "aclGroups", events: ["success", "error"] },
+    // prettier-ignore
+    { name: "aclGroup", events: ["createLDAPSuccess", "createSuccess", "deleteSuccess", "updateSuccess" ],
+    },
+  ];
+
+  state = {
+    groupsStoreError: false,
+    groupsStoreSuccess: false,
+    openNewGroupModal: false,
+    openNewLDAPGroupModal: false,
+  };
   constructor(...args) {
     super(...args);
-
-    this.store_listeners = [
-      { name: "marathon", events: ["success"] },
-      { name: "aclDirectories", events: ["fetchSuccess"] },
-      { name: "aclGroups", events: ["success", "error"] },
-      {
-        name: "aclGroup",
-        events: [
-          "createLDAPSuccess",
-          "createSuccess",
-          "deleteSuccess",
-          "updateSuccess",
-        ],
-      },
-    ];
-
-    this.state = {
-      groupsStoreError: false,
-      groupsStoreSuccess: false,
-      openNewGroupModal: false,
-      openNewLDAPGroupModal: false,
-    };
 
     EXTERNAL_CHANGE_EVENTS.forEach((event) => {
       this[event] = this.onAclGroupsChange;

--- a/plugins/organization/submodules/service-accounts/components/ServiceAccountForm.tsx
+++ b/plugins/organization/submodules/service-accounts/components/ServiceAccountForm.tsx
@@ -25,23 +25,11 @@ interface ServiceAccountFormProps {
   onChange: (e: React.FormEvent<HTMLFormElement>) => void;
 }
 
-interface ServiceAccountFormState {
-  manuallyEnteredSecretId: boolean;
-  generatedSecretId: string;
-}
-
-class ServiceAccountForm extends React.Component<
-  ServiceAccountFormProps,
-  ServiceAccountFormState
-> {
-  constructor(props: Readonly<ServiceAccountFormProps>) {
-    super(props);
-
-    this.state = {
-      manuallyEnteredSecretId: false,
-      generatedSecretId: "",
-    };
-  }
+class ServiceAccountForm extends React.Component<ServiceAccountFormProps> {
+  state = {
+    manuallyEnteredSecretId: false,
+    generatedSecretId: "",
+  };
 
   public handleFormChange = (e: React.FormEvent<HTMLFormElement>): void => {
     this.props.onChange(e);

--- a/plugins/organization/submodules/service-accounts/components/ServiceAccountSelect.tsx
+++ b/plugins/organization/submodules/service-accounts/components/ServiceAccountSelect.tsx
@@ -21,11 +21,7 @@ type Props = {
 type State = { serviceAccounts: string[] };
 
 class ServiceAccountSelect extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-
-    this.state = { serviceAccounts: [] };
-  }
+  state = { serviceAccounts: [] };
 
   public UNSAFE_componentWillMount() {
     ACLServiceAccountsStore.addListener(

--- a/plugins/organization/submodules/service-accounts/components/ServiceAccountsFormModal.tsx
+++ b/plugins/organization/submodules/service-accounts/components/ServiceAccountsFormModal.tsx
@@ -54,20 +54,16 @@ interface ServiceAccountFormModalState {
 }
 
 class ServiceAccountFormModal extends React.Component<
-  ServiceAccountFormModalProps,
-  ServiceAccountFormModalState
+  ServiceAccountFormModalProps
 > {
-  constructor(props: Readonly<ServiceAccountFormModalProps>) {
-    super(props);
-
-    this.state = {
-      pendingRequest: false,
-      failedToComplete: false,
-      formData: this.getFormDataFromAccount(props.account) || defaultFormData(),
-      manuallyEnteredSecretId: false,
-      errors: {},
-    };
-  }
+  state: ServiceAccountFormModalState = {
+    pendingRequest: false,
+    failedToComplete: false,
+    formData:
+      this.getFormDataFromAccount(this.props.account) || defaultFormData(),
+    manuallyEnteredSecretId: false,
+    errors: {},
+  };
 
   public componentDidMount() {
     ACLServiceAccountsStore.addChangeListener(

--- a/plugins/organization/submodules/service-accounts/pages/ServiceAccountsPage.tsx
+++ b/plugins/organization/submodules/service-accounts/pages/ServiceAccountsPage.tsx
@@ -40,20 +40,16 @@ class ServiceAccountsPage extends mixin(StoreMixin) {
   static propTypes = {
     params: PropTypes.object,
   };
-  constructor(...args) {
-    super(...args);
+  store_listeners = [
+    { name: "marathon", events: ["success"] },
+    { name: "aclServiceAccounts", events: ["change", "error"] },
+  ];
 
-    this.store_listeners = [
-      { name: "marathon", events: ["success"] },
-      { name: "aclServiceAccounts", events: ["change", "error"] },
-    ];
-
-    this.state = {
-      serviceAccountsStoreError: false,
-      serviceAccountsStoreSuccess: false,
-      openNewGroupModal: false,
-    };
-  }
+  state = {
+    serviceAccountsStoreError: false,
+    serviceAccountsStoreSuccess: false,
+    openNewGroupModal: false,
+  };
 
   componentDidMount() {
     super.componentDidMount();

--- a/plugins/organization/submodules/users/components/modals/LDAPUserFormModal.tsx
+++ b/plugins/organization/submodules/users/components/modals/LDAPUserFormModal.tsx
@@ -9,22 +9,19 @@ import StoreMixin from "#SRC/js/mixins/StoreMixin";
 import ACLUserStore from "../../stores/ACLUserStore";
 
 class LDAPUserFormModal extends mixin(StoreMixin) {
-  constructor() {
-    super();
+  state = {
+    disableNewUser: false,
+    errorMsg: false,
+    successMsg: false,
+    usernameValue: "",
+  };
 
-    this.state = {
-      disableNewUser: false,
-      errorMsg: false,
-      successMsg: false,
-      usernameValue: "",
-    };
+  formModalRef = React.createRef();
 
-    this.formModalRef = React.createRef();
+  store_listeners = [
+    { name: "aclUser", events: ["createLDAPSuccess", "createLDAPError"] },
+  ];
 
-    this.store_listeners = [
-      { name: "aclUser", events: ["createLDAPSuccess", "createLDAPError"] },
-    ];
-  }
   onAclUserStoreCreateLDAPSuccess = (successMsg) => {
     this.setState({
       disableNewUser: false,

--- a/plugins/organization/submodules/users/components/modals/UserEditFormModal.tsx
+++ b/plugins/organization/submodules/users/components/modals/UserEditFormModal.tsx
@@ -15,19 +15,14 @@ class UserEditFormModal extends mixin(StoreMixin) {
     onSubmit: PropTypes.func.isRequired,
     open: PropTypes.bool.isRequired,
   };
-  constructor(...args) {
-    super(...args);
 
-    // prettier-ignore
-    this.store_listeners = [
-      {name: "aclUser", events: ["updateSuccess", "updateError"], suppressUpdate: true}
-    ];
+  // prettier-ignore
+  store_listeners = [
+    { name: "aclUser", events: ["updateSuccess", "updateError"], suppressUpdate: true }
+  ];
 
-    this.state = {
-      disableSubmit: false,
-      errorMsg: false,
-    };
-  }
+  state = { disableSubmit: false, errorMsg: false };
+
   onAclUserStoreUpdateSuccess = () => {
     this.setState({
       disableSubmit: false,

--- a/plugins/organization/submodules/users/pages/UsersPage.tsx
+++ b/plugins/organization/submodules/users/pages/UsersPage.tsx
@@ -41,20 +41,19 @@ class UsersPage extends mixin(StoreMixin) {
   static propTypes = {
     items: PropTypes.array.isRequired,
   };
+  state = {
+    openNewLDAPUserModal: false,
+    openNewUserModal: false,
+  };
+
+  // prettier-ignore
+  store_listeners = [
+    { name: "user", events: ["createSuccess", "deleteSuccess"], suppressUpdate: true},
+    { name: "aclDirectories", events: ["fetchSuccess"]},
+    { name: "aclUser", events: ["createLDAPSuccess", "updateSuccess"] }
+  ];
   constructor(...args) {
     super(...args);
-
-    this.state = {
-      openNewLDAPUserModal: false,
-      openNewUserModal: false,
-    };
-
-    // prettier-ignore
-    this.store_listeners = [
-      {name: "user", events: ["createSuccess", "deleteSuccess"], suppressUpdate: true},
-      {name: "aclDirectories", events: ["fetchSuccess"]},
-      { name: "aclUser", events: ["createLDAPSuccess", "updateSuccess"] }
-    ];
 
     Hooks.applyFilter(
       "organizationTabChangeEvents",
@@ -62,8 +61,6 @@ class UsersPage extends mixin(StoreMixin) {
     ).forEach((event) => {
       this[event] = this.onUsersChange;
     });
-
-    this.selectedIDSet = {};
   }
 
   componentDidMount(...args) {

--- a/plugins/secrets/components/SecretActionsModal.tsx
+++ b/plugins/secrets/components/SecretActionsModal.tsx
@@ -30,18 +30,12 @@ class SecretActionsModal extends mixin(StoreMixin) {
     open: PropTypes.bool.isRequired,
     selectedItems: PropTypes.array.isRequired,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.store_listeners = [
-      { name: "secrets", events: ["deleteSecretSuccess", "deleteSecretError"] },
-    ];
+  store_listeners = [
+    { name: "secrets", events: ["deleteSecretSuccess", "deleteSecretError"] },
+  ];
 
-    this.state = {
-      pendingRequest: false,
-      errorMsg: null,
-    };
-  }
+  state = { pendingRequest: false, errorMsg: null };
   handleButtonConfirm = () => {
     const { action, selectedItems } = this.props;
     if (action === UserActions.DELETE) {

--- a/plugins/secrets/components/SecretFormModal.tsx
+++ b/plugins/secrets/components/SecretFormModal.tsx
@@ -102,25 +102,22 @@ class SecretFormModal extends mixin(StoreMixin) {
     onClose: PropTypes.func,
     open: PropTypes.bool,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      requestErrorType: null,
-      requestErrorMessage: null,
-      localErrors: null,
-      path: null,
-      textValue: null,
-      fileValue: null,
-      valueType: "text",
-      pendingRequest: false,
-    };
+  state = {
+    requestErrorType: null,
+    requestErrorMessage: null,
+    localErrors: null,
+    path: null,
+    textValue: null,
+    fileValue: null,
+    valueType: "text",
+    pendingRequest: false,
+  };
 
-    // prettier-ignore
-    this.store_listeners = [
-      {name: "secrets", events: ["createSecretSuccess", "createSecretError", "updateSecretSuccess", "updateSecretError"]}
-    ];
-  }
+  // prettier-ignore
+  store_listeners = [
+    {name: "secrets", events: ["createSecretSuccess", "createSecretError", "updateSecretSuccess", "updateSecretError"]}
+  ];
 
   UNSAFE_componentWillUpdate(nextProps) {
     // Populate state with current secret's values, if provided.

--- a/plugins/secrets/components/SecretsSelect.tsx
+++ b/plugins/secrets/components/SecretsSelect.tsx
@@ -23,11 +23,7 @@ type Props = {
 type State = { secrets: Array<{ path: string }> };
 
 class SecretsSelect extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-
-    this.state = { secrets: [] };
-  }
+  state = { secrets: [] };
 
   public componentDidMount() {
     SecretStore.addListener(

--- a/plugins/secrets/components/SecretsTable.tsx
+++ b/plugins/secrets/components/SecretsTable.tsx
@@ -32,13 +32,9 @@ class ServicesTable extends React.PureComponent<
   SecretsTableProps,
   SecretsTableState
 > {
+  state = { items: [], sortDirection: "ASC" };
   constructor(props: SecretsTableProps) {
     super(props);
-
-    this.state = {
-      items: [],
-      sortDirection: "ASC",
-    };
 
     this.handleSortClick = this.handleSortClick.bind(this);
   }

--- a/plugins/secrets/components/forms/MultiContainerSecretsFormSection.tsx
+++ b/plugins/secrets/components/forms/MultiContainerSecretsFormSection.tsx
@@ -41,10 +41,9 @@ class MultiContainerSecretsFormSection extends React.Component {
     onAddItem: PropTypes.func.isRequired,
     onRemoveItem: PropTypes.func.isRequired,
   };
+  state = { secrets: SecretStore.getSecrets() };
   constructor(props) {
     super(props);
-
-    this.state = { secrets: SecretStore.getSecrets() };
 
     this.getSecretsLines = this.getSecretsLines.bind(this);
     this.onStoreSuccess = this.onStoreSuccess.bind(this);

--- a/plugins/secrets/components/forms/SecretInput.tsx
+++ b/plugins/secrets/components/forms/SecretInput.tsx
@@ -23,6 +23,8 @@ class SecretInput extends React.PureComponent<Props, State> {
     secrets: PropTypes.arrayOf(PropTypes.string).isRequired,
   };
 
+  state = { secretOptions: this.props.secrets || [] };
+
   private readonly inputRef = React.createRef<HTMLInputElement>();
 
   constructor(props: Props) {
@@ -30,10 +32,6 @@ class SecretInput extends React.PureComponent<Props, State> {
 
     this.handleSelect = this.handleSelect.bind(this);
     this.filterList = this.filterList.bind(this);
-
-    this.state = {
-      secretOptions: props.secrets || [],
-    };
   }
 
   public handleSelect(selectedItems: string[]) {

--- a/plugins/secrets/pages/SecretDetail.tsx
+++ b/plugins/secrets/pages/SecretDetail.tsx
@@ -98,23 +98,19 @@ const SecretsDetailPageLoading = ({ path }) => (
 );
 
 class SecretDetail extends mixin(StoreMixin) {
-  constructor(...args) {
-    super(...args);
+  state = {
+    hideSecret: true,
+    removeSecretOpen: false,
+    loading: true,
+    secretFormOpen: false,
+    requestErrorType: null,
+    secret: null,
+  };
 
-    this.state = {
-      hideSecret: true,
-      removeSecretOpen: false,
-      loading: true,
-      secretFormOpen: false,
-      requestErrorType: null,
-      secret: null,
-    };
-
-    // prettier-ignore
-    this.store_listeners = [
-      {name: "secrets", events: ["secretDetailSuccess", "updateSecretSuccess", "secretDetailError"]}
-    ];
-  }
+  // prettier-ignore
+  store_listeners = [
+    {name: "secrets", events: ["secretDetailSuccess", "updateSecretSuccess", "secretDetailError"]}
+  ];
 
   componentDidMount() {
     super.componentDidMount();

--- a/plugins/secrets/pages/SecretStorePage.tsx
+++ b/plugins/secrets/pages/SecretStorePage.tsx
@@ -33,15 +33,11 @@ const SecretStoreBreadcrumbs = () => {
 };
 
 class SecretStorePage extends mixin(StoreMixin) {
-  constructor(...args) {
-    super(...args);
+  state = { requestError: false };
 
-    this.state = { requestError: false };
-
-    this.store_listeners = [
-      { name: "secrets", events: ["storesSuccess", "storesError"] },
-    ];
-  }
+  store_listeners = [
+    { name: "secrets", events: ["storesSuccess", "storesError"] },
+  ];
 
   componentDidMount() {
     super.componentDidMount();

--- a/plugins/secrets/pages/SecretsPage.tsx
+++ b/plugins/secrets/pages/SecretsPage.tsx
@@ -89,27 +89,23 @@ const PermissionErrorMessage = () => {
 };
 
 class SecretsPage extends mixin(StoreMixin) {
-  constructor(...args) {
-    super(...args);
+  state = {
+    checkedItems: {},
+    healthFilter: "all",
+    isLoadingStores: true,
+    isLoadingSecrets: true,
+    requestErrorType: null,
+    showActionDropdown: false,
+    searchString: "",
+    secretFormOpen: false,
+    secretToRemove: null,
+    selectedAction: "",
+  };
 
-    this.state = {
-      checkedItems: {},
-      healthFilter: "all",
-      isLoadingStores: true,
-      isLoadingSecrets: true,
-      requestErrorType: null,
-      showActionDropdown: false,
-      searchString: "",
-      secretFormOpen: false,
-      secretToRemove: null,
-      selectedAction: "",
-    };
-
-    // prettier-ignore
-    this.store_listeners = [
-      {name: "secrets", events: ["storesSuccess", "secretsSuccess", "secretsError"]}
-    ];
-  }
+  // prettier-ignore
+  store_listeners = [
+    { name: "secrets", events: ["storesSuccess", "secretsSuccess", "secretsError"] },
+  ];
 
   componentDidMount() {
     super.componentDidMount();

--- a/plugins/services/src/js/components/DeploymentStatusIndicator.tsx
+++ b/plugins/services/src/js/components/DeploymentStatusIndicator.tsx
@@ -17,15 +17,9 @@ import StoreMixin from "#SRC/js/mixins/StoreMixin";
 import DeploymentsModal from "./DeploymentsModal";
 
 export default class DeploymentStatusIndicator extends mixin(StoreMixin) {
-  constructor(...args) {
-    super(...args);
+  store_listeners = [{ name: "dcos", events: ["change"] }];
 
-    this.store_listeners = [{ name: "dcos", events: ["change"] }];
-
-    this.state = {
-      isOpen: false,
-    };
-  }
+  state = { isOpen: false };
 
   UNSAFE_componentWillReceiveProps() {
     const deployments = DCOSStore.deploymentsList.getItems();

--- a/plugins/services/src/js/components/DeploymentsModal.tsx
+++ b/plugins/services/src/js/components/DeploymentsModal.tsx
@@ -50,19 +50,15 @@ function columnClassNameGetter(prop, sortBy, row) {
 }
 
 class DeploymentsModal extends mixin(StoreMixin) {
-  constructor(...args) {
-    super(...args);
-
-    this.state = {
-      dcosServiceDataReceived: false,
-      dcosDeploymentsList: [],
-    };
-    // prettier-ignore
-    this.store_listeners = [
-      { name: "dcos", events: ["change"], suppressUpdate: true },
-      {name: "marathon", events: ["deploymentRollbackSuccess", "deploymentRollbackError"], suppressUpdate: true}
-    ];
-  }
+  state = {
+    dcosServiceDataReceived: false,
+    dcosDeploymentsList: [],
+  };
+  // prettier-ignore
+  store_listeners = [
+    { name: "dcos", events: ["change"], suppressUpdate: true },
+    {name: "marathon", events: ["deploymentRollbackSuccess", "deploymentRollbackError"], suppressUpdate: true}
+  ];
 
   onDcosStoreChange = () => {
     this.setState({

--- a/plugins/services/src/js/components/EmptyServicesQuotaOverview.tsx
+++ b/plugins/services/src/js/components/EmptyServicesQuotaOverview.tsx
@@ -14,9 +14,6 @@ interface EmptyServicesQuotaOverviewProps {
 class EmptyServicesQuotaOverview extends React.PureComponent<
   EmptyServicesQuotaOverviewProps
 > {
-  constructor(props: EmptyServicesQuotaOverviewProps) {
-    super(props);
-  }
   public backToServices = () => {
     if (this.props.router) {
       this.props.router.push("/services/overview");

--- a/plugins/services/src/js/components/GroupsQuotaOverviewTable.tsx
+++ b/plugins/services/src/js/components/GroupsQuotaOverviewTable.tsx
@@ -63,18 +63,13 @@ function sortForColumn(
 }
 
 class GroupsQuotaOverviewTable extends React.Component<
-  GroupsQuotaOverviewTableProps,
-  GroupsQuotaOverViewTableState
+  GroupsQuotaOverviewTableProps
 > {
-  constructor(props: Readonly<GroupsQuotaOverviewTableProps>) {
-    super(props);
-
-    this.state = {
-      groups: [],
-      sortColumn: "name",
-      sortDirection: "ASC",
-    };
-  }
+  state: GroupsQuotaOverViewTableState = {
+    groups: [],
+    sortColumn: "name",
+    sortDirection: "ASC",
+  };
 
   public componentWillReceiveProps(nextProps: GroupsQuotaOverviewTableProps) {
     this.setState({ groups: this.sortData(nextProps.groups || []) });

--- a/plugins/services/src/js/components/Highlight.tsx
+++ b/plugins/services/src/js/components/Highlight.tsx
@@ -48,10 +48,7 @@ class Highlight extends React.Component {
     selectedMatchClass: PropTypes.string,
     watching: PropTypes.number,
   };
-  constructor(...args) {
-    super(...args);
-    this.count = 0;
-  }
+  count = 0;
 
   shouldComponentUpdate(nextProps) {
     const currentProps = this.props;

--- a/plugins/services/src/js/components/LogView.tsx
+++ b/plugins/services/src/js/components/LogView.tsx
@@ -27,13 +27,12 @@ class LogView extends React.Component {
     logName: PropTypes.string,
     watching: PropTypes.number,
   };
+  state = { isAtBottom: true };
   constructor(...args) {
     super(...args);
 
     // Using variable on component to avoid the asynchronous `setState`
     this.updatingScrollPosition = false;
-
-    this.state = { isAtBottom: true };
 
     // Make sure to run this on the leading edge to capture this event as soon
     // as possible. This has impact on both checkIfCloseToTop and

--- a/plugins/services/src/js/components/MesosLogContainer.tsx
+++ b/plugins/services/src/js/components/MesosLogContainer.tsx
@@ -23,23 +23,20 @@ class MesosLogContainer extends mixin(StoreMixin) {
     task: PropTypes.object.isRequired,
     watching: PropTypes.number,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      direction: APPEND,
-      fullLog: null,
-      isFetchingPrevious: false,
-      isLoading: true,
-      hasLoadingError: 0,
-      hasOffsetLoadingError: false,
-    };
+  state = {
+    direction: APPEND,
+    fullLog: null,
+    isFetchingPrevious: false,
+    isLoading: true,
+    hasLoadingError: 0,
+    hasOffsetLoadingError: false,
+  };
 
-    // prettier-ignore
-    this.store_listeners = [
-      {name: "mesosLog", events: ["success", "error", "offsetSuccess", "offsetError"], suppressUpdate: true}
-    ];
-  }
+  // prettier-ignore
+  store_listeners = [
+    {name: "mesosLog", events: ["success", "error", "offsetSuccess", "offsetError"], suppressUpdate: true}
+  ];
 
   componentDidMount(...args) {
     super.componentDidMount(...args);

--- a/plugins/services/src/js/components/PodVolumeTable.tsx
+++ b/plugins/services/src/js/components/PodVolumeTable.tsx
@@ -16,9 +16,6 @@ class PodVolumeTable extends React.Component {
     params: PropTypes.object.isRequired,
     routes: PropTypes.array.isRequired,
   };
-  constructor() {
-    super();
-  }
 
   getData(volumes) {
     return volumes.map((volume) => ({

--- a/plugins/services/src/js/components/SearchLog.tsx
+++ b/plugins/services/src/js/components/SearchLog.tsx
@@ -16,17 +16,10 @@ class SearchLog extends React.PureComponent {
     actions: PropTypes.node,
     children: PropTypes.node,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      searchString: "",
-      totalFound: 0,
-      watching: 0,
-    };
+  state = { searchString: "", totalFound: 0, watching: 0 };
 
-    this.filterInputRef = React.createRef();
-  }
+  filterInputRef = React.createRef();
 
   UNSAFE_componentWillReceiveProps(nextProps, nextState) {
     const nextSearchString = nextState.searchString;

--- a/plugins/services/src/js/components/ServiceBreadcrumbs.tsx
+++ b/plugins/services/src/js/components/ServiceBreadcrumbs.tsx
@@ -33,17 +33,14 @@ class ServiceBreadcrumbs extends React.Component {
     runningInstancesCount: PropTypes.number,
     serviceStatus: PropTypes.object,
   };
-  constructor() {
-    super();
 
-    this.breadcrumbStatusRef = null;
-    this.primaryBreadcrumbTextRef = null;
-    this.lastStatusWidth = 0;
+  breadcrumbStatusRef = null;
+  primaryBreadcrumbTextRef = null;
+  lastStatusWidth = 0;
+  state = { shouldRenderServiceStatus: true };
 
-    this.state = {
-      shouldRenderServiceStatus: true,
-    };
-
+  constructor(props) {
+    super(props);
     this.handleViewportResize = Util.debounce(this.handleViewportResize, 100);
   }
 

--- a/plugins/services/src/js/components/ServicesQuotaOverview.tsx
+++ b/plugins/services/src/js/components/ServicesQuotaOverview.tsx
@@ -49,13 +49,10 @@ class ServicesQuotaOverviewWithMesosState extends React.Component<
   {},
   { mesosStateLoaded: boolean }
 > {
+  state = { mesosStateLoaded: false };
   constructor(props: {}) {
     super(props);
     this.onMesosStateChange = this.onMesosStateChange.bind(this);
-
-    this.state = {
-      mesosStateLoaded: false,
-    };
   }
 
   public componentDidMount() {

--- a/plugins/services/src/js/components/ServicesQuotaOverviewTable.tsx
+++ b/plugins/services/src/js/components/ServicesQuotaOverviewTable.tsx
@@ -44,15 +44,11 @@ class ServicesQuotaOverviewTable extends React.Component<
   ServicesQuotaOverviewTableProps,
   ServicesQuotaOverviewTableState
 > {
-  constructor(props: Readonly<ServicesQuotaOverviewTableProps>) {
-    super(props);
-
-    this.state = {
-      items: this.sortData(props.serviceTree.getItems(), "name", "ASC"),
-      sortColumn: "name",
-      sortDirection: "ASC",
-    };
-  }
+  state = {
+    items: this.sortData(this.props.serviceTree.getItems(), "name", "ASC"),
+    sortColumn: "name",
+    sortDirection: "ASC",
+  };
 
   public UNSAFE_componentWillReceiveProps(
     nextProps: ServicesQuotaOverviewTableProps

--- a/plugins/services/src/js/components/VolumeTable.tsx
+++ b/plugins/services/src/js/components/VolumeTable.tsx
@@ -15,9 +15,6 @@ class VolumeTable extends React.Component {
     params: PropTypes.object.isRequired,
     routes: PropTypes.array.isRequired,
   };
-  constructor() {
-    super();
-  }
 
   getData(volumes) {
     return volumes.map((volume) => ({

--- a/plugins/services/src/js/components/dsl/FuzzyTextDSLSection.tsx
+++ b/plugins/services/src/js/components/dsl/FuzzyTextDSLSection.tsx
@@ -26,15 +26,8 @@ class FuzzyTextDSLSection extends React.Component {
     onChange: PropTypes.func.isRequired,
     expression: PropTypes.instanceOf(DSLExpression).isRequired,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      data: {
-        text: "",
-      },
-    };
-  }
+  state = { data: { text: "" } };
 
   UNSAFE_componentWillReceiveProps(nextProps) {
     const { expression } = nextProps;

--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.tsx
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.tsx
@@ -68,11 +68,9 @@ class GeneralServiceFormSection extends React.Component {
     onRemoveItem: PropTypes.func,
     onClickItem: PropTypes.func,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = { convertToPodModalOpen: false };
-  }
+  state = { convertToPodModalOpen: false };
+
   handleConvertToPod = () => {
     this.props.onConvertToPod();
     this.handleCloseConvertToPodModal();

--- a/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.tsx
+++ b/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.tsx
@@ -68,10 +68,7 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
 
   state = { hasCalicoNetworking: false };
 
-  constructor(props) {
-    super(props);
-    this.store_listeners = [{ name: "virtualNetworks", events: ["success"] }];
-  }
+  store_listeners = [{ name: "virtualNetworks", events: ["success"] }];
 
   componentDidMount() {
     super.componentDidMount?.();

--- a/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.tsx
+++ b/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.tsx
@@ -40,7 +40,7 @@ import { Subscription } from "rxjs";
 const { CONTAINER, HOST } = Networking.type;
 
 const getVirtualNetworks = () =>
-  VirtualNetworksStore.getOverlays()
+  VirtualNetworksStore.overlays
     .filter((overlay) => overlay.enabled && !overlay.subnet6)
     .map(({ name }) => (
       <Trans

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.tsx
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.tsx
@@ -563,7 +563,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
     const isVirtualNetworkAvailable = (o: Overlay) =>
       o.enabled && (!isMesosContainer || !o.subnet6);
 
-    return VirtualNetworksStore.getOverlays()
+    return VirtualNetworksStore.overlays
       .filter(isVirtualNetworkAvailable)
       .map(({ name }) => (
         <Trans

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.tsx
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.tsx
@@ -53,10 +53,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
   $dcosVersion?: Subscription;
   state = { hasCalicoNetworking: false };
 
-  constructor(...args) {
-    super(...args);
-    this.store_listeners = [{ name: "virtualNetworks", events: ["success"] }];
-  }
+  store_listeners = [{ name: "virtualNetworks", events: ["success"] }];
 
   componentDidMount() {
     super.componentDidMount?.();

--- a/plugins/services/src/js/components/modals/CreateServiceJsonOnly.tsx
+++ b/plugins/services/src/js/components/modals/CreateServiceJsonOnly.tsx
@@ -32,13 +32,8 @@ class CreateServiceJsonOnly extends React.Component {
     onPropertyChange: PropTypes.func,
     service: PropTypes.object,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      appConfig: ServiceUtil.getServiceJSON(this.props.service),
-    };
-  }
+  state = { appConfig: ServiceUtil.getServiceJSON(this.props.service) };
 
   /**
    * @override

--- a/plugins/services/src/js/components/modals/CreateServiceModal.tsx
+++ b/plugins/services/src/js/components/modals/CreateServiceModal.tsx
@@ -87,11 +87,7 @@ class CreateServiceModal extends React.Component {
     params: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
   };
-  constructor(...args) {
-    super(...args);
-
-    this.state = this.getResetState(this.props);
-  }
+  state = this.getResetState(this.props);
 
   componentDidMount() {
     const { location, route } = this.props;

--- a/plugins/services/src/js/components/modals/KillPodInstanceModal.tsx
+++ b/plugins/services/src/js/components/modals/KillPodInstanceModal.tsx
@@ -37,13 +37,8 @@ class KillPodInstanceModal extends React.PureComponent {
     pod: PropTypes.instanceOf(Pod),
     selectedItems: PropTypes.array,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      errorMsg: null,
-    };
-  }
+  state = { errorMsg: null };
 
   UNSAFE_componentWillUpdate(nextProps) {
     const requestCompleted = this.props.isPending && !nextProps.isPending;

--- a/plugins/services/src/js/components/modals/KillTaskModal.tsx
+++ b/plugins/services/src/js/components/modals/KillTaskModal.tsx
@@ -34,13 +34,8 @@ class KillTaskModal extends React.PureComponent {
     open: PropTypes.bool.isRequired,
     selectedItems: PropTypes.array,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      errorMsg: null,
-    };
-  }
+  state = { errorMsg: null };
 
   UNSAFE_componentWillUpdate(nextProps) {
     const requestCompleted = this.props.isPending && !nextProps.isPending;

--- a/plugins/services/src/js/components/modals/ServiceActionDisabledModal.tsx
+++ b/plugins/services/src/js/components/modals/ServiceActionDisabledModal.tsx
@@ -37,11 +37,8 @@ class ServiceActionDisabledModal extends React.Component {
       PropTypes.instanceOf(Service),
     ]),
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = { copiedCommand: false };
-  }
+  state = { copiedCommand: false };
 
   UNSAFE_componentWillReceiveProps(nextProps) {
     if (this.props.open !== nextProps.open) {

--- a/plugins/services/src/js/components/modals/ServiceDestroyModal.tsx
+++ b/plugins/services/src/js/components/modals/ServiceDestroyModal.tsx
@@ -48,14 +48,8 @@ class ServiceDestroyModal extends React.PureComponent {
       PropTypes.instanceOf(Service),
     ]).isRequired,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      errorMsg: null,
-      serviceNameConfirmationValue: "",
-    };
-  }
+  state = { errorMsg: null, serviceNameConfirmationValue: "" };
 
   UNSAFE_componentWillUpdate(nextProps) {
     const requestCompleted = this.props.isPending && !nextProps.isPending;

--- a/plugins/services/src/js/components/modals/ServiceGroupFormModal.tsx
+++ b/plugins/services/src/js/components/modals/ServiceGroupFormModal.tsx
@@ -16,9 +16,6 @@ class ServiceGroupFormModal extends React.PureComponent {
     parentGroupId: PropTypes.string,
     onClose: PropTypes.func.isRequired,
   };
-  constructor(...args) {
-    super(...args);
-  }
 
   UNSAFE_componentWillUpdate(nextProps) {
     const requestCompleted = this.props.isPending && !nextProps.isPending;

--- a/plugins/services/src/js/components/modals/ServiceRestartModal.tsx
+++ b/plugins/services/src/js/components/modals/ServiceRestartModal.tsx
@@ -23,13 +23,8 @@ class ServiceRestartModal extends React.PureComponent {
       PropTypes.instanceOf(Service),
     ]).isRequired,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      errorMsg: null,
-    };
-  }
+  state = { errorMsg: null };
 
   UNSAFE_componentWillUpdate(nextProps) {
     const requestCompleted = this.props.isPending && !nextProps.isPending;

--- a/plugins/services/src/js/components/modals/ServiceResumeModal.tsx
+++ b/plugins/services/src/js/components/modals/ServiceResumeModal.tsx
@@ -26,14 +26,8 @@ class ServiceResumeModal extends React.PureComponent {
       PropTypes.instanceOf(Service),
     ]).isRequired,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      instancesFieldValue: 1,
-      errorMsg: null,
-    };
-  }
+  state = { instancesFieldValue: 1, errorMsg: null };
 
   UNSAFE_componentWillUpdate(nextProps) {
     const requestCompleted = this.props.isPending && !nextProps.isPending;

--- a/plugins/services/src/js/components/modals/ServiceRootGroupModal/index.tsx
+++ b/plugins/services/src/js/components/modals/ServiceRootGroupModal/index.tsx
@@ -129,11 +129,7 @@ class ServiceRootGroupModal extends React.Component<
     id: "",
   };
 
-  constructor() {
-    super(...arguments);
-
-    this.state = this.getInitialState();
-  }
+  state = this.getInitialState();
 
   public componentDidMount() {
     this.getGroupFormData();

--- a/plugins/services/src/js/components/modals/ServiceScaleFormModal.tsx
+++ b/plugins/services/src/js/components/modals/ServiceScaleFormModal.tsx
@@ -24,13 +24,8 @@ class ServiceScaleFormModal extends React.PureComponent {
       PropTypes.instanceOf(Service),
     ]).isRequired,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      errorMsg: null,
-    };
-  }
+  state = { errorMsg: null };
 
   UNSAFE_componentWillUpdate(nextProps) {
     const requestCompleted = this.props.isPending && !nextProps.isPending;

--- a/plugins/services/src/js/components/modals/ServiceStopModal.tsx
+++ b/plugins/services/src/js/components/modals/ServiceStopModal.tsx
@@ -23,13 +23,8 @@ class ServiceStopModal extends React.PureComponent {
       PropTypes.instanceOf(Service),
     ]).isRequired,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      errorMsg: null,
-    };
-  }
+  state = { errorMsg: null };
 
   UNSAFE_componentWillUpdate(nextProps) {
     const requestCompleted = this.props.isPending && !nextProps.isPending;

--- a/plugins/services/src/js/containers/framework-configuration/FrameworkConfigurationContainer.tsx
+++ b/plugins/services/src/js/containers/framework-configuration/FrameworkConfigurationContainer.tsx
@@ -26,17 +26,11 @@ class FrameworkConfigurationContainer extends React.Component {
       PropTypes.instanceOf(Application),
     ]).isRequired,
   };
+  state = { frameworkData: null, packageDetails: null, cosmosError: null };
   constructor(props) {
     super(props);
 
     const { service } = this.props;
-
-    this.state = {
-      frameworkData: null,
-      packageDetails: null,
-      cosmosError: null,
-    };
-
     CosmosPackagesStore.fetchServiceDescription(service.getId());
   }
 

--- a/plugins/services/src/js/containers/pod-debug/PodContainerTerminationTable.tsx
+++ b/plugins/services/src/js/containers/pod-debug/PodContainerTerminationTable.tsx
@@ -18,9 +18,6 @@ class PodContainerTerminationTable extends React.Component {
     className: PropTypes.string,
     containers: PropTypes.array.isRequired,
   };
-  constructor(...args) {
-    super(...args);
-  }
 
   getColumns() {
     const { getClassName } = ResourceTableUtil;

--- a/plugins/services/src/js/containers/pod-detail/PodDetail.tsx
+++ b/plugins/services/src/js/containers/pod-detail/PodDetail.tsx
@@ -30,14 +30,8 @@ class PodDetail extends React.Component<{ pod }> {
     children: PropTypes.node,
     pod: PropTypes.instanceOf(Pod),
   };
-  constructor(a, ...args) {
-    super(a, ...args);
 
-    this.state = {
-      actionDisabledID: null,
-      actionDisabledModalOpen: false,
-    };
-  }
+  state = { actionDisabledID: null, actionDisabledModalOpen: false };
 
   onActionsItemSelection(actionID) {
     const { pod } = this.props;

--- a/plugins/services/src/js/containers/pod-detail/PodHeader.tsx
+++ b/plugins/services/src/js/containers/pod-detail/PodHeader.tsx
@@ -29,9 +29,6 @@ class PodHeader extends React.Component {
     pod: PropTypes.instanceOf(Pod).isRequired,
     tabs: PropTypes.array,
   };
-  constructor(...args) {
-    super(...args);
-  }
 
   getActionButtons() {
     const { pod } = this.props;

--- a/plugins/services/src/js/containers/pod-instances/PodInstancesView.tsx
+++ b/plugins/services/src/js/containers/pod-instances/PodInstancesView.tsx
@@ -43,13 +43,8 @@ class PodInstancesView extends React.Component {
     handleExpressionChange: PropTypes.func.isRequired,
     filters: PropTypes.instanceOf(Array),
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      selectedItems: [],
-    };
-  }
+  state = { selectedItems: [] };
 
   getKillButtons() {
     if (!this.state.selectedItems.length) {

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.tsx
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.tsx
@@ -40,15 +40,9 @@ class ServiceConfiguration extends mixin(StoreMixin) {
     errors: PropTypes.array,
     service: PropTypes.instanceOf(Service).isRequired,
   };
-  constructor(...args) {
-    super(...args);
+  state = { selectedVersionID: null };
 
-    this.state = {
-      selectedVersionID: null,
-    };
-
-    this.store_listeners = [{ name: "dcos", events: ["change"] }];
-  }
+  store_listeners = [{ name: "dcos", events: ["change"] }];
 
   UNSAFE_componentWillMount() {
     const { service } = this.props;

--- a/plugins/services/src/js/containers/service-connection/SDKServiceConnectionEndpointList.tsx
+++ b/plugins/services/src/js/containers/service-connection/SDKServiceConnectionEndpointList.tsx
@@ -25,13 +25,9 @@ class SDKServiceConnectionEndpointList extends React.Component {
   static propTypes = {
     service: PropTypes.instanceOf(Service),
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      servicePreviousState: "",
-    };
-  }
+  state = { servicePreviousState: "" };
+
   handleOpenEditConfigurationModal = () => {
     const { service } = this.props;
     const { router } = this.context;

--- a/plugins/services/src/js/containers/service-connection/ServiceConnectionEndpointList.tsx
+++ b/plugins/services/src/js/containers/service-connection/ServiceConnectionEndpointList.tsx
@@ -22,9 +22,6 @@ class ServiceConnectionEndpointList extends React.Component {
     errors: PropTypes.array,
     service: PropTypes.instanceOf(Service),
   };
-  constructor(...args) {
-    super(...args);
-  }
   handleOpenEditConfigurationModal = () => {
     const { router } = this.context;
     router.push(

--- a/plugins/services/src/js/containers/service-connection/ServicePodConnectionEndpointList.tsx
+++ b/plugins/services/src/js/containers/service-connection/ServicePodConnectionEndpointList.tsx
@@ -21,9 +21,6 @@ class ServicePodConnectionEndpointList extends React.Component {
     errors: PropTypes.array,
     service: PropTypes.instanceOf(Service),
   };
-  constructor(...args) {
-    super(...args);
-  }
   handleOpenEditConfigurationModal = () => {
     const { router } = this.context;
     router.push(

--- a/plugins/services/src/js/containers/service-debug/ServiceDebugContainer.tsx
+++ b/plugins/services/src/js/containers/service-debug/ServiceDebugContainer.tsx
@@ -26,9 +26,6 @@ class ServiceDebugContainer extends React.Component {
   static propTypes = {
     service: PropTypes.instanceOf(Service),
   };
-  constructor(...args) {
-    super(...args);
-  }
 
   UNSAFE_componentWillMount() {
     MarathonStore.setShouldEmbedLastUnusedOffers(true);

--- a/plugins/services/src/js/containers/service-detail/ServiceDetail.tsx
+++ b/plugins/services/src/js/containers/service-detail/ServiceDetail.tsx
@@ -32,14 +32,7 @@ class ServiceDetail extends React.Component<
     children: PropTypes.node,
   };
 
-  constructor(a, ...args) {
-    super(a, ...args);
-
-    this.state = {
-      actionDisabledID: null,
-      actionDisabledModalOpen: false,
-    };
-  }
+  state = { actionDisabledID: null, actionDisabledModalOpen: false };
 
   handleEditClearError = () => {
     this.props.clearError(ActionKeys.SERVICE_EDIT);

--- a/plugins/services/src/js/containers/service-instances/ServiceInstancesContainer.tsx
+++ b/plugins/services/src/js/containers/service-instances/ServiceInstancesContainer.tsx
@@ -15,18 +15,12 @@ class ServiceInstancesContainer extends mixin(StoreMixin) {
     service: PropTypes.instanceOf(Service),
     params: PropTypes.object.isRequired,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      lastUpdate: 0,
-      mesosStateErrorCount: 0,
-    };
+  state = { lastUpdate: 0, mesosStateErrorCount: 0 };
 
-    this.store_listeners = [
-      { name: "state", events: ["success", "error"], suppressUpdate: true },
-    ];
-  }
+  store_listeners = [
+    { name: "state", events: ["success", "error"], suppressUpdate: true },
+  ];
   onStateStoreSuccess = () => {
     // Throttle updates
     if (

--- a/plugins/services/src/js/containers/services/ServicesContainer.tsx
+++ b/plugins/services/src/js/containers/services/ServicesContainer.tsx
@@ -153,19 +153,16 @@ class ServicesContainer extends React.Component {
     params: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
   };
-  constructor(props) {
-    super(props);
 
-    this.state = {
-      actionErrors: {},
-      fetchErrors: {},
-      filterExpression: new DSLExpression(),
-      isLoading: true,
-      lastUpdate: 0,
-      pendingActions: {},
-      roles: [],
-    };
-  }
+  state = {
+    actionErrors: {},
+    fetchErrors: {},
+    filterExpression: new DSLExpression(),
+    isLoading: true,
+    lastUpdate: 0,
+    pendingActions: {},
+    roles: [],
+  };
 
   componentDidMount() {
     // This is so we get notified when the serviceTree is ready in DCOSStore. Making this a promise would be nice.

--- a/plugins/services/src/js/containers/services/ServicesTable.tsx
+++ b/plugins/services/src/js/containers/services/ServicesTable.tsx
@@ -137,21 +137,20 @@ class ServicesTable extends React.Component {
     isFiltered: PropTypes.bool,
     services: PropTypes.array,
   };
+  state = {
+    actionDisabledService: null,
+    data: [],
+    sortColumn: "name",
+    sortDirection: "ASC",
+  };
+
+  regionRenderer = regionRendererFactory(this.props.masterRegionName);
   constructor(props) {
     super(props);
     this.actionsRenderer = actionsRendererFactory(
       this.handleActionDisabledModalOpen.bind(this),
       this.handleServiceAction.bind(this)
     );
-
-    this.state = {
-      actionDisabledService: null,
-      data: [],
-      sortColumn: "name",
-      sortDirection: "ASC",
-    };
-
-    this.regionRenderer = regionRendererFactory(props.masterRegionName);
   }
 
   // this page does not use the composite state anymore, so let's not calculate it

--- a/plugins/services/src/js/containers/tasks/TasksContainer.tsx
+++ b/plugins/services/src/js/containers/tasks/TasksContainer.tsx
@@ -30,18 +30,14 @@ class TasksContainer extends React.Component {
     tasks: PropTypes.array.isRequired,
     params: PropTypes.object.isRequired,
   };
-  constructor(...args) {
-    super(...args);
 
-    const filters = [new TasksStatusFilter(), new TaskNameTextFilter()];
-    this.state = {
-      actionErrors: {},
-      pendingActions: {},
-      filterExpression: new DSLExpression(""),
-      filters,
-      defaultFilterData: { zones: [], regions: [] },
-    };
-  }
+  state = {
+    actionErrors: {},
+    pendingActions: {},
+    filterExpression: new DSLExpression(""),
+    filters: [new TasksStatusFilter(), new TaskNameTextFilter()],
+    defaultFilterData: { zones: [], regions: [] },
+  };
 
   UNSAFE_componentWillMount() {
     this.propsToState(this.props);

--- a/plugins/services/src/js/containers/tasks/TasksView.tsx
+++ b/plugins/services/src/js/containers/tasks/TasksView.tsx
@@ -44,13 +44,8 @@ class TasksView extends React.Component {
     itemID: PropTypes.string,
     tasks: PropTypes.array,
   };
-  constructor() {
-    super();
 
-    this.state = {
-      checkedItems: {},
-    };
-  }
+  state = { checkedItems: {} };
 
   UNSAFE_componentWillReceiveProps(nextProps) {
     const prevCheckedItems = this.state.checkedItems;

--- a/plugins/services/src/js/containers/volume-detail/PodVolumeContainer.tsx
+++ b/plugins/services/src/js/containers/volume-detail/PodVolumeContainer.tsx
@@ -13,14 +13,8 @@ class PodVolumeContainer extends React.Component {
   static propTypes = {
     params: PropTypes.object.isRequired,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      isLoading: !DCOSStore.serviceDataReceived,
-      lastUpdate: 0,
-    };
-  }
+  state = { isLoading: !DCOSStore.serviceDataReceived, lastUpdate: 0 };
 
   componentDidMount() {
     DCOSStore.addChangeListener(DCOS_CHANGE, this.onStoreChange);

--- a/plugins/services/src/js/containers/volume-detail/ServiceVolumeContainer.tsx
+++ b/plugins/services/src/js/containers/volume-detail/ServiceVolumeContainer.tsx
@@ -13,14 +13,8 @@ class ServiceVolumeContainer extends React.Component {
   static propTypes = {
     params: PropTypes.object.isRequired,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      isLoading: !DCOSStore.serviceDataReceived,
-      lastUpdate: 0,
-    };
-  }
+  state = { isLoading: !DCOSStore.serviceDataReceived, lastUpdate: 0 };
 
   componentDidMount() {
     DCOSStore.addChangeListener(DCOS_CHANGE, this.onStoreChange);

--- a/plugins/services/src/js/containers/volume-detail/TaskVolumeContainer.tsx
+++ b/plugins/services/src/js/containers/volume-detail/TaskVolumeContainer.tsx
@@ -14,14 +14,8 @@ class TaskVolumeContainer extends React.Component {
   static propTypes = {
     params: PropTypes.object.isRequired,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      isLoading: !DCOSStore.serviceDataReceived,
-      lastUpdate: 0,
-    };
-  }
+  state = { isLoading: !DCOSStore.serviceDataReceived, lastUpdate: 0 };
 
   componentDidMount() {
     DCOSStore.addChangeListener(DCOS_CHANGE, this.onStoreChange);

--- a/plugins/services/src/js/pages/EditFrameworkConfiguration.tsx
+++ b/plugins/services/src/js/pages/EditFrameworkConfiguration.tsx
@@ -17,22 +17,21 @@ class EditFrameworkConfiguration extends mixin(StoreMixin) {
   static propTypes = {
     params: PropTypes.object.isRequired,
   };
+  state = {
+    packageDetails: null,
+    deployErrors: null,
+    formData: null,
+    formErrors: {},
+    cosmosErrors: null,
+    defaultConfigWarning: null,
+  };
+
+  // prettier-ignore
+  store_listeners = [
+    {name: "cosmosPackages", events: ["serviceDescriptionError", "serviceDescriptionSuccess", "serviceUpdateSuccess", "serviceUpdateError"]}
+  ];
   constructor(props) {
     super(props);
-
-    this.state = {
-      packageDetails: null,
-      deployErrors: null,
-      formData: null,
-      formErrors: {},
-      cosmosErrors: null,
-      defaultConfigWarning: null,
-    };
-
-    // prettier-ignore
-    this.store_listeners = [
-      {name: "cosmosPackages", events: ["serviceDescriptionError", "serviceDescriptionSuccess", "serviceUpdateSuccess", "serviceUpdateError"]}
-    ];
 
     CosmosPackagesStore.fetchServiceDescription(props.params.id);
   }

--- a/plugins/services/src/js/pages/task-details/TaskDetail.tsx
+++ b/plugins/services/src/js/pages/task-details/TaskDetail.tsx
@@ -20,23 +20,22 @@ class TaskDetail extends mixin(StoreMixin) {
     params: PropTypes.object,
     routes: PropTypes.array,
   };
+  state = {
+    directory: null,
+    expandClass: "large",
+    selectedLogFile: null,
+    taskDirectoryErrorCount: 0,
+  };
+
+  // prettier-ignore
+  store_listeners = [
+    { name: "marathon", events: ["appsSuccess"], unmountWhen: (store, event) => event !== "appsSuccess" || store.hasProcessedApps() },
+    { name: "state", events: ["success"], unmountWhen: (store, event) => (event === "success") && Object.keys(store.get("lastMesosState")).length },
+    { name: "summary", events: ["success"], unmountWhen: (store, event) => event === "success" && store.get("statesProcessed") },
+    { name: "taskDirectory", events: ["error", "success", "nodeStateError", "nodeStateSuccess"], suppressUpdate: true }
+  ];
   constructor(...args) {
     super(...args);
-
-    this.state = {
-      directory: null,
-      expandClass: "large",
-      selectedLogFile: null,
-      taskDirectoryErrorCount: 0,
-    };
-
-    // prettier-ignore
-    this.store_listeners = [
-      { name: "marathon", events: ["appsSuccess"], unmountWhen: (store, event) => event !== "appsSuccess" || store.hasProcessedApps() },
-      { name: "state", events: ["success"], unmountWhen: (store, event) => (event === "success") && Object.keys(store.get("lastMesosState")).length },
-      { name: "summary", events: ["success"], unmountWhen: (store, event) => event === "success" && store.get("statesProcessed") },
-      { name: "taskDirectory", events: ["error", "success", "nodeStateError", "nodeStateSuccess"], suppressUpdate: true }
-    ];
 
     this.onTaskDirectoryStoreNodeStateError = this.onTaskDirectoryStoreError;
     this.onTaskDirectoryStoreNodeStateSuccess = this.onTaskDirectoryStoreSuccess;

--- a/plugins/services/src/js/pages/task-details/TaskFileViewer.tsx
+++ b/plugins/services/src/js/pages/task-details/TaskFileViewer.tsx
@@ -27,11 +27,8 @@ export default class TaskFileViewer extends React.Component {
     selectedLogFile: PropTypes.object,
     task: PropTypes.object,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = { currentFile: null };
-  }
+  state = { currentFile: null };
 
   shouldComponentUpdate(nextProps, nextState) {
     const curProps = this.props;

--- a/plugins/services/src/js/pages/task-details/TaskLogsContainer.tsx
+++ b/plugins/services/src/js/pages/task-details/TaskLogsContainer.tsx
@@ -22,16 +22,11 @@ class TaskLogsContainer extends mixin(StoreMixin) {
     selectedLogFile: PropTypes.object,
     task: PropTypes.instanceOf(Task),
   };
-  constructor(...args) {
-    super(...args);
-    this.state = {
-      isLoading: true,
-    };
+  state = { isLoading: true };
 
-    this.store_listeners = [
-      { name: "config", events: ["success", "error"], unmountWhen: () => true },
-    ];
-  }
+  store_listeners = [
+    { name: "config", events: ["success", "error"], unmountWhen: () => true },
+  ];
 
   UNSAFE_componentWillMount() {
     // We already have a configuration, so stop loading. No need to fetch

--- a/plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx
+++ b/plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx
@@ -45,23 +45,20 @@ class TaskSystemLogsContainer extends mixin(StoreMixin) {
       slave_id: PropTypes.string,
     }),
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      direction: APPEND,
-      fullLog: null,
-      hasError: false,
-      streams: [],
-      isFetchingPrevious: false,
-      isLoading: true,
-    };
+  state = {
+    direction: APPEND,
+    fullLog: null,
+    hasError: false,
+    streams: [],
+    isFetchingPrevious: false,
+    isLoading: true,
+  };
 
-    // prettier-ignore
-    this.store_listeners = [
-      {events: ["success", "error", "streamSuccess", "streamError"], name: "systemLog", suppressUpdate: true}
-    ];
-  }
+  // prettier-ignore
+  store_listeners = [
+    {events: ["success", "error", "streamSuccess", "streamError"], name: "systemLog", suppressUpdate: true}
+  ];
 
   /**
    * @override

--- a/plugins/services/src/js/structs/Application.ts
+++ b/plugins/services/src/js/structs/Application.ts
@@ -9,14 +9,10 @@ import * as ServiceStatus from "../constants/ServiceStatus";
 import TaskStats from "./TaskStats";
 
 export default class Application extends Service {
-  constructor(...args) {
-    super(...args);
-
-    // The variable is prefixed because `Item` will expose all the properties
-    // it gets as a properties of this object and we want to avoid any naming
-    // collisions.
-    this._spec = null;
-  }
+  // The variable is prefixed because `Item` will expose all the properties
+  // it gets as a properties of this object and we want to avoid any naming
+  // collisions.
+  _spec: ApplicationSpec | null = null;
 
   /**
    * @override

--- a/plugins/services/src/js/structs/Framework.ts
+++ b/plugins/services/src/js/structs/Framework.ts
@@ -23,14 +23,10 @@ const getHighestPriorityStatus = (tasks) => {
 };
 
 export default class Framework extends Application {
-  constructor(...args) {
-    super(...args);
-
-    // The variable is prefixed because `Item` will expose all the properties
-    // it gets as a properties of this object and we want to avoid any naming
-    // collisions.
-    this._spec = null;
-  }
+  // The variable is prefixed because `Item` will expose all the properties
+  // it gets as a properties of this object and we want to avoid any naming
+  // collisions.
+  _spec: FrameworkSpec | null = null;
 
   /**
    * @override

--- a/plugins/services/src/js/structs/Service.ts
+++ b/plugins/services/src/js/structs/Service.ts
@@ -12,10 +12,8 @@ export default class Service extends Item {
     cpus?: "unlimited" | number;
     mem?: "unlimited" | number;
   };
-  constructor(...args) {
-    super(...args);
-    this._regions = undefined;
-  }
+  _regions = undefined;
+
   getId() {
     return this.get("id") || "";
   }

--- a/src/js/__tests__/__snapshots__/tslint-test.ts.snap
+++ b/src/js/__tests__/__snapshots__/tslint-test.ts.snap
@@ -513,7 +513,6 @@ exports[`tslint snapshot should be up to date 1`] = `
 /src/js/components/__tests__/Authenticated-test.tsx - require statement not part of an import statement
 /src/js/components/__tests__/NestedServiceLinks-test.tsx - Shadowed name: 'id'
 /src/js/components/charts/TasksChart.tsx - Shadowed name: 'task'
-/src/js/components/charts/TimeSeriesChart.tsx - Declaration of constructor not allowed after declaration of public instance method. Instead, this should come after public static fields.
 /src/js/components/modals/ActionsModal.tsx - Shadowed name: 'action'
 /src/js/components/modals/__tests__/CliInstallModal-test.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact
 /src/js/components/modals/__tests__/CliInstallModal-test.tsx - Lambdas are forbidden in JSX attributes due to their rendering performance impact

--- a/src/js/__tests__/__snapshots__/typecheck-test.ts.snap
+++ b/src/js/__tests__/__snapshots__/typecheck-test.ts.snap
@@ -7,15 +7,13 @@ packages/foundation-ui/src/mount/Mount.tsx: error TS2339: Property 'type' does n
 packages/foundation-ui/src/mount/Mount.tsx: error TS2339: Property 'alwaysWrap' does not exist on type *.
 packages/foundation-ui/src/mount/Mount.tsx: error TS2339: Property 'limit' does not exist on type *.
 packages/foundation-ui/src/mount/Mount.tsx: error TS2339: Property 'wrapper' does not exist on type *.
-packages/foundation-ui/src/mount/Mount.tsx: error TS2339: Property 'components' does not exist on type 'Readonly<{}>'.
 packages/foundation-ui/src/mount/MountService.ts: error TS2339: Property 'components' does not exist on type 'MountService'.
 packages/foundation-ui/src/mount/MountService.ts: error TS2339: Property 'instance' does not exist on type 'MountService'.
 packages/foundation-ui/src/mount/MountService.ts: error TS2339: Property 'components' does not exist on type 'MountService'.
 packages/foundation-ui/src/mount/MountService.ts: error TS2339: Property 'components' does not exist on type 'MountService'.
 packages/foundation-ui/src/mount/MountService.ts: error TS2339: Property 'instance' does not exist on type 'MountService'.
 packages/foundation-ui/src/mount/MountService.ts: error TS2339: Property 'rank' does not exist on type 'MountService'.
-packages/foundation-ui/src/mount/MountService.ts: error TS2556: Expected 0 arguments, but got 1 or more.
-packages/foundation-ui/src/mount/__tests__/Mount-test.tsx: error TS2322: type * is not assignable to type *.
+packages/foundation-ui/src/mount/__tests__/Mount-test.tsx: error TS2769: No overload matches this call.
 packages/foundation-ui/src/navigation/NavigationService.ts: error TS2339: Property 'instance' does not exist on type 'NavigationService'.
 packages/foundation-ui/src/navigation/NavigationService.ts: error TS2339: Property 'definition' does not exist on type 'NavigationService'.
 packages/foundation-ui/src/navigation/NavigationService.ts: error TS2339: Property 'defer' does not exist on type 'NavigationService'.
@@ -50,22 +48,13 @@ plugins/auth-providers/SDK.ts: error TS2451: Cannot redeclare block-scoped varia
 plugins/auth-providers/actions/AuthProviderActions.ts: error TS2339: Property 'oidc' does not exist on type '{}'.
 plugins/auth-providers/actions/AuthProviderActions.ts: error TS2339: Property 'saml' does not exist on type '{}'.
 plugins/auth-providers/components/AuthProviderDetailTab.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
-plugins/auth-providers/components/AuthProviderDetailTab.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/auth-providers/components/AuthProviderDetailTab.tsx: error TS2339: Property 'hideSecret' does not exist on type 'Readonly<{}>'.
-plugins/auth-providers/components/AuthProviderDetailTab.tsx: error TS2339: Property 'hideSecret' does not exist on type 'Readonly<{}>'.
-plugins/auth-providers/components/AuthProviderDetailTab.tsx: error TS2339: Property 'hideSecret' does not exist on type 'Readonly<{}>'.
 plugins/auth-providers/components/AuthProviderDetailTab.tsx: error TS2339: Property 'provider' does not exist on type *.
 plugins/auth-providers/components/AuthProviderDetailTab.tsx: error TS2339: Property 'provider' does not exist on type *.
 plugins/auth-providers/components/AuthProviderDetailTab.tsx: error TS2322: Type 'Element[]' is not assignable to type 'null'.
 plugins/auth-providers/components/AuthProvidersModal.tsx: error TS2339: Property 'open' does not exist on type *.
 plugins/auth-providers/components/AuthProvidersModal.tsx: error TS2339: Property 'provider' does not exist on type *.
-plugins/auth-providers/components/AuthProvidersModal.tsx: error TS2339: Property 'selectedProviderType' does not exist on type 'Readonly<{}>'.
 plugins/auth-providers/components/AuthProvidersModal.tsx: error TS2322: type * is not assignable to type *.
-plugins/auth-providers/components/AuthProvidersModal.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/auth-providers/components/AuthProvidersModal.tsx: error TS2339: Property 'triggerFormSubmit' does not exist on type 'AuthProvidersModal'.
 plugins/auth-providers/components/AuthProvidersModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
-plugins/auth-providers/components/AuthProvidersModal.tsx: error TS2339: Property 'triggerFormSubmit' does not exist on type 'AuthProvidersModal'.
-plugins/auth-providers/components/AuthProvidersModal.tsx: error TS2339: Property 'triggerFormSubmit' does not exist on type 'AuthProvidersModal'.
 plugins/auth-providers/components/AuthProvidersModal.tsx: error TS2339: Property 'provider' does not exist on type *.
 plugins/auth-providers/components/AuthProvidersModalButtonContents.tsx: error TS2339: Property 'onClick' does not exist on type *.
 plugins/auth-providers/components/AuthProvidersModalButtonContents.tsx: error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
@@ -73,7 +62,6 @@ plugins/auth-providers/components/AuthProvidersModalForm.tsx: error TS2339: Prop
 plugins/auth-providers/components/AuthProvidersModalForm.tsx: error TS2339: Property 'providerType' does not exist on type *.
 plugins/auth-providers/components/AuthProvidersModalForm.tsx: error TS2339: Property 'i18n' does not exist on type *.
 plugins/auth-providers/components/AuthProvidersModalForm.tsx: error TS7030: Not all code paths return a value.
-plugins/auth-providers/components/AuthProvidersModalForm.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
 plugins/auth-providers/components/AuthProvidersModalForm.tsx: error TS2339: Property 'provider' does not exist on type *.
 plugins/auth-providers/components/AuthProvidersModalForm.tsx: error TS7030: Not all code paths return a value.
 plugins/auth-providers/components/AuthProvidersModalForm.tsx: error TS2339: Property 'i18n' does not exist on type *.
@@ -84,8 +72,6 @@ plugins/auth-providers/components/AuthProvidersModalForm.tsx: error TS2339: Prop
 plugins/auth-providers/components/AuthProvidersModalForm.tsx: error TS2339: Property 'open' does not exist on type *.
 plugins/auth-providers/components/AuthProvidersModalForm.tsx: error TS2339: Property 'provider' does not exist on type *.
 plugins/auth-providers/components/AuthProvidersModalForm.tsx: error TS2339: Property 'triggerSubmit' does not exist on type *.
-plugins/auth-providers/components/AuthProvidersModalForm.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/auth-providers/components/AuthProvidersModalForm.tsx: error TS2339: Property 'store_listeners' does not exist on type 'AuthProvidersModalForm'.
 plugins/auth-providers/components/AuthProvidersModalForm.tsx: error TS2339: Property 'onClose' does not exist on type *.
 plugins/auth-providers/components/AuthProvidersModalForm.tsx: error TS2339: Property 'onError' does not exist on type *.
 plugins/auth-providers/components/AuthProvidersModalForm.tsx: error TS2339: Property 'onClose' does not exist on type *.
@@ -93,30 +79,21 @@ plugins/auth-providers/components/AuthProvidersModalForm.tsx: error TS2339: Prop
 plugins/auth-providers/components/AuthProvidersModalForm.tsx: error TS2339: Property 'onClose' does not exist on type *.
 plugins/auth-providers/components/AuthProvidersModalForm.tsx: error TS2339: Property 'provider' does not exist on type *.
 plugins/auth-providers/components/AuthProvidersModalForm.tsx: error TS2339: Property 'providerType' does not exist on type *.
-plugins/auth-providers/components/AuthProvidersTable.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/auth-providers/components/AuthProvidersTable.tsx: error TS6133: 'prop' is declared but its value is never read.
 plugins/auth-providers/components/AuthProvidersTable.tsx: error TS2339: Property 'data' does not exist on type *.
-plugins/auth-providers/components/LoginModalProviders.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/auth-providers/components/LoginModalProviders.tsx: error TS2339: Property 'store_listeners' does not exist on type 'LoginModalProviders'.
-plugins/auth-providers/components/LoginModalProviders.tsx: error TS2556: Expected 0 arguments, but got 1 or more.
 plugins/auth-providers/components/LoginModalProviders.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
 plugins/auth-providers/components/LoginModalProviders.tsx: error TS2339: Property 'onUpdate' does not exist on type *.
-plugins/auth-providers/components/LoginModalProviders.tsx: error TS2339: Property 'showAllProviders' does not exist on type 'Readonly<{}>'.
 plugins/auth-providers/components/LoginModalProviders.tsx: error TS2339: Property 'target' does not exist on type *.
 plugins/auth-providers/components/LoginModalProviders.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/auth-providers/components/LoginModalProviders.tsx: error TS2339: Property 'showAllProviders' does not exist on type 'Readonly<{}>'.
 plugins/auth-providers/components/LoginModalProviders.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/auth-providers/components/LoginModalProviders.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
-plugins/auth-providers/components/LoginModalProviders.tsx: error TS2339: Property 'showAllProviders' does not exist on type 'Readonly<{}>'.
 plugins/auth-providers/components/LoginModalProviders.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/auth-providers/hooks.tsx: error TS6133: 'previousContent' is declared but its value is never read.
 plugins/auth-providers/hooks.tsx: error TS2322: type * is not assignable to type *.
 plugins/auth-providers/index.ts: error TS2306: File '/plugins/auth-providers/SDK.ts' is not a module.
 plugins/auth-providers/pages/AuthProviderDetailPage.tsx: error TS6133: 'error' is declared but its value is never read.
 plugins/auth-providers/pages/AuthProviderDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
-plugins/auth-providers/pages/AuthProviderDetailPage.tsx: error TS2339: Property 'deleteUpdateError' does not exist on type 'Readonly<{}>'.
 plugins/auth-providers/pages/AuthProviderDetailPage.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
-plugins/auth-providers/pages/AuthProviderDetailPage.tsx: error TS2339: Property 'deleteUpdateError' does not exist on type 'Readonly<{}>'.
 plugins/auth-providers/pages/AuthProviderDetailPage.tsx: error TS2531: Object is possibly 'null'.
 plugins/auth-providers/pages/AuthProviderDetailPage.tsx: error TS2339: Property 'description' does not exist on type 'AuthProvider'.
 plugins/auth-providers/pages/AuthProviderDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
@@ -124,28 +101,15 @@ plugins/auth-providers/pages/AuthProviderDetailPage.tsx: error TS2339: Property 
 plugins/auth-providers/pages/AuthProviderDetailPage.tsx: error TS2339: Property 'i18n' does not exist on type *.
 plugins/auth-providers/pages/AuthProviderDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/auth-providers/pages/AuthProviderDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
-plugins/auth-providers/pages/AuthProviderDetailPage.tsx: error TS2339: Property 'fetchedDetailsError' does not exist on type 'Readonly<{}>'.
 plugins/auth-providers/pages/AuthProviderDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/auth-providers/pages/AuthProviderDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
-plugins/auth-providers/pages/AuthProviderDetailPage.tsx: error TS2339: Property 'pendingRequest' does not exist on type 'Readonly<{}>'.
-plugins/auth-providers/pages/AuthProviderDetailPage.tsx: error TS2339: Property 'openDeleteConfirmation' does not exist on type 'Readonly<{}>'.
-plugins/auth-providers/pages/AuthProviderDetailPage.tsx: error TS2339: Property 'openEditFormModal' does not exist on type 'Readonly<{}>'.
-plugins/auth-providers/pages/AuthProviderDetailPage.tsx: error TS2322: type * is not assignable to type *.
+plugins/auth-providers/pages/AuthProviderDetailPage.tsx: error TS2769: No overload matches this call.
 plugins/auth-providers/pages/AuthProviderDetailPage.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
-plugins/auth-providers/pages/AuthProviderDetailPage.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/auth-providers/pages/AuthProviderDetailPage.tsx: error TS2339: Property 'store_listeners' does not exist on type 'AuthProviderDetailPage'.
 plugins/auth-providers/pages/AuthProviderDetailPage.tsx: error TS2556: Expected 0 arguments, but got 1 or more.
 plugins/auth-providers/pages/AuthProviderDetailPage.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
 plugins/auth-providers/pages/AuthProviderDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/auth-providers/pages/AuthProviderDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
-plugins/auth-providers/pages/AuthProvidersTab.tsx: error TS2339: Property 'storeFetchError' does not exist on type 'Readonly<{}>'.
-plugins/auth-providers/pages/AuthProvidersTab.tsx: error TS2339: Property 'storeFetchSuccess' does not exist on type 'Readonly<{}>'.
-plugins/auth-providers/pages/AuthProvidersTab.tsx: error TS2339: Property 'searchString' does not exist on type 'Readonly<{}>'.
-plugins/auth-providers/pages/AuthProvidersTab.tsx: error TS2339: Property 'searchString' does not exist on type 'Readonly<{}>'.
-plugins/auth-providers/pages/AuthProvidersTab.tsx: error TS2339: Property 'openNewItemModal' does not exist on type 'Readonly<{}>'.
 plugins/auth-providers/pages/AuthProvidersTab.tsx: error TS2339: Property 'routeConfig' does not exist on type *.
-plugins/auth-providers/pages/AuthProvidersTab.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/auth-providers/pages/AuthProvidersTab.tsx: error TS2339: Property 'store_listeners' does not exist on type 'AuthProvidersTab'.
 plugins/auth-providers/pages/AuthProvidersTab.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
 plugins/auth-providers/pages/AuthProvidersTab.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/auth-providers/pages/AuthProvidersTab.tsx: error TS2322: type * is not assignable to type *.
@@ -162,17 +126,12 @@ plugins/auth/components/AuthenticatedUserAccountDropdown.tsx: error TS2556: Expe
 plugins/auth/components/AuthenticatedUserAccountDropdown.tsx: error TS2339: Property 'userLabel' does not exist on type 'AuthenticatedUserAccountDropdown'.
 plugins/auth/components/AuthenticatedUserAccountDropdown.tsx: error TS2339: Property 'userLabel' does not exist on type 'AuthenticatedUserAccountDropdown'.
 plugins/auth/components/AuthenticatedUserAccountDropdown.tsx: error TS2339: Property 'userLabel' does not exist on type 'AuthenticatedUserAccountDropdown'.
-plugins/auth/components/LoginModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/auth/components/LoginModal.tsx: error TS2339: Property 'disableLogin' does not exist on type 'Readonly<{}>'.
-plugins/auth/components/LoginModal.tsx: error TS2339: Property 'disableLogin' does not exist on type 'Readonly<{}>'.
 plugins/auth/components/LoginModal.tsx: error TS2339: Property 'target' does not exist on type *.
-plugins/auth/components/LoginModal.tsx: error TS2554: Expected 1-2 arguments, but got 0.
-plugins/auth/components/LoginModal.tsx: error TS2339: Property 'store_listeners' does not exist on type 'LoginModal'.
 plugins/auth/components/LoginModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
 plugins/auth/components/LoginModal.tsx: error TS2339: Property 'target' does not exist on type *.
 plugins/auth/components/LoginModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/auth/components/LoginModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
 plugins/auth/components/LoginModal.tsx: error TS2307: Cannot find module '#SRC/img/logo-d2iq-dcos.svg' or its corresponding type declarations.
+plugins/auth/components/LoginModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
 plugins/auth/components/LoginPage.tsx: error TS2339: Property 'location' does not exist on type *.
 plugins/auth/components/LoginPage.tsx: error TS2322: type * is not assignable to type *.
 plugins/auth/hooks.tsx: error TS2554: Expected 2 arguments, but got 0.
@@ -203,7 +162,6 @@ plugins/banner/hooks.tsx: error TS2339: Property 'contentWindow' does not exist 
 plugins/banner/hooks.tsx: error TS2339: Property 'location' does not exist on type 'Global'.
 plugins/bootstrap-config/SDK.ts: error TS2451: Cannot redeclare block-scoped variable 'SDK'.
 plugins/bootstrap-config/components/BootstrapConfigHashMap.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/bootstrap-config/components/BootstrapConfigHashMap.tsx: error TS2339: Property 'loaded' does not exist on type 'Readonly<{}>'.
 plugins/bootstrap-config/components/BootstrapConfigHashMap.tsx: error TS2769: No overload matches this call.
 plugins/bootstrap-config/index.ts: error TS2306: File '/plugins/bootstrap-config/SDK.ts' is not a module.
 plugins/bootstrap-config/stores/BootstrapConfigStore.ts: error TS2556: Expected 0 arguments, but got 1 or more.
@@ -249,20 +207,17 @@ plugins/catalog/src/js/repositories/components/AddRepositoryFormModal.tsx: error
 plugins/catalog/src/js/repositories/components/AddRepositoryFormModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
 plugins/catalog/src/js/repositories/components/AddRepositoryFormModal.tsx: error TS2339: Property 'open' does not exist on type *.
 plugins/catalog/src/js/repositories/components/AddRepositoryFormModal.tsx: error TS2339: Property 'errorMsg' does not exist on type *.
-plugins/catalog/src/js/repositories/components/AddRepositoryFormModal.tsx: error TS2554: Expected 1-2 arguments, but got 0.
 plugins/catalog/src/js/repositories/components/AddRepositoryFormModal.tsx: error TS2339: Property 'addRepository' does not exist on type *.
 plugins/catalog/src/js/repositories/components/AddRepositoryFormModal.tsx: error TS2339: Property 'numberOfRepositories' does not exist on type *.
 plugins/catalog/src/js/repositories/components/AddRepositoryFormModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
 plugins/catalog/src/js/repositories/components/AddRepositoryFormModal.tsx: error TS2339: Property 'pendingRequest' does not exist on type *.
 plugins/catalog/src/js/repositories/components/RepositoriesError.tsx: error TS2741: Property 'addButton' is missing in type * but required in type *.
 plugins/catalog/src/js/repositories/components/RepositoriesLoading.tsx: error TS2741: Property 'addButton' is missing in type * but required in type *.
-plugins/catalog/src/js/repositories/components/RepositoriesTabUI.tsx: error TS2554: Expected 1-2 arguments, but got 0.
-plugins/catalog/src/js/repositories/components/RepositoriesTabUI.tsx: error TS2339: Property 'addRepositoryModalOpen' does not exist on type 'Readonly<{}>'.
 plugins/catalog/src/js/repositories/components/RepositoriesTabUI.tsx: error TS2339: Property 'repositories' does not exist on type *.
 plugins/catalog/src/js/repositories/components/RepositoriesTabUI.tsx: error TS2339: Property 'searchTerm' does not exist on type *.
 plugins/catalog/src/js/repositories/components/RepositoriesTabUI.tsx: error TS2339: Property 'onSearch' does not exist on type *.
 plugins/catalog/src/js/repositories/components/RepositoriesTabUI.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/catalog/src/js/repositories/components/RepositoriesTabUI.tsx: error TS2322: type * is not assignable to type *.
+plugins/catalog/src/js/repositories/components/RepositoriesTabUI.tsx: error TS2769: No overload matches this call.
 plugins/catalog/src/js/repositories/components/RepositoriesTabUI.tsx: error TS2322: type * is not assignable to type *.
 plugins/catalog/src/js/repositories/components/RepositoriesTable.tsx: error TS6133: 'prop' is declared but its value is never read.
 plugins/catalog/src/js/repositories/components/RepositoriesTable.tsx: error TS6133: 'prop' is declared but its value is never read.
@@ -271,8 +226,6 @@ plugins/catalog/src/js/repositories/components/RepositoriesTable.tsx: error TS23
 plugins/catalog/src/js/repositories/components/RepositoriesTable.tsx: error TS6133: 'prop' is declared but its value is never read.
 plugins/catalog/src/js/repositories/components/RepositoriesTable.tsx: error TS2339: Property 'repositories' does not exist on type *.
 plugins/catalog/src/js/repositories/components/RepositoriesTable.tsx: error TS2322: type * is not assignable to type *.
-plugins/catalog/src/js/repositories/components/RepositoriesTable.tsx: error TS2339: Property 'repositoryToRemove' does not exist on type 'Readonly<{}>'.
-plugins/catalog/src/js/repositories/components/RepositoriesTable.tsx: error TS2554: Expected 1-2 arguments, but got 0.
 plugins/catalog/src/js/repositories/components/RepositoriesTable.tsx: error TS2339: Property 'repositories' does not exist on type *.
 plugins/catalog/src/js/repositories/data/__tests__/PackageRepositoryClient-test.ts: error TS2345: Argument of type 'Observable<string>' is not assignable to parameter of type 'Observable<RequestResponse<unknown>>'.
 plugins/catalog/src/js/repositories/data/__tests__/PackageRepositoryClient-test.ts: error TS2345: Argument of type 'Observable<string>' is not assignable to parameter of type 'Observable<RequestResponse<unknown>>'.
@@ -300,8 +253,6 @@ plugins/catalog/src/js/repositories/data/repositoriesModel.ts: error TS6133: 'pa
 plugins/catalog/src/js/repositories/data/repositoriesModel.ts: error TS2339: Property 'id' does not exist on type 'RepositoryExtension'.
 plugins/cluster-linking/SDK.ts: error TS2451: Cannot redeclare block-scoped variable 'SDK'.
 plugins/cluster-linking/components/ClusterLinkingModalContent.tsx: error TS2339: Property 'clusters' does not exist on type *.
-plugins/cluster-linking/components/ClusterLinkingModalTrigger.tsx: error TS2339: Property 'clusterList' does not exist on type 'Readonly<{}>'.
-plugins/cluster-linking/components/ClusterLinkingModalTrigger.tsx: error TS2554: Expected 1-2 arguments, but got 0.
 plugins/cluster-linking/components/LinkedClustersTable.tsx: error TS2339: Property 'clusters' does not exist on type *.
 plugins/cluster-linking/components/LinkedClustersTable.tsx: error TS2554: Expected 1-2 arguments, but got 0.
 plugins/cluster-linking/components/LinkedClustersTable.tsx: error TS6133: 'prop' is declared but its value is never read.
@@ -317,9 +268,6 @@ plugins/cluster-linking/components/LinkedClustersTable.tsx: error TS2322: Type '
 plugins/cluster-linking/index.ts: error TS2306: File '/plugins/cluster-linking/SDK.ts' is not a module.
 plugins/cluster-linking/pages/LinkedClustersPage.tsx: error TS2322: type * is not assignable to type *.
 plugins/cluster-linking/pages/LinkedClustersPage.tsx: error TS2339: Property 'routeConfig' does not exist on type *.
-plugins/cluster-linking/pages/LinkedClustersPage.tsx: error TS2554: Expected 1-2 arguments, but got 0.
-plugins/cluster-linking/pages/LinkedClustersPage.tsx: error TS2339: Property 'clusters' does not exist on type 'Readonly<{}>'.
-plugins/cluster-linking/pages/LinkedClustersPage.tsx: error TS2339: Property 'loading' does not exist on type 'Readonly<{}>'.
 plugins/cluster-linking/stores/ClusterLinkingStore.ts: error TS2556: Expected 0 arguments, but got 1 or more.
 plugins/cluster-linking/stores/ClusterLinkingStore.ts: error TS2339: Property 'clusters' does not exist on type 'ClusterLinkingStore'.
 plugins/cluster-linking/stores/ClusterLinkingStore.ts: error TS2339: Property 'clusters' does not exist on type 'ClusterLinkingStore'.
@@ -328,8 +276,8 @@ plugins/cluster-linking/stores/ClusterLinkingStore.ts: error TS2339: Property 'c
 plugins/dss/SDK.ts: error TS2451: Cannot redeclare block-scoped variable 'SDK'.
 plugins/dss/components/DSSInput.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/dss/components/DSSInput.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
-plugins/dss/components/DSSInput.tsx: error TS2322: type * is not assignable to type *.
-plugins/dss/components/DSSVolumeConfig.tsx: error TS2322: type * is not assignable to type *.
+plugins/dss/components/DSSInput.tsx: error TS2769: No overload matches this call.
+plugins/dss/components/DSSVolumeConfig.tsx: error TS2769: No overload matches this call.
 plugins/dss/index.ts: error TS1192: Module '\\"/plugins/dss/hooks\\"' has no default export.
 plugins/dss/index.ts: error TS2306: File '/plugins/dss/SDK.ts' is not a module.
 plugins/external-links/SDK.ts: error TS2451: Cannot redeclare block-scoped variable 'SDK'.
@@ -346,10 +294,10 @@ plugins/jobs/src/js/JobDetailPageContainer.tsx: error TS2769: No overload matche
 plugins/jobs/src/js/__tests__/jobsRunNow-test.ts: error TS2339: Property 'mockReturnValue' does not exist on type *.
 plugins/jobs/src/js/__tests__/jobsToggleSchedule-test.ts: error TS2339: Property 'mockReturnValue' does not exist on type *.
 plugins/jobs/src/js/__tests__/jobsToggleSchedule-test.ts: error TS2339: Property 'mockReturnValue' does not exist on type *.
+plugins/jobs/src/js/components/JobsForm.tsx: error TS2769: No overload matches this call.
 plugins/jobs/src/js/components/JobsForm.tsx: error TS2322: type * is not assignable to type *.
 plugins/jobs/src/js/components/JobsForm.tsx: error TS2322: type * is not assignable to type *.
-plugins/jobs/src/js/components/JobsForm.tsx: error TS2322: type * is not assignable to type *.
-plugins/jobs/src/js/components/JobsFormConfig.tsx: error TS2322: type * is not assignable to type *.
+plugins/jobs/src/js/components/JobsFormConfig.tsx: error TS2769: No overload matches this call.
 plugins/jobs/src/js/components/JobsOverviewList.tsx: error TS2769: No overload matches this call.
 plugins/jobs/src/js/components/form/ArgsSection.tsx: error TS2322: Type 'void' is not assignable to type *.
 plugins/jobs/src/js/components/form/ContainerFormSection.tsx: error TS2322: type * is not assignable to type *.
@@ -368,7 +316,7 @@ plugins/jobs/src/js/components/form/ScheduleFormSection.tsx: error TS2322: Type 
 plugins/jobs/src/js/components/form/ScheduleFormSection.tsx: error TS2322: type * is not assignable to type *.
 plugins/jobs/src/js/components/form/VolumesFormSection.tsx: error TS2322: type * is not assignable to type *.
 plugins/jobs/src/js/components/form/VolumesFormSection.tsx: error TS2322: Type 'void' is not assignable to type *.
-plugins/jobs/src/js/components/form/VolumesFormSection.tsx: error TS2322: type * is not assignable to type *.
+plugins/jobs/src/js/components/form/VolumesFormSection.tsx: error TS2769: No overload matches this call.
 plugins/jobs/src/js/components/form/helpers/JobParsers.ts: error TS2339: Property 'run' does not exist on type '{}'.
 plugins/jobs/src/js/components/form/helpers/JobParsers.ts: error TS2339: Property 'run' does not exist on type '{}'.
 plugins/jobs/src/js/components/form/helpers/JobParsers.ts: error TS2339: Property 'schedules' does not exist on type '{}'.
@@ -551,15 +499,15 @@ plugins/jobs/src/js/data/__tests__/JobModel-test.ts: error TS2345: Argument of t
 plugins/jobs/src/js/jobsRunNow.ts: error TS2571: Object is of type 'unknown'.
 plugins/jobs/src/js/jobsToggleSchedule.ts: error TS2571: Object is of type 'unknown'.
 plugins/jobs/src/js/pages/JobRunHistoryTable.tsx: error TS2339: Property 'isParent' does not exist on type '{}'.
-plugins/jobs/src/js/pages/JobRunHistoryTable.tsx: error TS2339: Property 'mesosStateStoreLoaded' does not exist on type 'Readonly<{}>'.
 plugins/jobs/src/js/pages/JobRunHistoryTable.tsx: error TS2322: Type '\\"bottom-left\\"' is not assignable to type 'Direction'.
 plugins/jobs/src/js/pages/JobRunHistoryTable.tsx: error TS2339: Property 'isExpanded' does not exist on type '{}'.
 plugins/jobs/src/js/pages/JobRunHistoryTable.tsx: error TS2339: Property 'clickHandler' does not exist on type '{}'.
 plugins/jobs/src/js/pages/JobRunHistoryTable.tsx: error TS2339: Property 'isParent' does not exist on type '{}'.
 plugins/jobs/src/js/pages/JobRunHistoryTable.tsx: error TS6133: 'prop' is declared but its value is never read.
-plugins/jobs/src/js/pages/JobRunHistoryTable.tsx: error TS2339: Property 'selectedID' does not exist on type 'Readonly<{}>'.
 plugins/jobs/src/js/pages/JobRunHistoryTable.tsx: error TS2339: Property 'jobRuns' does not exist on type *.
+plugins/jobs/src/js/pages/JobRunHistoryTable.tsx: error TS2538: Type 'null' cannot be used as an index type.
 plugins/jobs/src/js/pages/JobRunHistoryTable.tsx: error TS2322: type * is not assignable to type *.
+plugins/jobs/src/js/pages/JobRunHistoryTable.tsx: error TS2322: Type 'null' is not assignable to type 'string'.
 plugins/jobs/src/js/pages/JobTaskDetailPage.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/jobs/src/js/pages/JobTaskDetailPage.tsx: error TS2339: Property 'mesosStateStoreLoaded' does not exist on type 'Readonly<{}>'.
 plugins/jobs/src/js/pages/JobTaskDetailPage.tsx: error TS2339: Property 'location' does not exist on type *.
@@ -570,14 +518,17 @@ plugins/licensing/SDK.ts: error TS2451: Cannot redeclare block-scoped variable '
 plugins/licensing/actions/LicensingActions.ts: error TS2306: File '/plugins/licensing/config/LicensingConfig.ts' is not a module.
 plugins/licensing/actions/__tests__/LicensingActions-test.ts: error TS2306: File '/plugins/licensing/config/LicensingConfig.ts' is not a module.
 plugins/licensing/components/LicensingBanner.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
-plugins/licensing/components/LicensingBanner.tsx: error TS2339: Property 'licensingSummary' does not exist on type 'Readonly<{}>'.
-plugins/licensing/components/LicensingBanner.tsx: error TS2339: Property 'licensingSummary' does not exist on type 'Readonly<{}>'.
+plugins/licensing/components/LicensingBanner.tsx: error TS2531: Object is possibly 'null'.
+plugins/licensing/components/LicensingBanner.tsx: error TS2531: Object is possibly 'null'.
+plugins/licensing/components/LicensingBanner.tsx: error TS2531: Object is possibly 'null'.
+plugins/licensing/components/LicensingBanner.tsx: error TS2531: Object is possibly 'null'.
+plugins/licensing/components/LicensingBanner.tsx: error TS2531: Object is possibly 'null'.
+plugins/licensing/components/LicensingBanner.tsx: error TS2531: Object is possibly 'null'.
 plugins/licensing/components/LicensingExpirationRow.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/licensing/components/LicensingExpirationRow.tsx: error TS2339: Property 'licensingSummary' does not exist on type 'Readonly<{}>'.
-plugins/licensing/components/LicensingExpirationRow.tsx: error TS2322: Type 'Element' is not assignable to type 'string'.
+plugins/licensing/components/LicensingExpirationRow.tsx: error TS2769: No overload matches this call.
 plugins/licensing/components/LicensingNodeCapacityRow.tsx: error TS2306: File '/plugins/licensing/config/LicensingConfig.ts' is not a module.
-plugins/licensing/components/LicensingNodeCapacityRow.tsx: error TS2339: Property 'licensingSummary' does not exist on type 'Readonly<{}>'.
-plugins/licensing/components/LicensingNodeCapacityRow.tsx: error TS2339: Property 'licensingSummary' does not exist on type 'Readonly<{}>'.
+plugins/licensing/components/LicensingNodeCapacityRow.tsx: error TS2531: Object is possibly 'null'.
+plugins/licensing/components/LicensingNodeCapacityRow.tsx: error TS2531: Object is possibly 'null'.
 plugins/licensing/index.ts: error TS2306: File '/plugins/licensing/SDK.ts' is not a module.
 plugins/licensing/stores/LicensingStore.ts: error TS2339: Property 'licensingSummary' does not exist on type 'LicensingStore'.
 plugins/licensing/stores/LicensingStore.ts: error TS2556: Expected 0 arguments, but got 1 or more.
@@ -597,37 +548,22 @@ plugins/networking/SDK.ts: error TS2451: Cannot redeclare block-scoped variable 
 plugins/networking/index.ts: error TS2306: File '/plugins/networking/SDK.ts' is not a module.
 plugins/networking/submodules/internal-load-balancing/__tests__/utils-test.ts: error TS2451: Cannot redeclare block-scoped variable 'DEFAULT_MAX_INTERVALS'.
 plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
-plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2339: Property 'backendConnectionRequestErrorCount' does not exist on type 'BackendDetailPage'.
-plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2339: Property 'backendConnectionRequestSuccess' does not exist on type 'BackendDetailPage'.
-plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2339: Property 'backendConnectionRequestErrorCount' does not exist on type 'BackendDetailPage'.
-plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2339: Property 'selectedDropdownItem' does not exist on type 'Readonly<{}>'.
 plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2339: Property 'details' does not exist on type '{}'.
 plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2339: Property 'details' does not exist on type '{}'.
-plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2339: Property 'tabs_tabs' does not exist on type 'BackendDetailPage'.
-plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2339: Property 'backendConnectionRequestErrorCount' does not exist on type 'BackendDetailPage'.
-plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2339: Property 'backendConnectionRequestSuccess' does not exist on type 'BackendDetailPage'.
+plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2339: Property 'details' does not exist on type *.
 plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2531: Object is possibly 'null'.
 plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2322: type * is not assignable to type *.
-plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2339: Property 'selectedDropdownItem' does not exist on type 'Readonly<{}>'.
-plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2322: type * is not assignable to type *.
+plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2769: No overload matches this call.
 plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2769: No overload matches this call.
 plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2531: Object is possibly 'null'.
 plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2339: Property 'details' does not exist on type 'BackendConnection'.
-plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2339: Property 'tabs_tabs' does not exist on type 'BackendDetailPage'.
-plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2339: Property 'currentTab' does not exist on type 'Readonly<{}>'.
+plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2538: Type 'undefined' cannot be used as an index type.
 plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
-plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2339: Property 'store_listeners' does not exist on type 'BackendDetailPage'.
-plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2339: Property 'tabs_tabs' does not exist on type 'BackendDetailPage'.
-plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2339: Property 'tabs_tabs' does not exist on type 'BackendDetailPage'.
-plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2339: Property 'backendConnectionRequestSuccess' does not exist on type 'BackendDetailPage'.
-plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2339: Property 'backendConnectionRequestErrorCount' does not exist on type 'BackendDetailPage'.
 plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
 plugins/networking/submodules/internal-load-balancing/components/BackendDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
-plugins/networking/submodules/internal-load-balancing/components/BackendsTable.tsx: error TS2769: No overload matches this call.
 plugins/networking/submodules/internal-load-balancing/components/BackendsTable.tsx: error TS2769: No overload matches this call.
 plugins/networking/submodules/internal-load-balancing/components/BackendsTable.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/networking/submodules/internal-load-balancing/components/BackendsTable.tsx: error TS6133: 'prop' is declared but its value is never read.
@@ -635,22 +571,15 @@ plugins/networking/submodules/internal-load-balancing/components/BackendsTable.t
 plugins/networking/submodules/internal-load-balancing/components/BackendsTable.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/networking/submodules/internal-load-balancing/components/BackendsTable.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/networking/submodules/internal-load-balancing/components/BackendsTable.tsx: error TS2339: Property 'backends' does not exist on type *.
-plugins/networking/submodules/internal-load-balancing/components/BackendsTable.tsx: error TS2339: Property 'searchString' does not exist on type 'Readonly<{}>'.
-plugins/networking/submodules/internal-load-balancing/components/BackendsTable.tsx: error TS2339: Property 'searchString' does not exist on type 'Readonly<{}>'.
-plugins/networking/submodules/internal-load-balancing/components/BackendsTable.tsx: error TS2339: Property 'searchString' does not exist on type 'Readonly<{}>'.
-plugins/networking/submodules/internal-load-balancing/components/BackendsTable.tsx: error TS2554: Expected 1-2 arguments, but got 0.
 plugins/networking/submodules/internal-load-balancing/components/BackendsTable.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
 plugins/networking/submodules/internal-load-balancing/components/BackendsTable.tsx: error TS2339: Property 'mountedAt' does not exist on type 'BackendsTable'.
 plugins/networking/submodules/internal-load-balancing/components/BackendsTable.tsx: error TS2339: Property 'displayedData' does not exist on type *.
 plugins/networking/submodules/internal-load-balancing/components/BackendsTable.tsx: error TS2769: No overload matches this call.
+plugins/networking/submodules/internal-load-balancing/components/BackendsTable.tsx: error TS2769: No overload matches this call.
 plugins/networking/submodules/internal-load-balancing/components/ClientsTable.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/networking/submodules/internal-load-balancing/components/ClientsTable.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
-plugins/networking/submodules/internal-load-balancing/components/ClientsTable.tsx: error TS2554: Expected 1-2 arguments, but got 0.
-plugins/networking/submodules/internal-load-balancing/components/ClientsTable.tsx: error TS2339: Property 'searchString' does not exist on type 'Readonly<{}>'.
 plugins/networking/submodules/internal-load-balancing/components/ClientsTable.tsx: error TS2339: Property 'clients' does not exist on type *.
 plugins/networking/submodules/internal-load-balancing/components/ClientsTable.tsx: error TS2339: Property 'mountedAt' does not exist on type 'ClientsTable'.
-plugins/networking/submodules/internal-load-balancing/components/LineChart.tsx: error TS2339: Property 'disabledSeries' does not exist on type 'Readonly<{}>'.
-plugins/networking/submodules/internal-load-balancing/components/LineChart.tsx: error TS2339: Property 'graph' does not exist on type 'LineChart'.
 plugins/networking/submodules/internal-load-balancing/components/LineChart.tsx: error TS2339: Property 'graph' does not exist on type 'LineChart'.
 plugins/networking/submodules/internal-load-balancing/components/LineChart.tsx: error TS2339: Property 'height' does not exist on type *.
 plugins/networking/submodules/internal-load-balancing/components/LineChart.tsx: error TS2339: Property 'width' does not exist on type *.
@@ -660,12 +589,7 @@ plugins/networking/submodules/internal-load-balancing/components/LineChart.tsx: 
 plugins/networking/submodules/internal-load-balancing/components/LineChart.tsx: error TS2339: Property 'data' does not exist on type *.
 plugins/networking/submodules/internal-load-balancing/components/LineChart.tsx: error TS2339: Property 'chartOptions' does not exist on type *.
 plugins/networking/submodules/internal-load-balancing/components/LineChart.tsx: error TS2339: Property 'chartOptions' does not exist on type *.
-plugins/networking/submodules/internal-load-balancing/components/LineChart.tsx: error TS2339: Property 'disabledSeries' does not exist on type 'Readonly<{}>'.
-plugins/networking/submodules/internal-load-balancing/components/LineChart.tsx: error TS2339: Property 'chartRef' does not exist on type 'LineChart'.
-plugins/networking/submodules/internal-load-balancing/components/LineChart.tsx: error TS2554: Expected 1-2 arguments, but got 0.
-plugins/networking/submodules/internal-load-balancing/components/LineChart.tsx: error TS2339: Property 'chartRef' does not exist on type 'LineChart'.
 plugins/networking/submodules/internal-load-balancing/components/LineChart.tsx: error TS2339: Property 'graph' does not exist on type 'LineChart'.
-plugins/networking/submodules/internal-load-balancing/components/LineChart.tsx: error TS2339: Property 'chartRef' does not exist on type 'LineChart'.
 plugins/networking/submodules/internal-load-balancing/components/LineChart.tsx: error TS2339: Property 'graph' does not exist on type 'LineChart'.
 plugins/networking/submodules/internal-load-balancing/components/LineChart.tsx: error TS2339: Property 'width' does not exist on type *.
 plugins/networking/submodules/internal-load-balancing/components/LineChart.tsx: error TS2339: Property 'height' does not exist on type *.
@@ -676,11 +600,9 @@ plugins/networking/submodules/internal-load-balancing/components/LineChart.tsx: 
 plugins/networking/submodules/internal-load-balancing/components/LineChart.tsx: error TS2339: Property 'width' does not exist on type *.
 plugins/networking/submodules/internal-load-balancing/components/LineChart.tsx: error TS2339: Property 'labels' does not exist on type *.
 plugins/networking/submodules/internal-load-balancing/components/LineChart.tsx: error TS2339: Property 'data' does not exist on type *.
-plugins/networking/submodules/internal-load-balancing/components/LineChart.tsx: error TS2339: Property 'disabledSeries' does not exist on type 'Readonly<{}>'.
+plugins/networking/submodules/internal-load-balancing/components/LineChart.tsx: error TS2339: Property 'graph' does not exist on type 'LineChart'.
 plugins/networking/submodules/internal-load-balancing/components/LineChart.tsx: error TS2339: Property 'graph' does not exist on type 'LineChart'.
 plugins/networking/submodules/internal-load-balancing/components/LoadBalancingPage.ts: error TS2339: Property 'routeConfig' does not exist on type *.
-plugins/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.tsx: error TS2339: Property 'searchString' does not exist on type 'Readonly<{}>'.
-plugins/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.tsx: error TS2339: Property 'searchString' does not exist on type 'Readonly<{}>'.
 plugins/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.tsx: error TS2339: Property 'getName' does not exist on type '{}'.
 plugins/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.tsx: error TS2339: Property 'getVIP' does not exist on type '{}'.
 plugins/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.tsx: error TS2339: Property 'getVIPString' does not exist on type '{}'.
@@ -690,17 +612,12 @@ plugins/networking/submodules/internal-load-balancing/components/LoadBalancingTa
 plugins/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.tsx: error TS2339: Property 'getApplicationReachabilityPercent' does not exist on type '{}'.
 plugins/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.tsx: error TS2339: Property 'getMachineReachabilityPercent' does not exist on type '{}'.
 plugins/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.tsx: error TS2339: Property 'getP99Latency' does not exist on type '{}'.
-plugins/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.tsx: error TS2339: Property 'receivedVIPSummaries' does not exist on type 'Readonly<{}>'.
-plugins/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.tsx: error TS2339: Property 'vipSummariesErrorCount' does not exist on type 'Readonly<{}>'.
 plugins/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
-plugins/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.tsx: error TS2554: Expected 1-2 arguments, but got 0.
-plugins/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.tsx: error TS2339: Property 'store_listeners' does not exist on type 'LoadBalancingTabContent'.
 plugins/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
 plugins/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
-plugins/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.tsx: error TS2339: Property 'vipSummariesErrorCount' does not exist on type 'Readonly<{}>'.
 plugins/networking/submodules/internal-load-balancing/components/NetworkItemChart.tsx: error TS2339: Property 'selectedData' does not exist on type *.
 plugins/networking/submodules/internal-load-balancing/components/NetworkItemChart.tsx: error TS2339: Property 'i18n' does not exist on type *.
 plugins/networking/submodules/internal-load-balancing/components/NetworkItemChart.tsx: error TS2339: Property 'chartData' does not exist on type *.
@@ -720,50 +637,33 @@ plugins/networking/submodules/internal-load-balancing/components/NetworkItemChar
 plugins/networking/submodules/internal-load-balancing/components/NetworkItemChart.tsx: error TS2339: Property 'selectedData' does not exist on type *.
 plugins/networking/submodules/internal-load-balancing/components/NetworkItemChart.tsx: error TS2339: Property 'i18n' does not exist on type *.
 plugins/networking/submodules/internal-load-balancing/components/NetworkItemDetails.tsx: error TS2339: Property 'details' does not exist on type *.
-plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2322: type * is not assignable to type *.
-plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2339: Property 'selectedDropdownItem' does not exist on type 'Readonly<{}>'.
+plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2769: No overload matches this call.
 plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
-plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2339: Property 'selectedDropdownItem' does not exist on type 'Readonly<{}>'.
 plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
-plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2339: Property 'currentTab' does not exist on type 'Readonly<{}>'.
 plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2339: Property 'details' does not exist on type '{}'.
 plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2339: Property 'details' does not exist on type '{}'.
-plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2339: Property 'tabs_tabs' does not exist on type 'VIPDetail'.
-plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2339: Property 'vipDetailErrorCount' does not exist on type 'VIPDetail'.
-plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2339: Property 'vipDetailSuccess' does not exist on type 'VIPDetail'.
-plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2339: Property 'tabs_tabs' does not exist on type 'VIPDetail'.
-plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2339: Property 'currentTab' does not exist on type 'Readonly<{}>'.
+plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2339: Property 'details' does not exist on type *.
+plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2538: Type 'undefined' cannot be used as an index type.
 plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2531: Object is possibly 'null'.
 plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2322: type * is not assignable to type *.
-plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2339: Property 'selectedDropdownItem' does not exist on type 'Readonly<{}>'.
 plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2769: No overload matches this call.
 plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2531: Object is possibly 'null'.
 plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2339: Property 'details' does not exist on type 'VIPDetail'.
 plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
-plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2339: Property 'store_listeners' does not exist on type 'VIPDetail'.
-plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2339: Property 'tabs_tabs' does not exist on type 'VIPDetail'.
-plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2339: Property 'tabs_tabs' does not exist on type 'VIPDetail'.
-plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2339: Property 'vipDetailSuccess' does not exist on type 'VIPDetail'.
-plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2339: Property 'vipDetailErrorCount' does not exist on type 'VIPDetail'.
 plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2556: Expected 0 arguments, but got 1 or more.
 plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
 plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2556: Expected 0 arguments, but got 1 or more.
 plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
-plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2339: Property 'vipDetailErrorCount' does not exist on type 'VIPDetail'.
-plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2339: Property 'vipDetailErrorCount' does not exist on type 'VIPDetail'.
-plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2339: Property 'vipDetailSuccess' does not exist on type 'VIPDetail'.
-plugins/networking/submodules/internal-load-balancing/components/VIPDetailPage.tsx: error TS2339: Property 'vipDetailErrorCount' does not exist on type 'VIPDetail'.
 plugins/networking/submodules/internal-load-balancing/components/VIPsTable.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/networking/submodules/internal-load-balancing/components/VIPsTable.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/networking/submodules/internal-load-balancing/components/VIPsTable.tsx: error TS6133: 'prop' is declared but its value is never read.
 plugins/networking/submodules/internal-load-balancing/components/VIPsTable.tsx: error TS2339: Property 'vips' does not exist on type *.
 plugins/networking/submodules/internal-load-balancing/components/VIPsTable.tsx: error TS2554: Expected 1-2 arguments, but got 0.
-plugins/networking/submodules/internal-load-balancing/components/__tests__/BackendsTable-test.tsx: error TS2322: type * is not assignable to type *.
+plugins/networking/submodules/internal-load-balancing/components/__tests__/BackendsTable-test.tsx: error TS2769: No overload matches this call.
 plugins/networking/submodules/internal-load-balancing/stores/NetworkingBackendConnectionsStore.ts: error TS2556: Expected 0 arguments, but got 1 or more.
 plugins/networking/submodules/internal-load-balancing/stores/NetworkingBackendConnectionsStore.ts: error TS2322: Type 'number' is not assignable to type 'null'.
 plugins/networking/submodules/internal-load-balancing/stores/NetworkingBackendConnectionsStore.ts: error TS2769: No overload matches this call.
@@ -799,19 +699,16 @@ plugins/networking/submodules/internal-load-balancing/utils.ts: error TS2339: Pr
 plugins/nodes/src/js/components/DrainNodeForm.tsx: error TS2322: type * is not assignable to type *.
 plugins/nodes/src/js/components/DrainNodeForm.tsx: error TS2322: type * is not assignable to type *.
 plugins/nodes/src/js/components/DrainNodeForm.tsx: error TS2322: type * is not assignable to type *.
-plugins/nodes/src/js/components/HealthTab.tsx: error TS2339: Property 'params' does not exist on type *.
-plugins/nodes/src/js/components/HealthTab.tsx: error TS2339: Property 'node' does not exist on type *.
-plugins/nodes/src/js/components/HealthTab.tsx: error TS2339: Property 'healthFilter' does not exist on type 'Readonly<{}>'.
-plugins/nodes/src/js/components/HealthTab.tsx: error TS2339: Property 'searchString' does not exist on type 'Readonly<{}>'.
 plugins/nodes/src/js/components/HealthTab.tsx: error TS2339: Property 'i18n' does not exist on type *.
 plugins/nodes/src/js/components/HealthTab.tsx: error TS2339: Property 'units' does not exist on type *.
 plugins/nodes/src/js/components/HealthTab.tsx: error TS2339: Property 'healthFilter' does not exist on type 'HealthTab'.
-plugins/nodes/src/js/components/HealthTab.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/nodes/src/js/components/HealthTab.tsx: error TS2339: Property 'healthFilter' does not exist on type 'HealthTab'.
 plugins/nodes/src/js/components/HealthTab.tsx: error TS2339: Property 'healthFilter' does not exist on type 'HealthTab'.
 plugins/nodes/src/js/components/HealthTab.tsx: error TS2339: Property 'healthFilter' does not exist on type 'HealthTab'.
 plugins/nodes/src/js/components/HealthTab.tsx: error TS6133: 'prop' is declared but its value is never read.
 plugins/nodes/src/js/components/HealthTab.tsx: error TS6133: 'prop' is declared but its value is never read.
+plugins/nodes/src/js/components/HealthTab.tsx: error TS2339: Property 'params' does not exist on type *.
+plugins/nodes/src/js/components/HealthTab.tsx: error TS2339: Property 'node' does not exist on type *.
 plugins/nodes/src/js/components/NodesGridDials.tsx: error TS2554: Expected 1-3 arguments, but got 0.
 plugins/nodes/src/js/components/NodesGridDials.tsx: error TS6133: 'v' is declared but its value is never read.
 plugins/nodes/src/js/components/NodesGridDials.tsx: error TS2322: Type 'any' is not assignable to type 'never'.
@@ -837,22 +734,17 @@ plugins/nodes/src/js/components/dsl/NodesHealthDSLSection.tsx: error TS2339: Pro
 plugins/nodes/src/js/components/dsl/NodesHealthDSLSection.tsx: error TS2339: Property 'is_unhealthy' does not exist on type 'string'.
 plugins/nodes/src/js/components/dsl/NodesRegionDSLFilter.tsx: error TS7041: The containing arrow function captures the global value of 'this'.
 plugins/nodes/src/js/components/dsl/NodesStatusDSLSection.tsx: error TS2345: Argument of type 'string' is not assignable to parameter of type 'undefined'.
-plugins/nodes/src/js/components/dsl/NodesStatusDSLSection.tsx: error TS2322: type * is not assignable to type *.
+plugins/nodes/src/js/components/dsl/NodesStatusDSLSection.tsx: error TS2769: No overload matches this call.
 plugins/nodes/src/js/components/dsl/NodesTypeDSLSection.tsx: error TS2345: Argument of type '\\"private\\"' is not assignable to parameter of type 'undefined'.
 plugins/nodes/src/js/components/dsl/NodesTypeDSLSection.tsx: error TS2345: Argument of type '\\"public\\"' is not assignable to parameter of type 'undefined'.
 plugins/nodes/src/js/components/dsl/NodesTypeDSLSection.tsx: error TS2339: Property 'is_private' does not exist on type 'string'.
 plugins/nodes/src/js/components/dsl/NodesTypeDSLSection.tsx: error TS2339: Property 'is_public' does not exist on type 'string'.
 plugins/nodes/src/js/components/dsl/NodesZoneDSLFilter.tsx: error TS7041: The containing arrow function captures the global value of 'this'.
-plugins/nodes/src/js/data/MesosMasters.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/nodes/src/js/data/MesosMasters.tsx: error TS2339: Property 'stream' does not exist on type 'MesosMasters'.
 plugins/nodes/src/js/data/MesosMasters.tsx: error TS2339: Property 'stream' does not exist on type *.
 plugins/nodes/src/js/data/MesosMasters.tsx: error TS2339: Property 'initialState' does not exist on type *.
 plugins/nodes/src/js/data/MesosMasters.tsx: error TS2339: Property 'subscription' does not exist on type 'MesosMasters'.
-plugins/nodes/src/js/data/MesosMasters.tsx: error TS2339: Property 'stream' does not exist on type 'MesosMasters'.
 plugins/nodes/src/js/data/MesosMasters.tsx: error TS2339: Property 'subscription' does not exist on type 'MesosMasters'.
-plugins/nodes/src/js/data/MesosMasters.tsx: error TS2339: Property 'masters' does not exist on type 'Readonly<{}>'.
-plugins/nodes/src/js/data/MesosMasters.tsx: error TS2339: Property 'leader' does not exist on type 'Readonly<{}>'.
-plugins/nodes/src/js/data/MesosMasters.tsx: error TS2322: type * is not assignable to type *.
+plugins/nodes/src/js/data/MesosMasters.tsx: error TS2769: No overload matches this call.
 plugins/nodes/src/js/data/MesosMastersHealth.ts: error TS2571: Object is of type 'unknown'.
 plugins/nodes/src/js/data/__tests__/MesosMastersLeader-test.ts: error TS2554: Expected 1 arguments, but got 0.
 plugins/nodes/src/js/filters/NodesHealthFilter.ts: error TS6133: 'filterType' is declared but its value is never read.
@@ -867,12 +759,10 @@ plugins/nodes/src/js/pages/NodesAgents.tsx: error TS2322: type * is not assignab
 plugins/nodes/src/js/pages/NodesAgents.tsx: error TS2345: Argument of type '\\"statesProcessed\\"' is not assignable to parameter of type 'never'.
 plugins/nodes/src/js/pages/NodesAgents.tsx: error TS2345: Argument of type '\\"states\\"' is not assignable to parameter of type 'never'.
 plugins/nodes/src/js/pages/NodesAgents.tsx: error TS2531: Object is possibly 'null'.
-plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.tsx: error TS2339: Property 'defaultFilterData' does not exist on type 'Readonly<{}>'.
+plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.tsx: error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'never'.
+plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.tsx: error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'never'.
 plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.tsx: error TS2339: Property 'onFilterChange' does not exist on type *.
-plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.tsx: error TS2339: Property 'filterExpression' does not exist on type 'Readonly<{}>'.
-plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.tsx: error TS2339: Property 'filters' does not exist on type 'Readonly<{}>'.
-plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.tsx: error TS2339: Property 'defaultFilterData' does not exist on type 'Readonly<{}>'.
-plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.tsx: error TS2322: type * is not assignable to type *.
+plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.tsx: error TS2769: No overload matches this call.
 plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.tsx: error TS2339: Property 'location' does not exist on type *.
 plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.tsx: error TS2339: Property 'selectedResource' does not exist on type *.
 plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.tsx: error TS2339: Property 'onResourceSelectionChange' does not exist on type *.
@@ -889,105 +779,71 @@ plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.tsx: error TS2339: Pr
 plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.tsx: error TS2339: Property 'i18n' does not exist on type *.
 plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.tsx: error TS2339: Property 'serviceFilter' does not exist on type 'HostsPageContent'.
 plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.tsx: error TS2769: No overload matches this call.
-plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.tsx: error TS2339: Property 'onResetFilter' does not exist on type *.
 plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.tsx: error TS2339: Property 'serviceFilter' does not exist on type 'HostsPageContent'.
 plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.tsx: error TS2339: Property 'serviceFilter' does not exist on type 'HostsPageContent'.
 plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.tsx: error TS2339: Property 'serviceFilter' does not exist on type 'HostsPageContent'.
 plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.tsx: error TS2339: Property 'onFilterChange' does not exist on type *.
-plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.tsx: error TS2339: Property 'filters' does not exist on type 'Readonly<{}>'.
 plugins/nodes/src/js/pages/nodes/NodeDetailHealthTab.tsx: error TS2322: type * is not assignable to type *.
-plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2322: type * is not assignable to type 'never'.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2322: Type 'string' is not assignable to type 'never'.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2322: type * is not assignable to type 'never'.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'node' does not exist on type *.
-plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'summaryStatesProcessed' does not exist on type 'Readonly<{}>'.
-plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'mesosStateLoaded' does not exist on type 'Readonly<{}>'.
+plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'summaryStatesProcessed' does not exist on type *.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'node' does not exist on type *.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
-plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'selectedNodeToDrain' does not exist on type 'Readonly<{}>'.
-plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'selectedNodeToDeactivate' does not exist on type 'Readonly<{}>'.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2769: No overload matches this call.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'store_listeners' does not exist on type 'NodeDetailPage'.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'node' does not exist on type *.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'node' does not exist on type *.
-plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'mesosStateLoaded' does not exist on type 'Readonly<{}>'.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2345: Argument of type '\\"statesProcessed\\"' is not assignable to parameter of type 'never'.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2345: Argument of type '\\"states\\"' is not assignable to parameter of type 'never'.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2339: Property 'node' does not exist on type *.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2322: Type 'string' is not assignable to type 'never'.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2322: type * is not assignable to type 'never'.
 plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2322: Type 'string' is not assignable to type 'never'.
-plugins/nodes/src/js/pages/nodes/NodeDetailTab.tsx: error TS2339: Property 'version' does not exist on type 'Readonly<{}>'.
-plugins/nodes/src/js/pages/nodes/NodeDetailTab.tsx: error TS2339: Property 'masterRegion' does not exist on type 'Readonly<{}>'.
+plugins/nodes/src/js/pages/nodes/NodeDetailPage.tsx: error TS2322: type * is not assignable to type 'never'.
+plugins/nodes/src/js/pages/nodes/NodeDetailTab.tsx: error TS2339: Property 'version' does not exist on type *.
 plugins/nodes/src/js/pages/nodes/NodeDetailTab.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/nodes/src/js/pages/nodes/NodeDetailTab.tsx: error TS2339: Property 'node' does not exist on type *.
-plugins/nodes/src/js/pages/nodes/NodeDetailTaskTab.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/nodes/src/js/pages/nodes/NodeDetailTaskTab.tsx: error TS2339: Property 'lastUpdate' does not exist on type 'Readonly<{}>'.
-plugins/nodes/src/js/pages/nodes/NodeDetailTaskTab.tsx: error TS2339: Property 'isLoading' does not exist on type 'Readonly<{}>'.
 plugins/nodes/src/js/pages/nodes/NodeDetailTaskTab.tsx: error TS2339: Property 'location' does not exist on type *.
 plugins/nodes/src/js/pages/nodes/NodeDetailTaskTab.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/nodes/src/js/pages/nodes/NodeDetailTaskTab.tsx: error TS2339: Property 'params' does not exist on type *.
-plugins/nodes/src/js/pages/nodes/NodeDetailTaskTab.tsx: error TS2322: type * is not assignable to type *.
+plugins/nodes/src/js/pages/nodes/NodeDetailTaskTab.tsx: error TS2769: No overload matches this call.
 plugins/nodes/src/js/pages/nodes/NodeDetailTaskTab.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
-plugins/nodes/src/js/pages/nodes/NodesTaskDetailPage.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/nodes/src/js/pages/nodes/NodesTaskDetailPage.tsx: error TS2339: Property 'store_listeners' does not exist on type 'NodesTaskDetailPage'.
 plugins/nodes/src/js/pages/nodes/NodesTaskDetailPage.tsx: error TS2339: Property 'location' does not exist on type *.
 plugins/nodes/src/js/pages/nodes/NodesTaskDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/nodes/src/js/pages/nodes/NodesTaskDetailPage.tsx: error TS2339: Property 'routes' does not exist on type *.
 plugins/nodes/src/js/pages/nodes/NodesTaskDetailPage.tsx: error TS2339: Property 'node' does not exist on type *.
-plugins/nodes/src/js/pages/nodes/NodesUnitsHealthDetailPage.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/nodes/src/js/pages/nodes/NodesUnitsHealthDetailPage.tsx: error TS2339: Property 'store_listeners' does not exist on type 'NodesUnitsHealthDetailPage'.
 plugins/nodes/src/js/pages/nodes/NodesUnitsHealthDetailPage.tsx: error TS2556: Expected 0 arguments, but got 1 or more.
 plugins/nodes/src/js/pages/nodes/NodesUnitsHealthDetailPage.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
 plugins/nodes/src/js/pages/nodes/NodesUnitsHealthDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/nodes/src/js/pages/nodes/NodesUnitsHealthDetailPage.tsx: error TS2339: Property 'node' does not exist on type *.
 plugins/nodes/src/js/pages/nodes/NodesUnitsHealthDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
-plugins/nodes/src/js/pages/nodes/NodesUnitsHealthDetailPage.tsx: error TS2322: type * is not assignable to type *.
+plugins/nodes/src/js/pages/nodes/NodesUnitsHealthDetailPage.tsx: error TS2769: No overload matches this call.
 plugins/nodes/src/js/pages/nodes/NodesUnitsHealthDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
-plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.tsx: error TS2339: Property 'hiddenServices' does not exist on type 'Readonly<{}>'.
 plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.tsx: error TS2769: No overload matches this call.
 plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.tsx: error TS2345: Argument of type '\\"lastMesosState\\"' is not assignable to parameter of type 'never'.
-plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.tsx: error TS2339: Property 'mesosStateErrorCount' does not exist on type 'Readonly<{}>'.
-plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.tsx: error TS2339: Property 'filteredNodes' does not exist on type 'Readonly<{}>'.
-plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.tsx: error TS2339: Property 'hasLoadingError' does not exist on type 'Readonly<{}>'.
-plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.tsx: error TS2339: Property 'hiddenServices' does not exist on type 'Readonly<{}>'.
-plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.tsx: error TS2339: Property 'receivedEmptyMesosState' does not exist on type 'Readonly<{}>'.
-plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.tsx: error TS2339: Property 'receivedNodeHealthResponse' does not exist on type 'Readonly<{}>'.
-plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.tsx: error TS2339: Property 'resourcesByFramework' does not exist on type 'Readonly<{}>'.
-plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.tsx: error TS2339: Property 'serviceColors' does not exist on type 'Readonly<{}>'.
 plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.tsx: error TS2339: Property 'services' does not exist on type *.
 plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.tsx: error TS2339: Property 'selectedResource' does not exist on type *.
+plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.tsx: error TS2769: No overload matches this call.
 plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
-plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.tsx: error TS2559: Type 'never[]' has no properties in common with type *.
-plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.tsx: error TS2339: Property 'store_listeners' does not exist on type 'NodesGridContainer'.
-plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.tsx: error TS2339: Property 'serviceColors' does not exist on type 'Readonly<{}>'.
 plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.tsx: error TS2554: Expected 3 arguments, but got 2.
 plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.tsx: error TS2339: Property 'other' does not exist on type '{}'.
-plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.tsx: error TS2339: Property 'filters' does not exist on type 'Readonly<{}>'.
 plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.tsx: error TS2339: Property 'hosts' does not exist on type *.
-plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.tsx: error TS2339: Property 'filters' does not exist on type 'Readonly<{}>'.
-plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2339: Property 'filters' does not exist on type 'Readonly<{}>'.
-plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2339: Property 'filteredNodes' does not exist on type 'Readonly<{}>'.
-plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2339: Property 'masterRegion' does not exist on type 'Readonly<{}>'.
-plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2339: Property 'selectedNodeToDrain' does not exist on type 'Readonly<{}>'.
-plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2339: Property 'selectedNodeToDeactivate' does not exist on type 'Readonly<{}>'.
 plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2339: Property 'networks' does not exist on type *.
+plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2769: No overload matches this call.
 plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2339: Property 'networks' does not exist on type 'object'.
 plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2769: No overload matches this call.
 plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2322: Type 'Observable<unknown>' is not assignable to type 'Subscribable<ReactNode>'.
 plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2345: Argument of type * is not assignable to parameter of type *.
 plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2339: Property 'store_listeners' does not exist on type 'NodesTableContainer'.
 plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2339: Property 'location' does not exist on type *.
 plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2339: Property 'hosts' does not exist on type *.
 plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2339: Property 'networks' does not exist on type *.
 plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2554: Expected 4 arguments, but got 3.
 plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2554: Expected 4 arguments, but got 3.
-plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2339: Property 'filters' does not exist on type 'Readonly<{}>'.
 plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2339: Property 'networks' does not exist on type *.
 plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2339: Property 'hosts' does not exist on type *.
 plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2339: Property 'private_ip' does not exist on type 'never'.
@@ -1052,7 +908,8 @@ plugins/organization/components/AccountActionsModal.tsx: error TS2339: Property 
 plugins/organization/components/AccountActionsModal.tsx: error TS2339: Property 'action' does not exist on type *.
 plugins/organization/components/AccountActionsModal.tsx: error TS2339: Property 'itemID' does not exist on type *.
 plugins/organization/components/AccountActionsModal.tsx: error TS2339: Property 'selectedItems' does not exist on type *.
-plugins/organization/components/AccountActionsModal.tsx: error TS2339: Property 'selectedItem' does not exist on type 'Readonly<{}>'.
+plugins/organization/components/AccountActionsModal.tsx: error TS2531: Object is possibly 'null'.
+plugins/organization/components/AccountActionsModal.tsx: error TS2531: Object is possibly 'null'.
 plugins/organization/components/AccountActionsModal.tsx: error TS2339: Property 'deleteAccount' does not exist on type 'AccountsActionsModal'.
 plugins/organization/components/AccountActionsModal.tsx: error TS2345: Argument of type * is not assignable to parameter of type *.
 plugins/organization/components/AccountAdvancedACLsTab.ts: error TS2339: Property 'itemID' does not exist on type *.
@@ -1062,8 +919,7 @@ plugins/organization/components/AccountAdvancedACLsTab.ts: error TS2339: Propert
 plugins/organization/components/AccountAdvancedACLsTab.ts: error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
 plugins/organization/components/AccountAdvancedACLsTab.ts: error TS2322: Type 'any' is not assignable to type 'never'.
 plugins/organization/components/AccountAdvancedACLsTab.ts: error TS2322: Type 'boolean' is not assignable to type 'never'.
-plugins/organization/components/AccountAdvancedACLsTab.ts: error TS2339: Property 'store_listeners' does not exist on type 'AccountAdvancedACLsTab'.
-plugins/organization/components/AccountAdvancedACLsTab.ts: error TS2339: Property 'store_listeners' does not exist on type 'AccountAdvancedACLsTab'.
+plugins/organization/components/AccountAdvancedACLsTab.ts: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/organization/components/AccountAdvancedACLsTab.ts: error TS2551: Property 'onAclStoreUserRevokeSuccess' does not exist on type 'AccountAdvancedACLsTab'. Did you mean 'onAclStoreUserGrantSuccess'?
 plugins/organization/components/AccountAdvancedACLsTab.ts: error TS2551: Property 'onAclStoreUserRevokeError' does not exist on type 'AccountAdvancedACLsTab'. Did you mean 'onAclStoreUserGrantError'?
 plugins/organization/components/AccountAdvancedACLsTab.ts: error TS2339: Property 'fetchPermissionsDebounced' does not exist on type 'AccountAdvancedACLsTab'.
@@ -1076,10 +932,8 @@ plugins/organization/components/AccountAdvancedACLsTab.ts: error TS2556: Expecte
 plugins/organization/components/AccountAdvancedACLsTab.ts: error TS2339: Property 'fetchPermissions' does not exist on type *.
 plugins/organization/components/AccountAdvancedACLsTab.ts: error TS2417: Class static side 'typeof AccountAdvancedACLsTab' incorrectly extends base class static side 'typeof AdvancedACLsTab'.
 plugins/organization/components/AccountAdvancedACLsTab.ts: error TS2339: Property 'fetchPermissions' does not exist on type *.
-plugins/organization/components/AccountAdvancedACLsTab.ts: error TS2339: Property 'itemPermissionsRequestErrors' does not exist on type 'Readonly<{}>'.
 plugins/organization/components/AccountDetailPage.tsx: error TS2339: Property 'getAccount' does not exist on type 'AccountDetailPage'.
 plugins/organization/components/AccountDetailPage.tsx: error TS2339: Property 'getAccountID' does not exist on type 'AccountDetailPage'.
-plugins/organization/components/AccountDetailPage.tsx: error TS2339: Property 'deleteUpdateError' does not exist on type 'Readonly<{}>'.
 plugins/organization/components/AccountDetailPage.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/organization/components/AccountDetailPage.tsx: error TS2339: Property 'getAccount' does not exist on type 'AccountDetailPage'.
 plugins/organization/components/AccountDetailPage.tsx: error TS2339: Property 'getAccount' does not exist on type 'AccountDetailPage'.
@@ -1087,59 +941,34 @@ plugins/organization/components/AccountDetailPage.tsx: error TS2339: Property 'g
 plugins/organization/components/AccountDetailPage.tsx: error TS2322: type * is not assignable to type *.
 plugins/organization/components/AccountDetailPage.tsx: error TS2339: Property 'getAccount' does not exist on type 'AccountDetailPage'.
 plugins/organization/components/AccountDetailPage.tsx: error TS2339: Property 'getAccount' does not exist on type 'AccountDetailPage'.
-plugins/organization/components/AccountDetailPage.tsx: error TS2339: Property 'fetchedDetailsError' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/AccountDetailPage.tsx: error TS2339: Property 'currentTab' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/AccountDetailPage.tsx: error TS2339: Property 'pendingRequest' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/AccountDetailPage.tsx: error TS2339: Property 'pendingRequest' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/AccountDetailPage.tsx: error TS2339: Property 'openDeleteConfirmation' does not exist on type 'Readonly<{}>'.
 plugins/organization/components/AccountDetailPage.tsx: error TS2339: Property 'renderEditFormModal' does not exist on type 'AccountDetailPage'.
 plugins/organization/components/AccountDetailPage.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
 plugins/organization/components/AccountDetailPage.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/organization/components/AccountDetailPage.tsx: error TS2339: Property 'tabs_tabs' does not exist on type 'AccountDetailPage'.
-plugins/organization/components/AccountDetailPage.tsx: error TS2339: Property 'tabs_tabs' does not exist on type 'AccountDetailPage'.
-plugins/organization/components/AccountDetailPage.tsx: error TS2339: Property 'store_listeners' does not exist on type 'AccountDetailPage'.
 plugins/organization/components/AccountDetailPage.tsx: error TS2339: Property 'onACLChange' does not exist on type 'AccountDetailPage'.
-plugins/organization/components/AccountDetailPage.tsx: error TS2339: Property 'tabs_tabs' does not exist on type 'AccountDetailPage'.
-plugins/organization/components/AccountDetailPage.tsx: error TS2339: Property 'currentTab' does not exist on type 'Readonly<{}>'.
+plugins/organization/components/AccountDetailPage.tsx: error TS2538: Type 'undefined' cannot be used as an index type.
 plugins/organization/components/AccountDetailPage.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
 plugins/organization/components/AccountDetailPage.tsx: error TS2339: Property 'deleteAccount' does not exist on type 'AccountDetailPage'.
-plugins/organization/components/AccountGroupMembershipTab.tsx: error TS2339: Property 'gid' does not exist on type '{}'.
 plugins/organization/components/AccountGroupMembershipTab.tsx: error TS2339: Property 'gid' does not exist on type '{}'.
 plugins/organization/components/AccountGroupMembershipTab.tsx: error TS2339: Property 'accountID' does not exist on type *.
 plugins/organization/components/AccountGroupMembershipTab.tsx: error TS2339: Property 'getAccountDetails' does not exist on type *.
 plugins/organization/components/AccountGroupMembershipTab.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/organization/components/AccountGroupMembershipTab.tsx: error TS2339: Property 'searchString' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/AccountGroupMembershipTab.tsx: error TS2339: Property 'requestGroupsError' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/AccountGroupMembershipTab.tsx: error TS2339: Property 'requestGroupsSuccess' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/AccountGroupMembershipTab.tsx: error TS2339: Property 'selectedGroup' does not exist on type 'Readonly<{}>'.
 plugins/organization/components/AccountGroupMembershipTab.tsx: error TS2339: Property 'typeahead' does not exist on type 'AccountGroupMembershipTab'.
 plugins/organization/components/AccountGroupMembershipTab.tsx: error TS2769: No overload matches this call.
-plugins/organization/components/AccountGroupMembershipTab.tsx: error TS2322: type * is not assignable to type *.
-plugins/organization/components/AccountGroupMembershipTab.tsx: error TS2554: Expected 1-2 arguments, but got 0.
-plugins/organization/components/AccountGroupMembershipTab.tsx: error TS2339: Property 'store_listeners' does not exist on type 'AccountGroupMembershipTab'.
+plugins/organization/components/AccountGroupMembershipTab.tsx: error TS2769: No overload matches this call.
 plugins/organization/components/AccountGroupMembershipTab.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
 plugins/organization/components/AccountGroupMembershipTab.tsx: error TS2339: Property 'accountID' does not exist on type *.
 plugins/organization/components/AccountGroupMembershipTab.tsx: error TS2339: Property 'typeahead' does not exist on type 'AccountGroupMembershipTab'.
 plugins/organization/components/AccountGroupMembershipTab.tsx: error TS2339: Property 'getAccountDetails' does not exist on type *.
 plugins/organization/components/AccountGroupMembershipTab.tsx: error TS2339: Property 'get' does not exist on type '{}'.
-plugins/organization/components/AccountGroupTable.tsx: error TS2339: Property 'groupID' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/AccountGroupTable.tsx: error TS2339: Property 'userUpdateError' does not exist on type 'Readonly<{}>'.
+plugins/organization/components/AccountGroupMembershipTab.tsx: error TS2339: Property 'gid' does not exist on type '{}'.
 plugins/organization/components/AccountGroupTable.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/organization/components/AccountGroupTable.tsx: error TS6133: 'prop' is declared but its value is never read.
 plugins/organization/components/AccountGroupTable.tsx: error TS2339: Property 'getAccountDetails' does not exist on type *.
-plugins/organization/components/AccountGroupTable.tsx: error TS2339: Property 'pendingRequest' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/AccountGroupTable.tsx: error TS2339: Property 'openConfirm' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/AccountGroupTable.tsx: error TS2554: Expected 1-2 arguments, but got 0.
-plugins/organization/components/AccountGroupTable.tsx: error TS2339: Property 'store_listeners' does not exist on type 'AccountGroupTable'.
-plugins/organization/components/AccountGroupTable.tsx: error TS2339: Property 'groupID' does not exist on type 'Readonly<{}>'.
 plugins/organization/components/AccountGroupTable.tsx: error TS2339: Property 'accountID' does not exist on type *.
-plugins/organization/components/AdvancedACLsTab.tsx: error TS2339: Property 'aclsToBeCreated' does not exist on type 'Readonly<{}>'.
 plugins/organization/components/AdvancedACLsTab.tsx: error TS2339: Property 'aclsToBeCreatedDupes' does not exist on type *.
-plugins/organization/components/AdvancedACLsTab.tsx: error TS2339: Property 'aclsToBeCreatedDupes' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/AdvancedACLsTab.tsx: error TS2339: Property 'aclsToBeCreatedErrors' does not exist on type 'Readonly<{}>'.
 plugins/organization/components/AdvancedACLsTab.tsx: error TS2339: Property 'aclsToBeCreatedErrors' does not exist on type *.
+plugins/organization/components/AdvancedACLsTab.tsx: error TS2769: No overload matches this call.
 plugins/organization/components/AdvancedACLsTab.tsx: error TS2339: Property 'aclsToBeCreatedSuccess' does not exist on type *.
-plugins/organization/components/AdvancedACLsTab.tsx: error TS2339: Property 'aclsToBeCreatedSuccess' does not exist on type 'Readonly<{}>'.
 plugins/organization/components/AdvancedACLsTab.tsx: error TS2339: Property 'revokeActionsRemaining' does not exist on type 'AdvancedACLsTab'.
 plugins/organization/components/AdvancedACLsTab.tsx: error TS2339: Property 'revokeActionsRemaining' does not exist on type 'AdvancedACLsTab'.
 plugins/organization/components/AdvancedACLsTab.tsx: error TS2339: Property 'handleActionRevokeClick' does not exist on type 'AdvancedACLsTab'.
@@ -1147,26 +976,13 @@ plugins/organization/components/AdvancedACLsTab.tsx: error TS6133: 'prop' is dec
 plugins/organization/components/AdvancedACLsTab.tsx: error TS2322: Type 'Element' is not assignable to type 'string'.
 plugins/organization/components/AdvancedACLsTab.tsx: error TS2322: Type 'Element' is not assignable to type 'string'.
 plugins/organization/components/AdvancedACLsTab.tsx: error TS2339: Property 'handleActionRevokeClick' does not exist on type 'AdvancedACLsTab'.
-plugins/organization/components/AdvancedACLsTab.tsx: error TS2339: Property 'aclsRequestErrors' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/AdvancedACLsTab.tsx: error TS2339: Property 'aclsRequestSuccess' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/AdvancedACLsTab.tsx: error TS2339: Property 'aclsToBeCreated' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/AdvancedACLsTab.tsx: error TS2339: Property 'aclsToBeCreatedDupes' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/AdvancedACLsTab.tsx: error TS2339: Property 'aclsToBeCreatedErrors' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/AdvancedACLsTab.tsx: error TS2339: Property 'aclsToBeCreatedSuccess' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/AdvancedACLsTab.tsx: error TS2339: Property 'itemPermissionsRequestErrors' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/AdvancedACLsTab.tsx: error TS2339: Property 'itemPermissionsRequestSuccess' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/AdvancedACLsTab.tsx: error TS2339: Property 'permissionBuilderOpen' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/AdvancedACLsTab.tsx: error TS2339: Property 'permissionBuilderView' does not exist on type 'Readonly<{}>'.
+plugins/organization/components/AdvancedACLsTab.tsx: error TS2339: Property 'length' does not exist on type 'number'.
 plugins/organization/components/AdvancedACLsTab.tsx: error TS2322: type * is not assignable to type *.
 plugins/organization/components/AdvancedACLsTab.tsx: error TS2339: Property 'itemID' does not exist on type *.
-plugins/organization/components/AdvancedACLsTab.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/organization/components/AdvancedACLsTab.tsx: error TS2339: Property 'getACLs' does not exist on type 'AdvancedACLsTab'.
 plugins/organization/components/AdvancedACLsTab.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
-plugins/organization/components/AdvancedACLsTab.tsx: error TS2339: Property 'store_listeners' does not exist on type 'AdvancedACLsTab'.
-plugins/organization/components/AdvancedACLsTab.tsx: error TS2339: Property 'permissionBuilderView' does not exist on type 'Readonly<{}>'.
 plugins/organization/components/AdvancedACLsTab.tsx: error TS2339: Property 'permissionBuilderView' does not exist on type *.
 plugins/organization/components/AdvancedACLsTab.tsx: error TS2339: Property 'permissionBuilderView' does not exist on type *.
-plugins/organization/components/AdvancedACLsTab.tsx: error TS2339: Property 'aclsRequestErrors' does not exist on type 'Readonly<{}>'.
 plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'itemName' does not exist on type *.
 plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'itemID' does not exist on type *.
 plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'itemID' does not exist on type *.
@@ -1175,85 +991,49 @@ plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'ite
 plugins/organization/components/OrganizationTab.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/organization/components/OrganizationTab.tsx: error TS6133: 'prop' is declared but its value is never read.
 plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'itemID' does not exist on type *.
-plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'checkableCount' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'checkedCount' does not exist on type 'Readonly<{}>'.
 plugins/organization/components/OrganizationTab.tsx: error TS2322: Type 'false' is not assignable to type 'null'.
 plugins/organization/components/OrganizationTab.tsx: error TS2322: Type 'true' is not assignable to type 'null'.
-plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'selectedIDSet' does not exist on type 'OrganizationTab'.
-plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'checkedCount' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'checkableCount' does not exist on type 'Readonly<{}>'.
 plugins/organization/components/OrganizationTab.tsx: error TS6133: 'prop' is declared but its value is never read.
 plugins/organization/components/OrganizationTab.tsx: error TS6133: 'sortBy' is declared but its value is never read.
 plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'itemID' does not exist on type *.
 plugins/organization/components/OrganizationTab.tsx: error TS2322: type * is not assignable to type *.
 plugins/organization/components/OrganizationTab.tsx: error TS2322: type * is not assignable to type *.
-plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'showActionDropdown' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/OrganizationTab.tsx: error TS2554: Expected 1-2 arguments, but got 0.
 plugins/organization/components/OrganizationTab.tsx: error TS2322: type * is not assignable to type 'null'.
-plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'selectedAction' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'selectedIDSet' does not exist on type 'OrganizationTab'.
-plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'searchFilter' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'searchString' does not exist on type 'Readonly<{}>'.
 plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'itemID' does not exist on type *.
-plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'selectedIDSet' does not exist on type 'OrganizationTab'.
 plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'itemName' does not exist on type *.
-plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'searchFilter' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'selectedIDSet' does not exist on type 'OrganizationTab'.
-plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'itemID' does not exist on type *.
-plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'selectedIDSet' does not exist on type 'OrganizationTab'.
-plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'selectedIDSet' does not exist on type 'OrganizationTab'.
-plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'checkableCount' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'items' does not exist on type *.
 plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'itemID' does not exist on type *.
 plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'items' does not exist on type *.
-plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'selectedIDSet' does not exist on type 'OrganizationTab'.
+plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'items' does not exist on type *.
+plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'itemID' does not exist on type *.
 plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'items' does not exist on type *.
 plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'itemID' does not exist on type *.
 plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'itemName' does not exist on type *.
-plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'selectedAction' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'searchFilter' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'searchString' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'showActionDropdown' does not exist on type 'Readonly<{}>'.
 plugins/organization/components/OrganizationTab.tsx: error TS2769: No overload matches this call.
-plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'searchFilter' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'searchString' does not exist on type 'Readonly<{}>'.
 plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'items' does not exist on type *.
 plugins/organization/components/OrganizationTab.tsx: error TS6133: 'prevCheckboxState' is declared but its value is never read.
-plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'checkedCount' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'selectedIDSet' does not exist on type 'OrganizationTab'.
-plugins/organization/components/OrganizationTab.tsx: error TS2339: Property 'selectedIDSet' does not exist on type 'OrganizationTab'.
 plugins/organization/components/OrganizationTab.tsx: error TS6133: 'prevCheckboxState' is declared but its value is never read.
-plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'model' does not exist on type 'Readonly<{}>'.
+plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'actions' does not exist on type '{}'.
 plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'activeView' does not exist on type *.
 plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'checked' does not exist on type 'never'.
 plugins/organization/components/PermissionBuilderModal.tsx: error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
 plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'name' does not exist on type 'never'.
-plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'bulkacls' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'chosenRIDs' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'model' does not exist on type 'Readonly<{}>'.
+plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'bulkacls' does not exist on type *.
+plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'actions' does not exist on type '{}'.
 plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'disabled' does not exist on type *.
 plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'chosenRIDs' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'model' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'model' does not exist on type 'Readonly<{}>'.
+plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'actions' does not exist on type '{}'.
 plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'disabled' does not exist on type *.
-plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'chosenRIDs' does not exist on type 'Readonly<{}>'.
 plugins/organization/components/PermissionBuilderModal.tsx: error TS2345: Argument of type * is not assignable to parameter of type 'never'.
 plugins/organization/components/PermissionBuilderModal.tsx: error TS2345: Argument of type * is not assignable to parameter of type 'never[]'.
 plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'handleBulkAddToggle' does not exist on type *.
 plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'triggerSubmit' does not exist on type 'PermissionBuilderModal'.
-plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'chosenRIDs' does not exist on type 'Readonly<{}>'.
-plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'model' does not exist on type 'Readonly<{}>'.
 plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'disabled' does not exist on type *.
 plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'errors' does not exist on type *.
+plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'actions' does not exist on type '{}'.
 plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'validationError' does not exist on type *.
-plugins/organization/components/PermissionBuilderModal.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
 plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'disabled' does not exist on type *.
-plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'chosenRIDs' does not exist on type 'Readonly<{}>'.
 plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'triggerSubmit' does not exist on type 'PermissionBuilderModal'.
 plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'subjectID' does not exist on type *.
-plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'store_listeners' does not exist on type 'PermissionBuilderModal'.
 plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'disabled' does not exist on type *.
 plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'dupesFound' does not exist on type *.
 plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'errors' does not exist on type *.
@@ -1267,7 +1047,7 @@ plugins/organization/components/PermissionBuilderModal.tsx: error TS17001: JSX e
 plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'onSubmit' does not exist on type *.
 plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
 plugins/organization/components/PermissionBuilderModal.tsx: error TS6133: 'selection' is declared but its value is never read.
-plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'chosenRIDs' does not exist on type 'Readonly<{}>'.
+plugins/organization/components/PermissionBuilderModal.tsx: error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
 plugins/organization/components/PermissionBuilderModal.tsx: error TS2339: Property 'chosenRIDs' does not exist on type *.
 plugins/organization/components/__tests__/AccountAdvancedACLsTab-test.tsx: error TS7030: Not all code paths return a value.
 plugins/organization/components/__tests__/AccountGroupTable-test.tsx: error TS7030: Not all code paths return a value.
@@ -1321,17 +1101,8 @@ plugins/organization/submodules/directories/actions/__tests__/ACLDirectoriesActi
 plugins/organization/submodules/directories/actions/__tests__/ACLDirectoriesActions-test.ts: error TS2554: Expected 1 arguments, but got 0.
 plugins/organization/submodules/directories/actions/__tests__/ACLDirectoriesActions-test.ts: error TS2554: Expected 1 arguments, but got 0.
 plugins/organization/submodules/directories/components/DirectoryActionButtons.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/organization/submodules/directories/components/DirectoryActionButtons.tsx: error TS2339: Property 'deleteConfirmDisabled' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/directories/components/DirectoryActionButtons.tsx: error TS2339: Property 'formModalDisabled' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/directories/components/DirectoryActionButtons.tsx: error TS2339: Property 'onConfigurationEditClick' does not exist on type *.
-plugins/organization/submodules/directories/components/DirectoryActionButtons.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/organization/submodules/directories/components/DirectoryActionButtons.tsx: error TS2339: Property 'deleteConfirm' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/directories/components/DirectoryActionButtons.tsx: error TS2339: Property 'deleteConfirmDisabled' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/directories/components/DirectoryActionButtons.tsx: error TS2339: Property 'formModalDisabled' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/directories/components/DirectoryActionButtons.tsx: error TS2339: Property 'formModalOpen' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/directories/components/DirectoryActionButtons.tsx: error TS2339: Property 'successModalOpen' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/directories/components/DirectoryActionButtons.tsx: error TS2339: Property 'successModalMessage' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/directories/components/DirectoryActionButtons.tsx: error TS2339: Property 'store_listeners' does not exist on type 'DirectoryActionButtons'.
+plugins/organization/submodules/directories/components/DirectoryActionButtons.tsx: error TS2339: Property 'successModalMessage' does not exist on type *.
 plugins/organization/submodules/directories/components/DirectoryActionButtons.tsx: error TS2339: Property 'i18n' does not exist on type *.
 plugins/organization/submodules/directories/components/DirectoryActionButtons.tsx: error TS2339: Property 'i18n' does not exist on type *.
 plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'modalDisabled' does not exist on type *.
@@ -1340,52 +1111,33 @@ plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: e
 plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'editMode' does not exist on type *.
 plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'editMode' does not exist on type *.
 plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'model' does not exist on type *.
-plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'formData' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'formData' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'model' does not exist on type *.
 plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'editMode' does not exist on type *.
-plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'formData' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'formData' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'model' does not exist on type *.
 plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'editMode' does not exist on type *.
-plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'triggerTabFormSubmit' does not exist on type 'DirectoryFormModal'.
 plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'isCACertRequired' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'triggerTabFormSubmit' does not exist on type 'DirectoryFormModal'.
-plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'triggerTabFormSubmit' does not exist on type 'DirectoryFormModal'.
-plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'isCACertRequired' does not exist on type 'Readonly<{}>'.
+plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2721: Cannot invoke an object which is possibly 'null'.
 plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
 plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS6133: 'formData' is declared but its value is never read.
 plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
+plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
 plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'model' does not exist on type *.
-plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'formData' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'changeModalOpenState' does not exist on type *.
 plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'modalOpen' does not exist on type *.
-plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'isCACertRequired' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'onFormSubmit' does not exist on type *.
 plugins/organization/submodules/directories/components/DirectoryFormModal.tsx: error TS2339: Property 'model' does not exist on type *.
-plugins/organization/submodules/directories/pages/DirectoriesPage.tsx: error TS2339: Property 'modalEditMode' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/directories/pages/DirectoriesPage.tsx: error TS2322: type * is not assignable to type *.
-plugins/organization/submodules/directories/pages/DirectoriesPage.tsx: error TS2339: Property 'modalDisabled' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/directories/pages/DirectoriesPage.tsx: error TS2339: Property 'modalOpen' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/directories/pages/DirectoriesPage.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/organization/submodules/directories/pages/DirectoriesPage.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/organization/submodules/directories/pages/DirectoriesPage.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/organization/submodules/directories/pages/DirectoriesPage.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
-plugins/organization/submodules/directories/pages/DirectoriesPage.tsx: error TS2339: Property 'showValue' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/directories/pages/DirectoriesPage.tsx: error TS7030: Not all code paths return a value.
-plugins/organization/submodules/directories/pages/DirectoriesPage.tsx: error TS2339: Property 'showValue' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/directories/pages/DirectoriesPage.tsx: error TS2322: type * is not assignable to type *.
 plugins/organization/submodules/directories/pages/DirectoriesPage.tsx: error TS2339: Property 'routeConfig' does not exist on type *.
-plugins/organization/submodules/directories/pages/DirectoriesPage.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/organization/submodules/directories/pages/DirectoriesPage.tsx: error TS2339: Property 'store_listeners' does not exist on type 'DirectoriesPage'.
 plugins/organization/submodules/directories/pages/DirectoriesPage.tsx: error TS2556: Expected 0 arguments, but got 1 or more.
 plugins/organization/submodules/directories/pages/DirectoriesPage.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
-plugins/organization/submodules/directories/pages/DirectoriesPage.tsx: error TS2339: Property 'showValue' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/directories/stores/ACLDirectoriesStore.ts: error TS2556: Expected 0 arguments, but got 1 or more.
 plugins/organization/submodules/directories/stores/ACLDirectoriesStore.ts: error TS2556: Expected 0 arguments, but got 1 or more.
 plugins/organization/submodules/directories/stores/ACLDirectoriesStore.ts: error TS2556: Expected 1 arguments, but got 0 or more.
@@ -1393,17 +1145,11 @@ plugins/organization/submodules/directories/stores/ACLDirectoriesStore.ts: error
 plugins/organization/submodules/directories/stores/ACLDirectoriesStore.ts: error TS2556: Expected 1 arguments, but got 0 or more.
 plugins/organization/submodules/groups/actions/ACLGroupsActions.ts: error TS2571: Object is of type 'unknown'.
 plugins/organization/submodules/groups/components/GroupAccountMembershipTab.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/organization/submodules/groups/components/GroupAccountMembershipTab.tsx: error TS2339: Property 'requestUsersError' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/groups/components/GroupAccountMembershipTab.tsx: error TS2339: Property 'requestUsersSuccess' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/groups/components/GroupAccountMembershipTab.tsx: error TS2339: Property 'searchString' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/groups/components/GroupAccountMembershipTab.tsx: error TS2339: Property 'typeahead' does not exist on type 'GroupAccountMembershipTab'.
-plugins/organization/submodules/groups/components/GroupAccountMembershipTab.tsx: error TS2339: Property 'selectedUser' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/groups/components/GroupAccountMembershipTab.tsx: error TS2769: No overload matches this call.
 plugins/organization/submodules/groups/components/GroupAccountMembershipTab.tsx: error TS2322: type * is not assignable to type *.
 plugins/organization/submodules/groups/components/GroupAccountMembershipTab.tsx: error TS2339: Property 'groupID' does not exist on type *.
 plugins/organization/submodules/groups/components/GroupAccountMembershipTab.tsx: error TS2339: Property 'accountType' does not exist on type *.
-plugins/organization/submodules/groups/components/GroupAccountMembershipTab.tsx: error TS2554: Expected 1-2 arguments, but got 0.
-plugins/organization/submodules/groups/components/GroupAccountMembershipTab.tsx: error TS2339: Property 'store_listeners' does not exist on type 'GroupAccountMembershipTab'.
 plugins/organization/submodules/groups/components/GroupAccountMembershipTab.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
 plugins/organization/submodules/groups/components/GroupAccountMembershipTab.tsx: error TS2339: Property 'accountType' does not exist on type *.
 plugins/organization/submodules/groups/components/GroupAccountMembershipTab.tsx: error TS2339: Property 'accountType' does not exist on type *.
@@ -1413,13 +1159,11 @@ plugins/organization/submodules/groups/components/GroupAccountMembershipTab.tsx:
 plugins/organization/submodules/groups/components/GroupAccountMembershipTab.tsx: error TS2339: Property 'typeahead' does not exist on type 'GroupAccountMembershipTab'.
 plugins/organization/submodules/groups/components/GroupAdvancedACLsTab.ts: error TS2339: Property 'revokeActionsRemaining' does not exist on type 'GroupAdvancedACLsTab'.
 plugins/organization/submodules/groups/components/GroupAdvancedACLsTab.ts: error TS2339: Property 'itemID' does not exist on type *.
-plugins/organization/submodules/groups/components/GroupAdvancedACLsTab.ts: error TS2339: Property 'store_listeners' does not exist on type 'GroupAdvancedACLsTab'.
 plugins/organization/submodules/groups/components/GroupAdvancedACLsTab.ts: error TS2339: Property 'itemID' does not exist on type *.
 plugins/organization/submodules/groups/components/GroupAdvancedACLsTab.ts: error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
 plugins/organization/submodules/groups/components/GroupAdvancedACLsTab.ts: error TS2322: Type 'any' is not assignable to type 'never'.
 plugins/organization/submodules/groups/components/GroupAdvancedACLsTab.ts: error TS2322: Type 'never[]' is not assignable to type 'never'.
 plugins/organization/submodules/groups/components/GroupAdvancedACLsTab.ts: error TS2322: Type 'true' is not assignable to type 'never'.
-plugins/organization/submodules/groups/components/GroupAdvancedACLsTab.ts: error TS2339: Property 'store_listeners' does not exist on type 'GroupAdvancedACLsTab'.
 plugins/organization/submodules/groups/components/GroupAdvancedACLsTab.ts: error TS2551: Property 'onAclStoreGroupRevokeSuccess' does not exist on type 'GroupAdvancedACLsTab'. Did you mean 'onAclStoreGroupGrantSuccess'?
 plugins/organization/submodules/groups/components/GroupAdvancedACLsTab.ts: error TS2551: Property 'onAclStoreGroupRevokeError' does not exist on type 'GroupAdvancedACLsTab'. Did you mean 'onAclStoreGroupGrantError'?
 plugins/organization/submodules/groups/components/GroupAdvancedACLsTab.ts: error TS2551: Property 'onAclGroupStorePermissionsSuccess' does not exist on type 'GroupAdvancedACLsTab'. Did you mean 'onAclGroupStorePermissionsError'?
@@ -1432,33 +1176,22 @@ plugins/organization/submodules/groups/components/GroupAdvancedACLsTab.ts: error
 plugins/organization/submodules/groups/components/GroupAdvancedACLsTab.ts: error TS2556: Expected 0 arguments, but got 1 or more.
 plugins/organization/submodules/groups/components/GroupAdvancedACLsTab.ts: error TS2339: Property 'itemID' does not exist on type *.
 plugins/organization/submodules/groups/components/GroupAdvancedACLsTab.ts: error TS2339: Property 'itemID' does not exist on type *.
-plugins/organization/submodules/groups/components/GroupAdvancedACLsTab.ts: error TS2339: Property 'itemPermissionsRequestErrors' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/groups/components/GroupAdvancedACLsTab.ts: error TS2339: Property 'itemID' does not exist on type *.
 plugins/organization/submodules/groups/components/GroupAdvancedACLsTab.ts: error TS2556: Expected 1 arguments, but got 0 or more.
 plugins/organization/submodules/groups/components/GroupAdvancedACLsTab.ts: error TS2662: Cannot find name 'arguments'. Did you mean the static member 'GroupAdvancedACLsTab.arguments'?
+plugins/organization/submodules/groups/components/GroupAdvancedACLsTab.ts: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/organization/submodules/groups/components/GroupDetailPage.tsx: error TS2339: Property 'onACLChange' does not exist on type 'GroupDetailPage'.
 plugins/organization/submodules/groups/components/GroupDetailPage.tsx: error TS2339: Property 'onACLChange' does not exist on type 'GroupDetailPage'.
-plugins/organization/submodules/groups/components/GroupDetailPage.tsx: error TS2339: Property 'fetchedDetailsError' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/groups/components/GroupDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
-plugins/organization/submodules/groups/components/GroupDetailPage.tsx: error TS2339: Property 'deleteUpdateError' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/groups/components/GroupDetailPage.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
-plugins/organization/submodules/groups/components/GroupDetailPage.tsx: error TS2339: Property 'deleteUpdateError' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/groups/components/GroupDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/organization/submodules/groups/components/GroupDetailPage.tsx: error TS2339: Property 'gid' does not exist on type 'Group'.
 plugins/organization/submodules/groups/components/GroupDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/organization/submodules/groups/components/GroupDetailPage.tsx: error TS2339: Property 'i18n' does not exist on type *.
 plugins/organization/submodules/groups/components/GroupDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
-plugins/organization/submodules/groups/components/GroupDetailPage.tsx: error TS2339: Property 'fetchedDetailsError' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/groups/components/GroupDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
-plugins/organization/submodules/groups/components/GroupDetailPage.tsx: error TS2339: Property 'currentTab' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/groups/components/GroupDetailPage.tsx: error TS2339: Property 'pendingRequest' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/groups/components/GroupDetailPage.tsx: error TS2339: Property 'currentTab' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/groups/components/GroupDetailPage.tsx: error TS2339: Property 'currentTab' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/groups/components/GroupDetailPage.tsx: error TS2322: type * is not assignable to type *.
-plugins/organization/submodules/groups/components/GroupDetailPage.tsx: error TS2339: Property 'currentTab' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/groups/components/GroupDetailPage.tsx: error TS2322: type * is not assignable to type *.
-plugins/organization/submodules/groups/components/GroupDetailPage.tsx: error TS2339: Property 'pendingRequest' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/groups/components/GroupDetailPage.tsx: error TS2339: Property 'openDeleteConfirmation' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/groups/components/GroupDetailPage.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
 plugins/organization/submodules/groups/components/GroupDetailPage.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/organization/submodules/groups/components/GroupDetailPage.tsx: error TS2339: Property 'store_listeners' does not exist on type 'GroupDetailPage'.
@@ -1470,31 +1203,18 @@ plugins/organization/submodules/groups/components/GroupDetailPage.tsx: error TS2
 plugins/organization/submodules/groups/components/GroupDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/organization/submodules/groups/components/GroupDetailPage.tsx: error TS2339: Property 'onACLChange' does not exist on type 'GroupDetailPage'.
 plugins/organization/submodules/groups/components/GroupDetailPage.tsx: error TS2339: Property 'onACLChange' does not exist on type 'GroupDetailPage'.
+plugins/organization/submodules/groups/components/GroupFormModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
+plugins/organization/submodules/groups/components/GroupFormModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
+plugins/organization/submodules/groups/components/GroupFormModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
+plugins/organization/submodules/groups/components/GroupFormModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
 plugins/organization/submodules/groups/components/GroupFormModal.tsx: error TS2339: Property 'open' does not exist on type *.
-plugins/organization/submodules/groups/components/GroupFormModal.tsx: error TS2554: Expected 1-2 arguments, but got 0.
-plugins/organization/submodules/groups/components/GroupFormModal.tsx: error TS2339: Property 'store_listeners' does not exist on type 'GroupFormModal'.
-plugins/organization/submodules/groups/components/GroupFormModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
-plugins/organization/submodules/groups/components/GroupFormModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
-plugins/organization/submodules/groups/components/GroupFormModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/organization/submodules/groups/components/GroupFormModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/groups/components/GroupFormModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/organization/submodules/groups/components/GroupFormModal.tsx: error TS2339: Property 'disableNewGroup' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/groups/components/GroupFormModal.tsx: error TS2339: Property 'disableNewGroup' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/groups/components/GroupMemberTable.tsx: error TS2339: Property 'userID' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/groups/components/GroupMemberTable.tsx: error TS2339: Property 'groupUpdateError' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/groups/components/GroupMemberTable.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/organization/submodules/groups/components/GroupMemberTable.tsx: error TS2339: Property 'accountType' does not exist on type *.
 plugins/organization/submodules/groups/components/GroupMemberTable.tsx: error TS6133: 'prop' is declared but its value is never read.
 plugins/organization/submodules/groups/components/GroupMemberTable.tsx: error TS2339: Property 'accountType' does not exist on type *.
 plugins/organization/submodules/groups/components/GroupMemberTable.tsx: error TS2339: Property 'groupID' does not exist on type *.
 plugins/organization/submodules/groups/components/GroupMemberTable.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/organization/submodules/groups/components/GroupMemberTable.tsx: error TS2339: Property 'pendingRequest' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/groups/components/GroupMemberTable.tsx: error TS2339: Property 'pendingRequest' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/groups/components/GroupMemberTable.tsx: error TS2339: Property 'openConfirm' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/groups/components/GroupMemberTable.tsx: error TS2554: Expected 1-2 arguments, but got 0.
-plugins/organization/submodules/groups/components/GroupMemberTable.tsx: error TS2339: Property 'store_listeners' does not exist on type 'GroupMemberTable'.
 plugins/organization/submodules/groups/components/GroupMemberTable.tsx: error TS2339: Property 'groupID' does not exist on type *.
-plugins/organization/submodules/groups/components/GroupMemberTable.tsx: error TS2339: Property 'userID' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/groups/components/__tests__/GroupDetailPage-test.tsx: error TS7030: Not all code paths return a value.
 plugins/organization/submodules/groups/components/__tests__/GroupDetailPage-test.tsx: error TS2769: No overload matches this call.
 plugins/organization/submodules/groups/components/__tests__/GroupDetailPage-test.tsx: error TS2769: No overload matches this call.
@@ -1504,35 +1224,19 @@ plugins/organization/submodules/groups/components/modals/GroupsActionsModal.tsx:
 plugins/organization/submodules/groups/components/modals/GroupsActionsModal.tsx: error TS2339: Property 'action' does not exist on type *.
 plugins/organization/submodules/groups/components/modals/GroupsActionsModal.tsx: error TS2339: Property 'itemID' does not exist on type *.
 plugins/organization/submodules/groups/components/modals/GroupsActionsModal.tsx: error TS2339: Property 'selectedItems' does not exist on type *.
-plugins/organization/submodules/groups/components/modals/GroupsActionsModal.tsx: error TS2339: Property 'selectedItem' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/groups/components/modals/LDAPGroupFormModal.tsx: error TS2339: Property 'successMsg' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/groups/components/modals/LDAPGroupFormModal.tsx: error TS2339: Property 'partialSuccess' does not exist on type 'Readonly<{}>'.
+plugins/organization/submodules/groups/components/modals/GroupsActionsModal.tsx: error TS2531: Object is possibly 'null'.
+plugins/organization/submodules/groups/components/modals/GroupsActionsModal.tsx: error TS2531: Object is possibly 'null'.
+plugins/organization/submodules/groups/components/modals/LDAPGroupFormModal.tsx: error TS2339: Property 'partialSuccess' does not exist on type *.
 plugins/organization/submodules/groups/components/modals/LDAPGroupFormModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/organization/submodules/groups/components/modals/LDAPGroupFormModal.tsx: error TS2554: Expected 1-2 arguments, but got 0.
-plugins/organization/submodules/groups/components/modals/LDAPGroupFormModal.tsx: error TS2339: Property 'disableNewGroup' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/groups/components/modals/LDAPGroupFormModal.tsx: error TS2339: Property 'open' does not exist on type *.
-plugins/organization/submodules/groups/components/modals/LDAPGroupFormModal.tsx: error TS2339: Property 'formModalRef' does not exist on type 'LDAPGroupFormModal'.
-plugins/organization/submodules/groups/components/modals/LDAPGroupFormModal.tsx: error TS2339: Property 'store_listeners' does not exist on type 'LDAPGroupFormModal'.
-plugins/organization/submodules/groups/components/modals/LDAPGroupFormModal.tsx: error TS2339: Property 'formModalRef' does not exist on type 'LDAPGroupFormModal'.
-plugins/organization/submodules/groups/components/modals/LDAPGroupFormModal.tsx: error TS2339: Property 'formModalRef' does not exist on type 'LDAPGroupFormModal'.
-plugins/organization/submodules/groups/components/modals/LDAPGroupFormModal.tsx: error TS2339: Property 'formModalRef' does not exist on type 'LDAPGroupFormModal'.
-plugins/organization/submodules/groups/components/modals/LDAPGroupFormModal.tsx: error TS2339: Property 'formModalRef' does not exist on type 'LDAPGroupFormModal'.
-plugins/organization/submodules/groups/components/modals/LDAPGroupFormModal.tsx: error TS2339: Property 'formModalRef' does not exist on type 'LDAPGroupFormModal'.
-plugins/organization/submodules/groups/components/modals/LDAPGroupFormModal.tsx: error TS2339: Property 'formModalRef' does not exist on type 'LDAPGroupFormModal'.
+plugins/organization/submodules/groups/components/modals/LDAPGroupFormModal.tsx: error TS2571: Object is of type 'unknown'.
+plugins/organization/submodules/groups/components/modals/LDAPGroupFormModal.tsx: error TS2571: Object is of type 'unknown'.
 plugins/organization/submodules/groups/components/modals/LDAPGroupFormModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
 plugins/organization/submodules/groups/components/modals/LDAPGroupFormModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/organization/submodules/groups/components/modals/LDAPGroupFormModal.tsx: error TS2339: Property 'disableNewGroup' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/groups/components/modals/LDAPGroupFormModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/groups/components/modals/LDAPGroupFormModal.tsx: error TS2339: Property 'groupnameValue' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/groups/pages/GroupsPage.tsx: error TS2339: Property 'groupsStoreError' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/groups/pages/GroupsPage.tsx: error TS2339: Property 'groupsStoreSuccess' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/groups/pages/GroupsPage.tsx: error TS2322: type * is not assignable to type *.
-plugins/organization/submodules/groups/pages/GroupsPage.tsx: error TS2339: Property 'openNewGroupModal' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/groups/pages/GroupsPage.tsx: error TS2322: type * is not assignable to type *.
-plugins/organization/submodules/groups/pages/GroupsPage.tsx: error TS2339: Property 'openNewLDAPGroupModal' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/groups/pages/GroupsPage.tsx: error TS2339: Property 'routeConfig' does not exist on type *.
 plugins/organization/submodules/groups/pages/GroupsPage.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/organization/submodules/groups/pages/GroupsPage.tsx: error TS2339: Property 'store_listeners' does not exist on type 'GroupsPage'.
 plugins/organization/submodules/groups/pages/GroupsPage.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
 plugins/organization/submodules/groups/stores/ACLGroupStore.ts: error TS2556: Expected 1 arguments, but got 0 or more.
 plugins/organization/submodules/groups/stores/ACLGroupStore.ts: error TS2556: Expected 1 arguments, but got 0 or more.
@@ -1554,10 +1258,7 @@ plugins/organization/submodules/groups/structs/__tests__/GroupsList-test.ts: err
 plugins/organization/submodules/service-accounts/actions/__tests__/ACLServiceAccountActions-test.ts: error TS2554: Expected 2 arguments, but got 1.
 plugins/organization/submodules/service-accounts/components/ServiceAccountDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/organization/submodules/service-accounts/components/ServiceAccountDetailPage.tsx: error TS2322: type * is not assignable to type *.
-plugins/organization/submodules/service-accounts/components/ServiceAccountDetailPage.tsx: error TS2339: Property 'openEditFormModal' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/service-accounts/components/ServiceAccountDetailPage.tsx: error TS2322: type * is not assignable to type *.
-plugins/organization/submodules/service-accounts/components/ServiceAccountDetailPage.tsx: error TS2339: Property 'store_listeners' does not exist on type 'ServiceAccountDetailPage'.
-plugins/organization/submodules/service-accounts/components/ServiceAccountDetailPage.tsx: error TS2339: Property 'fetchedDetailsError' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/service-accounts/components/ServiceAccountDetailPage.tsx: error TS2339: Property 'isRemote' does not exist on type 'ServiceAccount'.
 plugins/organization/submodules/service-accounts/components/ServiceAccountDetailPage.tsx: error TS2339: Property 'isRemote' does not exist on type 'ServiceAccount'.
 plugins/organization/submodules/service-accounts/components/ServiceAccountsActionsModal.tsx: error TS2339: Property 'store_listeners' does not exist on type 'ServiceAccountsActionsModal'.
@@ -1565,23 +1266,16 @@ plugins/organization/submodules/service-accounts/components/ServiceAccountsActio
 plugins/organization/submodules/service-accounts/components/ServiceAccountsActionsModal.tsx: error TS2556: Expected 0 arguments, but got 1 or more.
 plugins/organization/submodules/service-accounts/components/ServiceAccountsActionsModal.tsx: error TS2556: Expected 1 arguments, but got 0 or more.
 plugins/organization/submodules/service-accounts/components/ServiceAccountsActionsModal.tsx: error TS2339: Property 'itemType' does not exist on type *.
-plugins/organization/submodules/service-accounts/components/ServiceAccountsActionsModal.tsx: error TS2339: Property 'requestErrors' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/service-accounts/components/ServiceAccountsActionsModal.tsx: error TS2339: Property 'validationError' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/service-accounts/components/ServiceAccountsActionsModal.tsx: error TS7030: Not all code paths return a value.
 plugins/organization/submodules/service-accounts/components/ServiceAccountsActionsModal.tsx: error TS2339: Property 'action' does not exist on type *.
 plugins/organization/submodules/service-accounts/components/ServiceAccountsActionsModal.tsx: error TS2339: Property 'selectedItems' does not exist on type *.
 plugins/organization/submodules/service-accounts/pages/ServiceAccountsPage.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/organization/submodules/service-accounts/pages/ServiceAccountsPage.tsx: error TS2339: Property 'routes' does not exist on type *.
 plugins/organization/submodules/service-accounts/pages/ServiceAccountsPage.tsx: error TS2322: type * is not assignable to type *.
-plugins/organization/submodules/service-accounts/pages/ServiceAccountsPage.tsx: error TS2339: Property 'openNewGroupModal' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/service-accounts/pages/ServiceAccountsPage.tsx: error TS2339: Property 'routeConfig' does not exist on type *.
-plugins/organization/submodules/service-accounts/pages/ServiceAccountsPage.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/organization/submodules/service-accounts/pages/ServiceAccountsPage.tsx: error TS2339: Property 'store_listeners' does not exist on type 'ServiceAccountsPage'.
 plugins/organization/submodules/service-accounts/pages/ServiceAccountsPage.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
-plugins/organization/submodules/service-accounts/pages/ServiceAccountsPage.tsx: error TS2339: Property 'serviceAccountsStoreError' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/service-accounts/pages/ServiceAccountsPage.tsx: error TS2339: Property 'serviceAccountsStoreSuccess' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/service-accounts/pages/ServiceAccountsPage.tsx: error TS2339: Property 'routes' does not exist on type *.
-plugins/organization/submodules/service-accounts/pages/ServiceAccountsPage.tsx: error TS2322: type * is not assignable to type *.
+plugins/organization/submodules/service-accounts/pages/ServiceAccountsPage.tsx: error TS2769: No overload matches this call.
 plugins/organization/submodules/service-accounts/pages/ServiceAccountsPage.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/organization/submodules/service-accounts/stores/ACLServiceAccountsStore.ts: error TS2306: File '/plugins/organization/SDK.ts' is not a module.
 plugins/organization/submodules/service-accounts/stores/__tests__/ACLServiceAccountsStore-test.ts: error TS6133: 'error' is declared but its value is never read.
@@ -1594,48 +1288,28 @@ plugins/organization/submodules/service-accounts/structs/__tests__/ServiceAccoun
 plugins/organization/submodules/service-accounts/structs/__tests__/ServiceAccount-test.ts: error TS2339: Property 'get' does not exist on type '{}'.
 plugins/organization/submodules/users/actions/__tests__/ACLUsersActions-test.ts: error TS2554: Expected 2 arguments, but got 1.
 plugins/organization/submodules/users/components/UserDetailPage.tsx: error TS2322: type * is not assignable to type *.
-plugins/organization/submodules/users/components/UserDetailPage.tsx: error TS2339: Property 'pendingRequest' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/users/components/UserDetailPage.tsx: error TS2339: Property 'openEditFormModal' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/users/components/UserDetailPage.tsx: error TS2339: Property 'routeConfig' does not exist on type *.
-plugins/organization/submodules/users/components/UserDetailPage.tsx: error TS2339: Property 'store_listeners' does not exist on type 'UserDetailPage'.
-plugins/organization/submodules/users/components/UserDetailPage.tsx: error TS2339: Property 'store_listeners' does not exist on type 'UserDetailPage'.
 plugins/organization/submodules/users/components/UserDetailPage.tsx: error TS2339: Property 'onACLChange' does not exist on type 'UserDetailPage'.
-plugins/organization/submodules/users/components/UserDetailPage.tsx: error TS2339: Property 'fetchedDetailsError' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/users/components/UserDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/organization/submodules/users/components/UserDetailPage.tsx: error TS2322: type * is not assignable to type *.
 plugins/organization/submodules/users/components/__tests__/UserDetailPage-test.tsx: error TS7030: Not all code paths return a value.
 plugins/organization/submodules/users/components/__tests__/UserDetailPage-test.tsx: error TS2769: No overload matches this call.
 plugins/organization/submodules/users/components/__tests__/UserDetailPage-test.tsx: error TS2769: No overload matches this call.
 plugins/organization/submodules/users/components/__tests__/UserDetailPage-test.tsx: error TS2769: No overload matches this call.
-plugins/organization/submodules/users/components/modals/LDAPUserFormModal.tsx: error TS2339: Property 'successMsg' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/users/components/modals/LDAPUserFormModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/organization/submodules/users/components/modals/LDAPUserFormModal.tsx: error TS2554: Expected 1-2 arguments, but got 0.
-plugins/organization/submodules/users/components/modals/LDAPUserFormModal.tsx: error TS2339: Property 'disableNewUser' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/users/components/modals/LDAPUserFormModal.tsx: error TS2339: Property 'open' does not exist on type *.
-plugins/organization/submodules/users/components/modals/LDAPUserFormModal.tsx: error TS2339: Property 'formModalRef' does not exist on type 'LDAPUserFormModal'.
-plugins/organization/submodules/users/components/modals/LDAPUserFormModal.tsx: error TS2339: Property 'formModalRef' does not exist on type 'LDAPUserFormModal'.
-plugins/organization/submodules/users/components/modals/LDAPUserFormModal.tsx: error TS2339: Property 'store_listeners' does not exist on type 'LDAPUserFormModal'.
-plugins/organization/submodules/users/components/modals/LDAPUserFormModal.tsx: error TS2339: Property 'formModalRef' does not exist on type 'LDAPUserFormModal'.
-plugins/organization/submodules/users/components/modals/LDAPUserFormModal.tsx: error TS2339: Property 'formModalRef' does not exist on type 'LDAPUserFormModal'.
-plugins/organization/submodules/users/components/modals/LDAPUserFormModal.tsx: error TS2339: Property 'formModalRef' does not exist on type 'LDAPUserFormModal'.
+plugins/organization/submodules/users/components/modals/LDAPUserFormModal.tsx: error TS2571: Object is of type 'unknown'.
 plugins/organization/submodules/users/components/modals/LDAPUserFormModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
 plugins/organization/submodules/users/components/modals/LDAPUserFormModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/organization/submodules/users/components/modals/LDAPUserFormModal.tsx: error TS2339: Property 'disableNewUser' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/users/components/modals/LDAPUserFormModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
-plugins/organization/submodules/users/components/modals/LDAPUserFormModal.tsx: error TS2339: Property 'usernameValue' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/users/components/modals/UserEditFormModal.tsx: error TS2339: Property 'account' does not exist on type *.
-plugins/organization/submodules/users/components/modals/UserEditFormModal.tsx: error TS2339: Property 'disableSubmit' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/users/components/modals/UserEditFormModal.tsx: error TS2339: Property 'open' does not exist on type *.
-plugins/organization/submodules/users/components/modals/UserEditFormModal.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/organization/submodules/users/components/modals/UserEditFormModal.tsx: error TS2339: Property 'store_listeners' does not exist on type 'UserEditFormModal'.
 plugins/organization/submodules/users/components/modals/UserEditFormModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
 plugins/organization/submodules/users/components/modals/UserEditFormModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
 plugins/organization/submodules/users/components/modals/UserEditFormModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
 plugins/organization/submodules/users/components/modals/UserEditFormModal.tsx: error TS2339: Property 'onSubmit' does not exist on type *.
 plugins/organization/submodules/users/components/modals/UserEditFormModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/organization/submodules/users/components/modals/UserEditFormModal.tsx: error TS2339: Property 'disableSubmit' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/users/components/modals/UserEditFormModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/organization/submodules/users/components/modals/UserEditFormModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
+plugins/organization/submodules/users/components/modals/UserEditFormModal.tsx: error TS2345: Argument of type 'boolean' is not assignable to parameter of type 'string'.
 plugins/organization/submodules/users/components/modals/UsersActionsModal.ts: error TS2556: Expected 0 arguments, but got 1 or more.
 plugins/organization/submodules/users/components/modals/UsersActionsModal.ts: error TS2556: Expected 1 arguments, but got 0 or more.
 plugins/organization/submodules/users/components/modals/UsersActionsModal.ts: error TS2339: Property 'store_listeners' does not exist on type 'UsersActionsModal'.
@@ -1645,13 +1319,9 @@ plugins/organization/submodules/users/hooks.tsx: error TS6133: 'props' is declar
 plugins/organization/submodules/users/hooks.tsx: error TS6133: 'definition' is declared but its value is never read.
 plugins/organization/submodules/users/hooks.tsx: error TS6133: 'props' is declared but its value is never read.
 plugins/organization/submodules/users/pages/UsersPage.tsx: error TS2339: Property 'items' does not exist on type *.
-plugins/organization/submodules/users/pages/UsersPage.tsx: error TS2339: Property 'openNewLDAPUserModal' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/users/pages/UsersPage.tsx: error TS2322: type * is not assignable to type *.
-plugins/organization/submodules/users/pages/UsersPage.tsx: error TS2339: Property 'openNewUserModal' does not exist on type 'Readonly<{}>'.
 plugins/organization/submodules/users/pages/UsersPage.tsx: error TS2322: type * is not assignable to type *.
 plugins/organization/submodules/users/pages/UsersPage.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/organization/submodules/users/pages/UsersPage.tsx: error TS2339: Property 'store_listeners' does not exist on type 'UsersPage'.
-plugins/organization/submodules/users/pages/UsersPage.tsx: error TS2339: Property 'selectedIDSet' does not exist on type 'UsersPage'.
 plugins/organization/submodules/users/pages/UsersPage.tsx: error TS2556: Expected 0 arguments, but got 1 or more.
 plugins/organization/submodules/users/pages/UsersPage.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
 plugins/organization/submodules/users/stores/ACLUserStore.ts: error TS2556: Expected 1 arguments, but got 0 or more.
@@ -1777,58 +1447,42 @@ plugins/secrets/actions/__tests__/SecretActions-test.ts: error TS2554: Expected 
 plugins/secrets/actions/__tests__/SecretActions-test.ts: error TS2554: Expected 2 arguments, but got 0.
 plugins/secrets/actions/__tests__/SecretActions-test.ts: error TS2554: Expected 2 arguments, but got 0.
 plugins/secrets/actions/__tests__/SecretActions-test.ts: error TS2554: Expected 2 arguments, but got 0.
-plugins/secrets/components/SecretActionsModal.tsx: error TS2339: Property 'selectedItems' does not exist on type *.
-plugins/secrets/components/SecretActionsModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
 plugins/secrets/components/SecretActionsModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
 plugins/secrets/components/SecretActionsModal.tsx: error TS2339: Property 'action' does not exist on type *.
 plugins/secrets/components/SecretActionsModal.tsx: error TS2339: Property 'open' does not exist on type *.
-plugins/secrets/components/SecretActionsModal.tsx: error TS2339: Property 'pendingRequest' does not exist on type 'Readonly<{}>'.
 plugins/secrets/components/SecretActionsModal.tsx: error TS2571: Object is of type 'unknown'.
 plugins/secrets/components/SecretActionsModal.tsx: error TS2571: Object is of type 'unknown'.
 plugins/secrets/components/SecretActionsModal.tsx: error TS2571: Object is of type 'unknown'.
 plugins/secrets/components/SecretActionsModal.tsx: error TS2571: Object is of type 'unknown'.
 plugins/secrets/components/SecretActionsModal.tsx: error TS2571: Object is of type 'unknown'.
 plugins/secrets/components/SecretActionsModal.tsx: error TS2571: Object is of type 'unknown'.
-plugins/secrets/components/SecretActionsModal.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/secrets/components/SecretActionsModal.tsx: error TS2339: Property 'store_listeners' does not exist on type 'SecretActionsModal'.
 plugins/secrets/components/SecretActionsModal.tsx: error TS2339: Property 'action' does not exist on type *.
 plugins/secrets/components/SecretActionsModal.tsx: error TS2339: Property 'selectedItems' does not exist on type *.
 plugins/secrets/components/SecretActionsModal.tsx: error TS2339: Property 'onSuccess' does not exist on type *.
 plugins/secrets/components/SecretActionsModal.tsx: error TS2339: Property 'action' does not exist on type *.
-plugins/secrets/components/SecretFormModal.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'store_listeners' does not exist on type 'SecretFormModal'.
+plugins/secrets/components/SecretActionsModal.tsx: error TS2339: Property 'selectedItems' does not exist on type *.
 plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'open' does not exist on type *.
 plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'open' does not exist on type *.
 plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
 plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
 plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
 plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'path' does not exist on type 'Readonly<{}>'.
 plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'textValue' does not exist on type 'Readonly<{}>'.
 plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'fileValue' does not exist on type 'Readonly<{}>'.
-plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'requestErrorType' does not exist on type 'Readonly<{}>'.
-plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'requestErrorMessage' does not exist on type 'Readonly<{}>'.
-plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'pendingRequest' does not exist on type 'Readonly<{}>'.
+plugins/secrets/components/SecretFormModal.tsx: error TS2531: Object is possibly 'null'.
 plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
-plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'pendingRequest' does not exist on type 'Readonly<{}>'.
-plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'path' does not exist on type 'Readonly<{}>'.
-plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'localErrors' does not exist on type 'Readonly<{}>'.
-plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'localErrors' does not exist on type 'Readonly<{}>'.
-plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'localErrors' does not exist on type 'Readonly<{}>'.
-plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'textValue' does not exist on type 'Readonly<{}>'.
-plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'localErrors' does not exist on type 'Readonly<{}>'.
-plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'fileValue' does not exist on type 'Readonly<{}>'.
-plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'localErrors' does not exist on type 'Readonly<{}>'.
-plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'localErrors' does not exist on type 'Readonly<{}>'.
+plugins/secrets/components/SecretFormModal.tsx: error TS2531: Object is possibly 'null'.
+plugins/secrets/components/SecretFormModal.tsx: error TS2322: Type 'null' is not assignable to type *.
+plugins/secrets/components/SecretFormModal.tsx: error TS2531: Object is possibly 'null'.
+plugins/secrets/components/SecretFormModal.tsx: error TS2531: Object is possibly 'null'.
+plugins/secrets/components/SecretFormModal.tsx: error TS2322: Type 'null' is not assignable to type *.
+plugins/secrets/components/SecretFormModal.tsx: error TS2531: Object is possibly 'null'.
+plugins/secrets/components/SecretFormModal.tsx: error TS2531: Object is possibly 'null'.
 plugins/secrets/components/SecretFormModal.tsx: error TS2322: type * is not assignable to type *.
-plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'localErrors' does not exist on type 'Readonly<{}>'.
-plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'path' does not exist on type 'Readonly<{}>'.
-plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'textValue' does not exist on type 'Readonly<{}>'.
-plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'fileValue' does not exist on type 'Readonly<{}>'.
+plugins/secrets/components/SecretFormModal.tsx: error TS2531: Object is possibly 'null'.
+plugins/secrets/components/SecretFormModal.tsx: error TS2531: Object is possibly 'null'.
 plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'secret' does not exist on type *.
-plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'valueType' does not exist on type 'Readonly<{}>'.
+plugins/secrets/components/SecretFormModal.tsx: error TS2345: Argument of type 'null' is not assignable to parameter of type 'string'.
 plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'localErrors' does not exist on type 'Readonly<{}>'.
 plugins/secrets/components/SecretFormModal.tsx: error TS2339: Property 'secret' does not exist on type *.
 plugins/secrets/components/SecretFormModal.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
@@ -1840,6 +1494,10 @@ plugins/secrets/components/SecretStoresTable.tsx: error TS2339: Property 'classN
 plugins/secrets/components/SecretStoresTable.tsx: error TS2339: Property 'stores' does not exist on type *.
 plugins/secrets/components/SecretsError.tsx: error TS2322: type * is not assignable to type *.
 plugins/secrets/components/SecretsSelect.tsx: error TS2322: Type 'Secret[]' is not assignable to type *.
+plugins/secrets/components/SecretsTable.tsx: error TS2345: Argument of type 'string' is not assignable to parameter of type *.
+plugins/secrets/components/SecretsTable.tsx: error TS2416: Property 'state' in type 'ServicesTable' is not assignable to the same property in base type *.
+plugins/secrets/components/SecretsTable.tsx: error TS2345: Argument of type 'string' is not assignable to parameter of type 'SortDirection'.
+plugins/secrets/components/SecretsTable.tsx: error TS2322: Type 'string' is not assignable to type *.
 plugins/secrets/components/forms/EnvironmentVariableInput.tsx: error TS2322: type * is not assignable to type *.
 plugins/secrets/components/forms/JobSecret.tsx: error TS2322: type * is not assignable to type *.
 plugins/secrets/components/forms/JobSecret.tsx: error TS2322: Type 'string' is not assignable to type *.
@@ -1861,7 +1519,6 @@ plugins/secrets/components/forms/MultiContainerSecretsFormSection.tsx: error TS2
 plugins/secrets/components/forms/MultiContainerSecretsFormSection.tsx: error TS2339: Property 'errors' does not exist on type *.
 plugins/secrets/components/forms/MultiContainerSecretsFormSection.tsx: error TS2345: Argument of type 'Element' is not assignable to parameter of type 'never'.
 plugins/secrets/components/forms/MultiContainerSecretsFormSection.tsx: error TS2345: Argument of type 'Element' is not assignable to parameter of type 'never'.
-plugins/secrets/components/forms/MultiContainerSecretsFormSection.tsx: error TS2339: Property 'secrets' does not exist on type 'Readonly<{}>'.
 plugins/secrets/components/forms/MultiContainerSecretsFormSection.tsx: error TS2339: Property 'data' does not exist on type *.
 plugins/secrets/components/forms/MultiContainerSecretsFormSection.tsx: error TS2339: Property 'onRemoveItem' does not exist on type *.
 plugins/secrets/components/forms/MultiContainerSecretsFormSection.tsx: error TS2339: Property 'data' does not exist on type *.
@@ -1904,10 +1561,7 @@ plugins/secrets/hooks.tsx: error TS6133: 'state' is declared but its value is ne
 plugins/secrets/hooks.tsx: error TS2554: Expected 3 arguments, but got 4.
 plugins/secrets/hooks.tsx: error TS2769: No overload matches this call.
 plugins/secrets/index.ts: error TS2306: File '/plugins/secrets/SDK.ts' is not a module.
-plugins/secrets/pages/SecretDetail.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/secrets/pages/SecretDetail.tsx: error TS2339: Property 'store_listeners' does not exist on type 'SecretDetail'.
 plugins/secrets/pages/SecretDetail.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
-plugins/secrets/pages/SecretDetail.tsx: error TS2339: Property 'hideSecret' does not exist on type 'Readonly<{}>'.
 plugins/secrets/pages/SecretDetail.tsx: error TS2322: type * is not assignable to type 'never'.
 plugins/secrets/pages/SecretDetail.tsx: error TS2322: Type 'string' is not assignable to type 'never'.
 plugins/secrets/pages/SecretDetail.tsx: error TS2322: Type 'string' is not assignable to type 'never'.
@@ -1917,44 +1571,21 @@ plugins/secrets/pages/SecretDetail.tsx: error TS2322: Type 'Element' is not assi
 plugins/secrets/pages/SecretDetail.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/secrets/pages/SecretDetail.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/secrets/pages/SecretDetail.tsx: error TS2322: Type '\\"system-download\\"' is not assignable to type *.
-plugins/secrets/pages/SecretDetail.tsx: error TS2339: Property 'hideSecret' does not exist on type 'Readonly<{}>'.
-plugins/secrets/pages/SecretDetail.tsx: error TS2339: Property 'hideSecret' does not exist on type 'Readonly<{}>'.
 plugins/secrets/pages/SecretDetail.tsx: error TS2339: Property 'params' does not exist on type *.
-plugins/secrets/pages/SecretDetail.tsx: error TS2339: Property 'requestErrorType' does not exist on type 'Readonly<{}>'.
-plugins/secrets/pages/SecretDetail.tsx: error TS2339: Property 'secretFormOpen' does not exist on type 'Readonly<{}>'.
-plugins/secrets/pages/SecretDetail.tsx: error TS2339: Property 'secret' does not exist on type 'Readonly<{}>'.
 plugins/secrets/pages/SecretDetail.tsx: error TS2741: Property 'secretPath' is missing in type '{}' but required in type *.
-plugins/secrets/pages/SecretDetail.tsx: error TS2339: Property 'loading' does not exist on type 'Readonly<{}>'.
 plugins/secrets/pages/SecretDetail.tsx: error TS2339: Property 'params' does not exist on type *.
-plugins/secrets/pages/SecretDetail.tsx: error TS2339: Property 'editSecretOpen' does not exist on type 'Readonly<{}>'.
-plugins/secrets/pages/SecretDetail.tsx: error TS2339: Property 'removeSecretOpen' does not exist on type 'Readonly<{}>'.
+plugins/secrets/pages/SecretDetail.tsx: error TS2339: Property 'editSecretOpen' does not exist on type *.
 plugins/secrets/pages/SecretDetail.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/secrets/pages/SecretDetail.tsx: error TS2322: type * is not assignable to type *.
 plugins/secrets/pages/SecretDetail.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
-plugins/secrets/pages/SecretStorePage.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/secrets/pages/SecretStorePage.tsx: error TS2339: Property 'store_listeners' does not exist on type 'SecretStorePage'.
 plugins/secrets/pages/SecretStorePage.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
-plugins/secrets/pages/SecretStorePage.tsx: error TS2339: Property 'requestError' does not exist on type 'Readonly<{}>'.
 plugins/secrets/pages/SecretStorePage.tsx: error TS2339: Property 'routeConfig' does not exist on type *.
-plugins/secrets/pages/SecretsPage.tsx: error TS2339: Property 'store_listeners' does not exist on type 'SecretsPage'.
 plugins/secrets/pages/SecretsPage.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
-plugins/secrets/pages/SecretsPage.tsx: error TS2339: Property 'secretToRemove' does not exist on type 'Readonly<{}>'.
 plugins/secrets/pages/SecretsPage.tsx: error TS2339: Property 'secretToRemove' does not exist on type *.
 plugins/secrets/pages/SecretsPage.tsx: error TS2339: Property 'checkedItems' does not exist on type *.
-plugins/secrets/pages/SecretsPage.tsx: error TS2339: Property 'checkedItems' does not exist on type 'Readonly<{}>'.
-plugins/secrets/pages/SecretsPage.tsx: error TS2339: Property 'secretToRemove' does not exist on type 'Readonly<{}>'.
-plugins/secrets/pages/SecretsPage.tsx: error TS2339: Property 'checkedItems' does not exist on type 'Readonly<{}>'.
-plugins/secrets/pages/SecretsPage.tsx: error TS2339: Property 'healthFilter' does not exist on type 'Readonly<{}>'.
-plugins/secrets/pages/SecretsPage.tsx: error TS2339: Property 'isLoadingStores' does not exist on type 'Readonly<{}>'.
-plugins/secrets/pages/SecretsPage.tsx: error TS2339: Property 'isLoadingSecrets' does not exist on type 'Readonly<{}>'.
-plugins/secrets/pages/SecretsPage.tsx: error TS2339: Property 'requestErrorType' does not exist on type 'Readonly<{}>'.
-plugins/secrets/pages/SecretsPage.tsx: error TS2339: Property 'searchString' does not exist on type 'Readonly<{}>'.
-plugins/secrets/pages/SecretsPage.tsx: error TS2339: Property 'secretFormOpen' does not exist on type 'Readonly<{}>'.
-plugins/secrets/pages/SecretsPage.tsx: error TS2339: Property 'selectedAction' does not exist on type 'Readonly<{}>'.
 plugins/secrets/pages/SecretsPage.tsx: error TS2322: type * is not assignable to type *.
 plugins/secrets/pages/SecretsPage.tsx: error TS2322: type * is not assignable to type *.
 plugins/secrets/pages/SecretsPage.tsx: error TS2339: Property 'routeConfig' does not exist on type *.
-plugins/secrets/pages/SecretsPage.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/secrets/pages/SecurityPage.tsx: error TS2339: Property 'routeConfig' does not exist on type *.
 plugins/secrets/pages/__tests__/SecretDetail-test.tsx: error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
 plugins/secrets/pages/__tests__/SecretDetail-test.tsx: error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
@@ -2017,6 +1648,7 @@ plugins/services/src/js/columns/QuotaOverviewDiskConsumedColumn.tsx: error TS255
 plugins/services/src/js/columns/QuotaOverviewDiskConsumedColumn.tsx: error TS2554: Expected 5 arguments, but got 2.
 plugins/services/src/js/columns/QuotaOverviewMemoryConsumedColumn.tsx: error TS2554: Expected 5 arguments, but got 2.
 plugins/services/src/js/columns/QuotaOverviewMemoryConsumedColumn.tsx: error TS2554: Expected 5 arguments, but got 2.
+plugins/services/src/js/columns/ServicesTableRegionColumn.tsx: error TS2322: type * is not assignable to type 'string[]'.
 plugins/services/src/js/columns/resourceLimits.ts: error TS2339: Property 'spec' does not exist on type 'Pod'.
 plugins/services/src/js/columns/resourceLimits.ts: error TS2339: Property 'spec' does not exist on type 'Pod'.
 plugins/services/src/js/components/ConfigurationMapTable.tsx: error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
@@ -2033,12 +1665,8 @@ plugins/services/src/js/components/DeclinedOffersTable.tsx: error TS2554: Expect
 plugins/services/src/js/components/DeclinedOffersTable.tsx: error TS2554: Expected 2 arguments, but got 1.
 plugins/services/src/js/components/DeclinedOffersTable.tsx: error TS2554: Expected 2 arguments, but got 1.
 plugins/services/src/js/components/DeclinedOffersTable.tsx: error TS2339: Property 'offers' does not exist on type *.
-plugins/services/src/js/components/DeploymentStatusIndicator.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/services/src/js/components/DeploymentStatusIndicator.tsx: error TS2339: Property 'store_listeners' does not exist on type 'DeploymentStatusIndicator'.
-plugins/services/src/js/components/DeploymentStatusIndicator.tsx: error TS2339: Property 'isOpen' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/DeploymentStatusIndicator.tsx: error TS2322: type * is not assignable to type *.
-plugins/services/src/js/components/DeploymentStatusIndicator.tsx: error TS2339: Property 'isOpen' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/DeploymentsModal.tsx: error TS2339: Property 'deploymentToRollback' does not exist on type 'Readonly<{}>'.
+plugins/services/src/js/components/DeploymentsModal.tsx: error TS2339: Property 'deploymentToRollback' does not exist on type *.
 plugins/services/src/js/components/DeploymentsModal.tsx: error TS2554: Expected 2 arguments, but got 1.
 plugins/services/src/js/components/DeploymentsModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
 plugins/services/src/js/components/DeploymentsModal.tsx: error TS6133: 'prop' is declared but its value is never read.
@@ -2048,28 +1676,24 @@ plugins/services/src/js/components/DeploymentsModal.tsx: error TS6133: 'prop' is
 plugins/services/src/js/components/DeploymentsModal.tsx: error TS2322: Type 'string' is not assignable to type 'null'.
 plugins/services/src/js/components/DeploymentsModal.tsx: error TS2322: Type 'null' is not assignable to type *.
 plugins/services/src/js/components/DeploymentsModal.tsx: error TS7030: Not all code paths return a value.
-plugins/services/src/js/components/DeploymentsModal.tsx: error TS2339: Property 'awaitingRevertDeploymentResponse' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/DeploymentsModal.tsx: error TS2339: Property 'deploymentToRollback' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/DeploymentsModal.tsx: error TS2339: Property 'deploymentRollbackError' does not exist on type 'Readonly<{}>'.
+plugins/services/src/js/components/DeploymentsModal.tsx: error TS2339: Property 'awaitingRevertDeploymentResponse' does not exist on type *.
+plugins/services/src/js/components/DeploymentsModal.tsx: error TS2339: Property 'deploymentToRollback' does not exist on type *.
+plugins/services/src/js/components/DeploymentsModal.tsx: error TS2339: Property 'deploymentRollbackError' does not exist on type *.
 plugins/services/src/js/components/DeploymentsModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
 plugins/services/src/js/components/DeploymentsModal.tsx: error TS6133: 'prop' is declared but its value is never read.
 plugins/services/src/js/components/DeploymentsModal.tsx: error TS6133: 'prop' is declared but its value is never read.
 plugins/services/src/js/components/DeploymentsModal.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/components/DeploymentsModal.tsx: error TS7030: Not all code paths return a value.
-plugins/services/src/js/components/DeploymentsModal.tsx: error TS2339: Property 'dcosDeploymentsList' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/DeploymentsModal.tsx: error TS2339: Property 'isOpen' does not exist on type *.
 plugins/services/src/js/components/DeploymentsModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
-plugins/services/src/js/components/DeploymentsModal.tsx: error TS2339: Property 'dcosServiceDataReceived' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/DeploymentsModal.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/services/src/js/components/DeploymentsModal.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/services/src/js/components/DeploymentsModal.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
-plugins/services/src/js/components/DeploymentsModal.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/services/src/js/components/DeploymentsModal.tsx: error TS2339: Property 'store_listeners' does not exist on type 'DeploymentsModal'.
-plugins/services/src/js/components/DeploymentsModal.tsx: error TS2339: Property 'deploymentToRollback' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/DeploymentsModal.tsx: error TS2339: Property 'deploymentToRollback' does not exist on type 'Readonly<{}>'.
+plugins/services/src/js/components/DeploymentsModal.tsx: error TS2339: Property 'deploymentToRollback' does not exist on type *.
+plugins/services/src/js/components/DeploymentsModal.tsx: error TS2339: Property 'deploymentToRollback' does not exist on type *.
 plugins/services/src/js/components/FilterByFramework.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/components/HighOrderServiceInstances.tsx: error TS2322: type * is not assignable to type *.
-plugins/services/src/js/components/HighOrderServiceInstances.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/components/HighOrderServiceInstances.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/components/Highlight.tsx: error TS2339: Property 'search' does not exist on type *.
 plugins/services/src/js/components/Highlight.tsx: error TS2339: Property 'search' does not exist on type *.
 plugins/services/src/js/components/Highlight.tsx: error TS2339: Property 'caseSensitive' does not exist on type *.
@@ -2086,23 +1710,15 @@ plugins/services/src/js/components/Highlight.tsx: error TS2532: Object is possib
 plugins/services/src/js/components/Highlight.tsx: error TS2345: Argument of type 'Element' is not assignable to parameter of type 'never'.
 plugins/services/src/js/components/Highlight.tsx: error TS2345: Argument of type * is not assignable to parameter of type 'never'.
 plugins/services/src/js/components/Highlight.tsx: error TS2532: Object is possibly 'undefined'.
-plugins/services/src/js/components/Highlight.tsx: error TS2339: Property 'count' does not exist on type 'Highlight'.
-plugins/services/src/js/components/Highlight.tsx: error TS2339: Property 'count' does not exist on type 'Highlight'.
-plugins/services/src/js/components/Highlight.tsx: error TS2339: Property 'count' does not exist on type 'Highlight'.
 plugins/services/src/js/components/Highlight.tsx: error TS2339: Property 'matchElement' does not exist on type *.
-plugins/services/src/js/components/Highlight.tsx: error TS2339: Property 'count' does not exist on type 'Highlight'.
 plugins/services/src/js/components/Highlight.tsx: error TS2339: Property 'matchClass' does not exist on type *.
-plugins/services/src/js/components/Highlight.tsx: error TS2339: Property 'count' does not exist on type 'Highlight'.
 plugins/services/src/js/components/Highlight.tsx: error TS2339: Property 'matchElement' does not exist on type *.
 plugins/services/src/js/components/Highlight.tsx: error TS2339: Property 'selectedMatchClass' does not exist on type *.
-plugins/services/src/js/components/Highlight.tsx: error TS2339: Property 'count' does not exist on type 'Highlight'.
 plugins/services/src/js/components/Highlight.tsx: error TS2339: Property 'matchElement' does not exist on type *.
 plugins/services/src/js/components/Highlight.tsx: error TS2322: type * is not assignable to type 'Validator<any>'.
-plugins/services/src/js/components/Highlight.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/services/src/js/components/Highlight.tsx: error TS2339: Property 'count' does not exist on type 'Highlight'.
 plugins/services/src/js/components/Highlight.tsx: error TS2339: Property 'search' does not exist on type *.
-plugins/services/src/js/components/Highlight.tsx: error TS7030: Not all code paths return a value.
 plugins/services/src/js/components/Highlight.tsx: error TS2769: No overload matches this call.
+plugins/services/src/js/components/Highlight.tsx: error TS7030: Not all code paths return a value.
 plugins/services/src/js/components/Highlight.tsx: error TS2339: Property 'searchDebounceThreshold' does not exist on type *.
 plugins/services/src/js/components/Highlight.tsx: error TS2339: Property 'searchDebounceDelay' does not exist on type *.
 plugins/services/src/js/components/Highlight.tsx: error TS2322: Type 'Timeout' is not assignable to type 'null'.
@@ -2117,9 +1733,8 @@ plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'watching
 plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'highlightText' does not exist on type *.
 plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'direction' does not exist on type *.
 plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'fullLog' does not exist on type *.
-plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'fullLog' does not exist on type 'Readonly<{}>'.
+plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'fullLog' does not exist on type *.
 plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'logContainer' does not exist on type 'LogView'.
-plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'isAtBottom' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'updatingScrollPosition' does not exist on type 'LogView'.
 plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'updatingScrollPosition' does not exist on type 'LogView'.
 plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'logContainer' does not exist on type 'LogView'.
@@ -2132,7 +1747,6 @@ plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'updating
 plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'hasLoadedTop' does not exist on type *.
 plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'fetchPreviousLogs' does not exist on type *.
 plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'updatingScrollPosition' does not exist on type 'LogView'.
-plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'isAtBottom' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'logContainer' does not exist on type 'LogView'.
 plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'updatingScrollPosition' does not exist on type 'LogView'.
 plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'updatingScrollPosition' does not exist on type 'LogView'.
@@ -2140,24 +1754,20 @@ plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'highligh
 plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'logName' does not exist on type *.
 plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'onCountChange' does not exist on type *.
 plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'watching' does not exist on type *.
-plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'fullLog' does not exist on type 'Readonly<{}>'.
+plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'fullLog' does not exist on type *.
 plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'logContainer' does not exist on type 'LogView'.
-plugins/services/src/js/components/LogView.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/components/LogView.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'highlightText' does not exist on type *.
-plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'isAtBottom' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'hasLoadedTop' does not exist on type *.
 plugins/services/src/js/components/LogView.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'updatingScrollPosition' does not exist on type 'LogView'.
 plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'logContainer' does not exist on type 'LogView'.
-plugins/services/src/js/components/LogView.tsx: error TS2339: Property 'isAtBottom' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/MarathonTaskDetailsList.tsx: error TS2322: Type 'Element' is not assignable to type 'string'.
 plugins/services/src/js/components/MarathonTaskDetailsList.tsx: error TS2339: Property 'taskID' does not exist on type *.
 plugins/services/src/js/components/MesosLogContainer.tsx: error TS2339: Property 'task' does not exist on type *.
 plugins/services/src/js/components/MesosLogContainer.tsx: error TS2339: Property 'filePath' does not exist on type *.
-plugins/services/src/js/components/MesosLogContainer.tsx: error TS2339: Property 'hasLoadingError' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/MesosLogContainer.tsx: error TS2339: Property 'filePath' does not exist on type *.
 plugins/services/src/js/components/MesosLogContainer.tsx: error TS2339: Property 'task' does not exist on type *.
-plugins/services/src/js/components/MesosLogContainer.tsx: error TS2339: Property 'isFetchingPrevious' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/MesosLogContainer.tsx: error TS2339: Property 'task' does not exist on type *.
 plugins/services/src/js/components/MesosLogContainer.tsx: error TS2339: Property 'filePath' does not exist on type *.
 plugins/services/src/js/components/MesosLogContainer.tsx: error TS2339: Property 'filePath' does not exist on type *.
@@ -2165,14 +1775,7 @@ plugins/services/src/js/components/MesosLogContainer.tsx: error TS2339: Property
 plugins/services/src/js/components/MesosLogContainer.tsx: error TS2339: Property 'logName' does not exist on type *.
 plugins/services/src/js/components/MesosLogContainer.tsx: error TS2339: Property 'onCountChange' does not exist on type *.
 plugins/services/src/js/components/MesosLogContainer.tsx: error TS2339: Property 'watching' does not exist on type *.
-plugins/services/src/js/components/MesosLogContainer.tsx: error TS2339: Property 'direction' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/MesosLogContainer.tsx: error TS2339: Property 'fullLog' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/MesosLogContainer.tsx: error TS2322: type * is not assignable to type *.
-plugins/services/src/js/components/MesosLogContainer.tsx: error TS2339: Property 'hasLoadingError' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/MesosLogContainer.tsx: error TS2339: Property 'isLoading' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/MesosLogContainer.tsx: error TS2339: Property 'hasOffsetLoadingError' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/MesosLogContainer.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/services/src/js/components/MesosLogContainer.tsx: error TS2339: Property 'store_listeners' does not exist on type 'MesosLogContainer'.
 plugins/services/src/js/components/MesosLogContainer.tsx: error TS2556: Expected 0 arguments, but got 1 or more.
 plugins/services/src/js/components/MesosLogContainer.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
 plugins/services/src/js/components/MesosLogContainer.tsx: error TS2339: Property 'filePath' does not exist on type *.
@@ -2189,7 +1792,6 @@ plugins/services/src/js/components/PodVolumeTable.tsx: error TS2339: Property 'r
 plugins/services/src/js/components/PodVolumeTable.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/components/PodVolumeTable.tsx: error TS6133: 'prop' is declared but its value is never read.
 plugins/services/src/js/components/PodVolumeTable.tsx: error TS2339: Property 'service' does not exist on type *.
-plugins/services/src/js/components/PodVolumeTable.tsx: error TS2554: Expected 1-2 arguments, but got 0.
 plugins/services/src/js/components/RecentOffersSummary.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/services/src/js/components/RecentOffersSummary.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/services/src/js/components/RecentOffersSummary.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
@@ -2226,32 +1828,11 @@ plugins/services/src/js/components/RecentOffersSummary.tsx: error TS2554: Expect
 plugins/services/src/js/components/RecentOffersSummary.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/services/src/js/components/SearchLog.tsx: error TS2339: Property 'actions' does not exist on type *.
 plugins/services/src/js/components/SearchLog.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/services/src/js/components/SearchLog.tsx: error TS2339: Property 'searchString' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/SearchLog.tsx: error TS2339: Property 'watching' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/SearchLog.tsx: error TS2769: No overload matches this call.
-plugins/services/src/js/components/SearchLog.tsx: error TS2339: Property 'searchString' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/SearchLog.tsx: error TS2339: Property 'filterInputRef' does not exist on type 'SearchLog'.
-plugins/services/src/js/components/SearchLog.tsx: error TS2339: Property 'searchString' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/SearchLog.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/services/src/js/components/SearchLog.tsx: error TS2339: Property 'filterInputRef' does not exist on type 'SearchLog'.
+plugins/services/src/js/components/SearchLog.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/components/SearchLog.tsx: error TS6133: 'nextProps' is declared but its value is never read.
 plugins/services/src/js/components/SearchLog.tsx: error TS2339: Property 'watching' does not exist on type '{}'.
-plugins/services/src/js/components/SearchLog.tsx: error TS2339: Property 'watching' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/SearchLog.tsx: error TS2339: Property 'searchString' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/SearchLog.tsx: error TS2339: Property 'watching' does not exist on type '{}'.
-plugins/services/src/js/components/SearchLog.tsx: error TS2339: Property 'totalFound' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/SearchLog.tsx: error TS2339: Property 'watching' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/SearchLog.tsx: error TS2339: Property 'searchString' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/SearchLog.tsx: error TS2339: Property 'totalFound' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/SearchLog.tsx: error TS2339: Property 'watching' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/SearchLog.tsx: error TS2339: Property 'totalFound' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2339: Property 'shouldRenderServiceStatus' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2339: Property 'shouldRenderServiceStatus' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2339: Property 'breadcrumbStatusRef' does not exist on type 'ServiceBreadcrumbs'.
-plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2339: Property 'lastStatusWidth' does not exist on type 'ServiceBreadcrumbs'.
-plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2339: Property 'breadcrumbStatusRef' does not exist on type 'ServiceBreadcrumbs'.
-plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2339: Property 'lastStatusWidth' does not exist on type 'ServiceBreadcrumbs'.
-plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2339: Property 'shouldRenderServiceStatus' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2339: Property 'taskID' does not exist on type *.
 plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
@@ -2260,7 +1841,6 @@ plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2339: Propert
 plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2339: Property 'taskID' does not exist on type *.
 plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2322: type * is not assignable to type *.
-plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2339: Property 'breadcrumbStatusRef' does not exist on type 'ServiceBreadcrumbs'.
 plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2339: Property 'serviceID' does not exist on type *.
 plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2339: Property 'taskID' does not exist on type *.
 plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2339: Property 'taskName' does not exist on type *.
@@ -2268,12 +1848,7 @@ plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2339: Propert
 plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2322: type * is not assignable to type 'null'.
 plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2322: type * is not assignable to type 'null'.
 plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2322: type * is not assignable to type *.
-plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2339: Property 'primaryBreadcrumbTextRef' does not exist on type 'ServiceBreadcrumbs'.
 plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2769: No overload matches this call.
-plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2554: Expected 1-2 arguments, but got 0.
-plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2339: Property 'breadcrumbStatusRef' does not exist on type 'ServiceBreadcrumbs'.
-plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2339: Property 'primaryBreadcrumbTextRef' does not exist on type 'ServiceBreadcrumbs'.
-plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2339: Property 'lastStatusWidth' does not exist on type 'ServiceBreadcrumbs'.
 plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2339: Property 'serviceID' does not exist on type *.
 plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2339: Property 'taskID' does not exist on type *.
 plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2339: Property 'taskName' does not exist on type *.
@@ -2281,11 +1856,9 @@ plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2339: Propert
 plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2339: Property 'instancesCount' does not exist on type *.
 plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2339: Property 'runningInstances' does not exist on type *.
 plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2339: Property 'serviceStatus' does not exist on type *.
-plugins/services/src/js/components/ServiceBreadcrumbs.tsx: error TS2339: Property 'primaryBreadcrumbTextRef' does not exist on type 'ServiceBreadcrumbs'.
 plugins/services/src/js/components/ServicesQuotaOverviewDetail.tsx: error TS2554: Expected 5 arguments, but got 2.
 plugins/services/src/js/components/ServicesQuotaOverviewDetail.tsx: error TS2554: Expected 5 arguments, but got 2.
-plugins/services/src/js/components/ServicesQuotaOverviewTable.tsx: error TS2345: Argument of type '{}[]' is not assignable to parameter of type *.
-plugins/services/src/js/components/ServicesQuotaOverviewTable.tsx: error TS2345: Argument of type '{}[]' is not assignable to parameter of type *.
+plugins/services/src/js/components/ServicesQuotaOverviewTable.tsx: error TS2729: Property 'sortData' is used before its initialization.
 plugins/services/src/js/components/TaskDirectoryTable.tsx: error TS2554: Expected 5 arguments, but got 2.
 plugins/services/src/js/components/TaskDirectoryTable.tsx: error TS2339: Property 'files' does not exist on type *.
 plugins/services/src/js/components/TaskDirectoryTable.tsx: error TS2339: Property 'onFileClick' does not exist on type *.
@@ -2298,7 +1871,6 @@ plugins/services/src/js/components/VolumeTable.tsx: error TS2339: Property 'para
 plugins/services/src/js/components/VolumeTable.tsx: error TS2339: Property 'routes' does not exist on type *.
 plugins/services/src/js/components/VolumeTable.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/components/VolumeTable.tsx: error TS2339: Property 'service' does not exist on type *.
-plugins/services/src/js/components/VolumeTable.tsx: error TS2554: Expected 1-2 arguments, but got 0.
 plugins/services/src/js/components/__tests__/ConfigurationMapTable-test.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/components/__tests__/ConfigurationMapTable-test.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/components/__tests__/ConfigurationMapTable-test.tsx: error TS2322: type * is not assignable to type *.
@@ -2306,10 +1878,11 @@ plugins/services/src/js/components/__tests__/ConfigurationMapTable-test.tsx: err
 plugins/services/src/js/components/__tests__/ConfigurationMapTable-test.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/components/__tests__/ConfigurationMapTable-test.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/components/__tests__/ConfigurationMapTable-test.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/components/__tests__/DeploymentsModal-test.ts: error TS2554: Expected 1-2 arguments, but got 0.
 plugins/services/src/js/components/__tests__/FilterByFramework-test.tsx: error TS2322: type * is not assignable to type 'Framework[]'.
-plugins/services/src/js/components/__tests__/Highlight-test.tsx: error TS2322: type * is not assignable to type *.
-plugins/services/src/js/components/__tests__/Highlight-test.tsx: error TS2322: type * is not assignable to type *.
-plugins/services/src/js/components/__tests__/Highlight-test.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/components/__tests__/Highlight-test.tsx: error TS2769: No overload matches this call.
+plugins/services/src/js/components/__tests__/Highlight-test.tsx: error TS2769: No overload matches this call.
+plugins/services/src/js/components/__tests__/Highlight-test.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/components/__tests__/Highlight-test.tsx: error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
 plugins/services/src/js/components/__tests__/LogView-test.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/components/__tests__/LogView-test.tsx: error TS2741: Property 'width' is missing in type * but required in type *.
@@ -2319,11 +1892,8 @@ plugins/services/src/js/components/__tests__/MesosLogContainer-test.tsx: error T
 plugins/services/src/js/components/__tests__/MesosLogContainer-test.tsx: error TS2339: Property 'calls' does not exist on type *.
 plugins/services/src/js/components/__tests__/ServiceBreadcrumbs-test.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/components/__tests__/ServiceBreadcrumbs-test.tsx: error TS2322: type * is not assignable to type *.
-plugins/services/src/js/components/dsl/FuzzyTextDSLSection.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/services/src/js/components/dsl/FuzzyTextDSLSection.tsx: error TS2339: Property 'onChange' does not exist on type *.
 plugins/services/src/js/components/dsl/FuzzyTextDSLSection.tsx: error TS2339: Property 'expression' does not exist on type *.
-plugins/services/src/js/components/dsl/FuzzyTextDSLSection.tsx: error TS2339: Property 'data' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/dsl/FuzzyTextDSLSection.tsx: error TS2339: Property 'data' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/dsl/FuzzyTextDSLSection.tsx: error TS2339: Property 'expression' does not exist on type *.
 plugins/services/src/js/components/dsl/FuzzyTextDSLSection.tsx: error TS2339: Property 'onApply' does not exist on type *.
 plugins/services/src/js/components/dsl/FuzzyTextDSLSection.tsx: error TS2339: Property 'onChange' does not exist on type *.
@@ -2397,7 +1967,7 @@ plugins/services/src/js/components/forms/EnvironmentFormSection.tsx: error TS233
 plugins/services/src/js/components/forms/EnvironmentFormSection.tsx: error TS2741: Property 'onClick' is missing in type '{}' but required in type *.
 plugins/services/src/js/components/forms/EnvironmentFormSection.tsx: error TS2339: Property 'onAddItem' does not exist on type *.
 plugins/services/src/js/components/forms/EnvironmentFormSection.tsx: error TS2339: Property 'mountType' does not exist on type *.
-plugins/services/src/js/components/forms/EnvironmentFormSection.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/components/forms/EnvironmentFormSection.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/components/forms/EnvironmentFormSection.tsx: error TS2339: Property 'onAddItem' does not exist on type *.
 plugins/services/src/js/components/forms/EnvironmentFormSection.tsx: error TS2339: Property 'onRemoveItem' does not exist on type *.
 plugins/services/src/js/components/forms/EnvironmentFormSection.tsx: error TS2339: Property 'configReducers' does not exist on type *.
@@ -2429,14 +1999,13 @@ plugins/services/src/js/components/forms/GeneralServiceFormSection.tsx: error TS
 plugins/services/src/js/components/forms/GeneralServiceFormSection.tsx: error TS2339: Property 'data' does not exist on type *.
 plugins/services/src/js/components/forms/GeneralServiceFormSection.tsx: error TS2339: Property 'errors' does not exist on type *.
 plugins/services/src/js/components/forms/GeneralServiceFormSection.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/services/src/js/components/forms/GeneralServiceFormSection.tsx: error TS2339: Property 'convertToPodModalOpen' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/forms/GeneralServiceFormSection.tsx: error TS2339: Property 'configReducers' does not exist on type *.
-plugins/services/src/js/components/forms/GeneralServiceFormSection.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/services/src/js/components/forms/GeneralServiceFormSection.tsx: error TS2339: Property 'onConvertToPod' does not exist on type *.
 plugins/services/src/js/components/forms/GeneralServiceFormSection.tsx: error TS2339: Property 'data' does not exist on type *.
 plugins/services/src/js/components/forms/GeneralServiceFormSection.tsx: error TS2339: Property 'errors' does not exist on type *.
 plugins/services/src/js/components/forms/GeneralServiceFormSection.tsx: error TS2339: Property 'expandAdvancedSettings' does not exist on type *.
 plugins/services/src/js/components/forms/GeneralServiceFormSection.tsx: error TS2339: Property 'service' does not exist on type *.
+plugins/services/src/js/components/forms/GeneralServiceFormSection.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/components/forms/HealthChecksFormSection.tsx: error TS2339: Property 'errors' does not exist on type *.
 plugins/services/src/js/components/forms/HealthChecksFormSection.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/components/forms/HealthChecksFormSection.tsx: error TS2339: Property 'data' does not exist on type *.
@@ -2452,6 +2021,7 @@ plugins/services/src/js/components/forms/HealthChecksFormSection.tsx: error TS23
 plugins/services/src/js/components/forms/HealthChecksFormSection.tsx: error TS2339: Property 'configReducers' does not exist on type *.
 plugins/services/src/js/components/forms/HealthChecksFormSection.tsx: error TS2339: Property 'validationReducers' does not exist on type *.
 plugins/services/src/js/components/forms/HealthChecksFormSection.tsx: error TS2339: Property 'errors' does not exist on type *.
+plugins/services/src/js/components/forms/HealthChecksFormSection.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.tsx: error TS2339: Property 'errors' does not exist on type *.
 plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.tsx: error TS2339: Property 'data' does not exist on type *.
@@ -2464,6 +2034,7 @@ plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.t
 plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.tsx: error TS2339: Property 'data' does not exist on type *.
 plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.tsx: error TS2339: Property 'handleTabChange' does not exist on type *.
 plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.tsx: error TS2339: Property 'errors' does not exist on type *.
+plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.tsx: error TS2339: Property 'errors' does not exist on type *.
 plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.tsx: error TS2339: Property 'errors' does not exist on type *.
 plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.tsx: error TS2322: type * is not assignable to type 'string'.
@@ -2485,13 +2056,12 @@ plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.tsx
 plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.tsx: error TS2339: Property 'errors' does not exist on type *.
 plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.tsx: error TS2339: Property 'configReducers' does not exist on type *.
-plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.tsx: error TS2339: Property 'store_listeners' does not exist on type 'MultiContainerNetworkingFormSection'.
 plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.tsx: error TS2339: Property 'data' does not exist on type *.
 plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.tsx: error TS2339: Property 'errors' does not exist on type *.
 plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.tsx: error TS2339: Property 'data' does not exist on type *.
 plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.tsx: error TS2339: Property 'errors' does not exist on type *.
 plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.tsx: error TS2339: Property 'onRemoveItem' does not exist on type *.
-plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.tsx: error TS7030: Not all code paths return a value.
 plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.tsx: error TS2339: Property 'data' does not exist on type *.
 plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.tsx: error TS2339: Property 'handleTabChange' does not exist on type *.
@@ -2500,7 +2070,7 @@ plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.tsx: e
 plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.tsx: error TS2339: Property 'data' does not exist on type *.
 plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
-plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/components/forms/NetworkingFormSection.tsx: error TS2339: Property 'data' does not exist on type *.
 plugins/services/src/js/components/forms/NetworkingFormSection.tsx: error TS2339: Property 'errors' does not exist on type *.
 plugins/services/src/js/components/forms/NetworkingFormSection.tsx: error TS2339: Property 'errors' does not exist on type *.
@@ -2517,18 +2087,16 @@ plugins/services/src/js/components/forms/NetworkingFormSection.tsx: error TS2339
 plugins/services/src/js/components/forms/NetworkingFormSection.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/services/src/js/components/forms/NetworkingFormSection.tsx: error TS2339: Property 'onRemoveItem' does not exist on type *.
 plugins/services/src/js/components/forms/NetworkingFormSection.tsx: error TS2339: Property 'data' does not exist on type *.
-plugins/services/src/js/components/forms/NetworkingFormSection.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/services/src/js/components/forms/NetworkingFormSection.tsx: error TS2339: Property 'data' does not exist on type *.
-plugins/services/src/js/components/forms/NetworkingFormSection.tsx: error TS2339: Property 'store_listeners' does not exist on type 'NetworkingFormSection'.
 plugins/services/src/js/components/forms/NetworkingFormSection.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/components/forms/NetworkingFormSection.tsx: error TS2339: Property 'data' does not exist on type *.
 plugins/services/src/js/components/forms/NetworkingFormSection.tsx: error TS2339: Property 'onAddItem' does not exist on type *.
 plugins/services/src/js/components/forms/NetworkingFormSection.tsx: error TS2339: Property 'data' does not exist on type *.
 plugins/services/src/js/components/forms/NetworkingFormSection.tsx: error TS2339: Property 'errors' does not exist on type *.
 plugins/services/src/js/components/forms/NetworkingFormSection.tsx: error TS2339: Property 'data' does not exist on type *.
-plugins/services/src/js/components/forms/NetworkingFormSection.tsx: error TS2339: Property 'configReducers' does not exist on type *.
 plugins/services/src/js/components/forms/NetworkingFormSection.tsx: error TS2339: Property 'errors' does not exist on type *.
 plugins/services/src/js/components/forms/NetworkingFormSection.tsx: error TS2339: Property 'data' does not exist on type *.
+plugins/services/src/js/components/forms/NetworkingFormSection.tsx: error TS2339: Property 'configReducers' does not exist on type *.
 plugins/services/src/js/components/forms/PlacementSection.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/components/forms/VolumesFormSection.tsx: error TS2339: Property 'errors' does not exist on type *.
 plugins/services/src/js/components/forms/VolumesFormSection.tsx: error TS2322: type * is not assignable to type *.
@@ -2536,24 +2104,22 @@ plugins/services/src/js/components/forms/VolumesFormSection.tsx: error TS2339: P
 plugins/services/src/js/components/forms/VolumesFormSection.tsx: error TS2339: Property 'errors' does not exist on type *.
 plugins/services/src/js/components/forms/VolumesFormSection.tsx: error TS2339: Property 'errors' does not exist on type *.
 plugins/services/src/js/components/forms/VolumesFormSection.tsx: error TS2339: Property 'data' does not exist on type *.
-plugins/services/src/js/components/forms/VolumesFormSection.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/components/forms/VolumesFormSection.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/components/forms/VolumesFormSection.tsx: error TS2339: Property 'errors' does not exist on type *.
 plugins/services/src/js/components/forms/VolumesFormSection.tsx: error TS2339: Property 'errors' does not exist on type *.
 plugins/services/src/js/components/forms/VolumesFormSection.tsx: error TS2339: Property 'onRemoveItem' does not exist on type *.
 plugins/services/src/js/components/forms/VolumesFormSection.tsx: error TS2339: Property 'onRemoveItem' does not exist on type *.
-plugins/services/src/js/components/forms/VolumesFormSection.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/components/forms/VolumesFormSection.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/components/forms/VolumesFormSection.tsx: error TS2339: Property 'data' does not exist on type *.
 plugins/services/src/js/components/forms/VolumesFormSection.tsx: error TS2339: Property 'onAddItem' does not exist on type *.
-plugins/services/src/js/components/forms/VolumesFormSection.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/components/forms/VolumesFormSection.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/components/forms/VolumesFormSection.tsx: error TS2339: Property 'configReducers' does not exist on type *.
 plugins/services/src/js/components/forms/VolumesFormSection.tsx: error TS2339: Property 'validationReducers' does not exist on type *.
 plugins/services/src/js/components/forms/VolumesFormSection.tsx: error TS2339: Property 'errors' does not exist on type *.
 plugins/services/src/js/components/forms/VolumesFormSection.tsx: error TS2339: Property 'errors' does not exist on type *.
-plugins/services/src/js/components/modals/CreateServiceJsonOnly.tsx: error TS2339: Property 'appConfig' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/modals/CreateServiceJsonOnly.tsx: error TS2339: Property 'errors' does not exist on type *.
 plugins/services/src/js/components/modals/CreateServiceJsonOnly.tsx: error TS2339: Property 'onPropertyChange' does not exist on type *.
 plugins/services/src/js/components/modals/CreateServiceJsonOnly.tsx: error TS2322: type * is not assignable to type *.
-plugins/services/src/js/components/modals/CreateServiceJsonOnly.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/services/src/js/components/modals/CreateServiceJsonOnly.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/components/modals/CreateServiceJsonOnly.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/components/modals/CreateServiceJsonOnly.tsx: error TS2339: Property 'onChange' does not exist on type *.
@@ -2563,85 +2129,35 @@ plugins/services/src/js/components/modals/CreateServiceJsonOnly.tsx: error TS233
 plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'unregisterLeaveHook' does not exist on type 'CreateServiceModal'.
 plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'location' does not exist on type *.
 plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'params' does not exist on type *.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'isPending' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2307: Cannot find module '#SRC/resources/raml/marathon/v2/types/app.raml' or its corresponding type declarations.
 plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'unregisterLeaveHook' does not exist on type 'CreateServiceModal'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'apiErrors' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'isOpen' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'hasChangesApplied' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'serviceReviewActive' does not exist on type 'Readonly<{}>'.
+plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'type' does not exist on type 'never'.
 plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2307: Cannot find module '#SRC/resources/raml/marathon/v2/types/pod.raml' or its corresponding type declarations.
 plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'location' does not exist on type *.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'serviceFormActive' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'serviceJsonActive' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'params' does not exist on type *.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'hasChangesApplied' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'serviceFormActive' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'servicePickerActive' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'serviceReviewActive' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'apiErrors' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'isJSONModeActive' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'isJSONModeActive' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'submitFailed' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'apiErrors' does not exist on type 'Readonly<{}>'.
+plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'type' does not exist on type 'never'.
+plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'path' does not exist on type 'never'.
 plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'params' does not exist on type *.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'serviceSpec' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'location' does not exist on type *.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'service' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'serviceSpec' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2554: Expected 1 arguments, but got 2.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'serviceSpec' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'serviceSpec' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'isPermissive' does not exist on type 'never'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'serviceFormErrors' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'apiErrors' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'formErrors' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'serviceFormErrors' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'serviceReviewActive' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'location' does not exist on type *.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'service' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'expandAdvancedSettings' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'isJSONModeActive' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'serviceSpec' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'serviceFormActive' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'serviceJsonActive' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'servicePickerActive' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'serviceReviewActive' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'expandAdvancedSettings' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'location' does not exist on type *.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'showAllErrors' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'configReducers' does not exist on type *.
 plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'configReducers' does not exist on type *.
 plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2322: type * is not assignable to type *.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'activeTab' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'createComponent' does not exist on type 'CreateServiceModal'.
 plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'createComponent' does not exist on type 'CreateServiceModal'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'serviceFormActive' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'serviceJsonActive' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'servicePickerActive' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'serviceReviewActive' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'isPending' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'isPending' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'isJSONModeActive' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'location' does not exist on type *.
 plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2740: Type 'ServiceSpec' is missing the following properties from type 'ApplicationSpec': getAcceptedResourceRoles, getCommand, getConstraints, getCpus, and 6 more.
 plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'location' does not exist on type *.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'servicePickerActive' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'serviceReviewActive' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'hasChangesApplied' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'isOpen' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'servicePickerActive' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'serviceReviewActive' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'isConfirmOpen' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
 plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
 plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'location' does not exist on type *.
 plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'route' does not exist on type *.
-plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2339: Property 'service' does not exist on type 'Readonly<{}>'.
+plugins/services/src/js/components/modals/CreateServiceModal.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
 plugins/services/src/js/components/modals/CreateServiceModalForm.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/services/src/js/components/modals/CreateServiceModalForm.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/components/modals/CreateServiceModalForm.tsx: error TS2783: 'baseConfig' is specified more than once, so this usage will be overwritten.
@@ -2696,6 +2212,7 @@ plugins/services/src/js/components/modals/CreateServiceModalForm.tsx: error TS23
 plugins/services/src/js/components/modals/CreateServiceModalForm.tsx: error TS6133: 'item' is declared but its value is never read.
 plugins/services/src/js/components/modals/CreateServiceModalForm.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/components/modals/CreateServiceModalForm.tsx: error TS2769: No overload matches this call.
+plugins/services/src/js/components/modals/CreateServiceModalForm.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/components/modals/CreateServiceModalForm.tsx: error TS2339: Property 'isNested' does not exist on type '{}'.
 plugins/services/src/js/components/modals/CreateServiceModalForm.tsx: error TS2339: Property 'isPod' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/modals/CreateServiceModalForm.tsx: error TS2345: Argument of type * is not assignable to parameter of type *.
@@ -2706,12 +2223,12 @@ plugins/services/src/js/components/modals/CreateServiceModalForm.tsx: error TS23
 plugins/services/src/js/components/modals/CreateServiceModalForm.tsx: error TS2339: Property 'showAllErrors' does not exist on type *.
 plugins/services/src/js/components/modals/CreateServiceModalForm.tsx: error TS2339: Property 'handleTabChange' does not exist on type *.
 plugins/services/src/js/components/modals/CreateServiceModalForm.tsx: error TS2339: Property 'isPod' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/CreateServiceModalForm.tsx: error TS2322: type * is not assignable to type *.
-plugins/services/src/js/components/modals/CreateServiceModalForm.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/components/modals/CreateServiceModalForm.tsx: error TS2769: No overload matches this call.
+plugins/services/src/js/components/modals/CreateServiceModalForm.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/components/modals/CreateServiceModalForm.tsx: error TS2339: Property 'handleTabChange' does not exist on type *.
 plugins/services/src/js/components/modals/CreateServiceModalForm.tsx: error TS2339: Property 'handleTabChange' does not exist on type *.
 plugins/services/src/js/components/modals/CreateServiceModalForm.tsx: error TS2339: Property 'handleTabChange' does not exist on type *.
-plugins/services/src/js/components/modals/CreateServiceModalForm.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/components/modals/CreateServiceModalForm.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/components/modals/CreateServiceModalForm.tsx: error TS2339: Property 'showAllErrors' does not exist on type *.
 plugins/services/src/js/components/modals/CreateServiceModalForm.tsx: error TS2339: Property 'editedFieldPaths' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/modals/CreateServiceModalForm.tsx: error TS2339: Property 'editingFieldPath' does not exist on type 'Readonly<{}>'.
@@ -2735,10 +2252,9 @@ plugins/services/src/js/components/modals/CreateServiceModalForm.tsx: error TS23
 plugins/services/src/js/components/modals/CreateServiceModalForm.tsx: error TS2339: Property 'editorWidth' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/modals/CreateServiceModalServicePicker.tsx: error TS2307: Cannot find module '../../../img/icon-service-default-large@2x.png' or its corresponding type declarations.
 plugins/services/src/js/components/modals/CreateServiceModalServicePicker.tsx: error TS2307: Cannot find module '../../../img/service-image-json-large@2x.png' or its corresponding type declarations.
-plugins/services/src/js/components/modals/CreateServiceModalServicePicker.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/components/modals/CreateServiceModalServicePicker.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/components/modals/CreateServiceModalServicePicker.tsx: error TS2339: Property 'onServiceSelect' does not exist on type *.
 plugins/services/src/js/components/modals/DisabledGroupDestroyModal.tsx: error TS2322: type * is not assignable to type *.
-plugins/services/src/js/components/modals/KillPodInstanceModal.tsx: error TS2741: Property 'service' is missing in type '{}' but required in type *.
 plugins/services/src/js/components/modals/KillPodInstanceModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
 plugins/services/src/js/components/modals/KillPodInstanceModal.tsx: error TS2339: Property 'selectedItems' does not exist on type *.
 plugins/services/src/js/components/modals/KillPodInstanceModal.tsx: error TS2339: Property 'action' does not exist on type *.
@@ -2751,12 +2267,10 @@ plugins/services/src/js/components/modals/KillPodInstanceModal.tsx: error TS2339
 plugins/services/src/js/components/modals/KillPodInstanceModal.tsx: error TS2339: Property 'selectedItems' does not exist on type *.
 plugins/services/src/js/components/modals/KillPodInstanceModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
 plugins/services/src/js/components/modals/KillPodInstanceModal.tsx: error TS2322: type * is not assignable to type *.
-plugins/services/src/js/components/modals/KillPodInstanceModal.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/services/src/js/components/modals/KillPodInstanceModal.tsx: error TS2339: Property 'isPending' does not exist on type *.
 plugins/services/src/js/components/modals/KillPodInstanceModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
-plugins/services/src/js/components/modals/KillPodInstanceModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/KillPodInstanceModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/KillPodInstanceModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
+plugins/services/src/js/components/modals/KillPodInstanceModal.tsx: error TS2345: Argument of type 'null' is not assignable to parameter of type 'string'.
+plugins/services/src/js/components/modals/KillPodInstanceModal.tsx: error TS2741: Property 'service' is missing in type '{}' but required in type *.
 plugins/services/src/js/components/modals/KillTaskModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
 plugins/services/src/js/components/modals/KillTaskModal.tsx: error TS2339: Property 'selectedItems' does not exist on type *.
 plugins/services/src/js/components/modals/KillTaskModal.tsx: error TS2339: Property 'action' does not exist on type *.
@@ -2768,15 +2282,12 @@ plugins/services/src/js/components/modals/KillTaskModal.tsx: error TS2339: Prope
 plugins/services/src/js/components/modals/KillTaskModal.tsx: error TS2339: Property 'selectedItems' does not exist on type *.
 plugins/services/src/js/components/modals/KillTaskModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
 plugins/services/src/js/components/modals/KillTaskModal.tsx: error TS2322: type * is not assignable to type *.
-plugins/services/src/js/components/modals/KillTaskModal.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/services/src/js/components/modals/KillTaskModal.tsx: error TS2339: Property 'isPending' does not exist on type *.
 plugins/services/src/js/components/modals/KillTaskModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
-plugins/services/src/js/components/modals/KillTaskModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/KillTaskModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/KillTaskModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
+plugins/services/src/js/components/modals/KillTaskModal.tsx: error TS2345: Argument of type 'null' is not assignable to parameter of type 'string'.
 plugins/services/src/js/components/modals/KillTaskModal.tsx: error TS2741: Property 'service' is missing in type '{}' but required in type *.
 plugins/services/src/js/components/modals/ServiceActionDisabledModal.tsx: error TS2339: Property 'service' does not exist on type *.
-plugins/services/src/js/components/modals/ServiceActionDisabledModal.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/components/modals/ServiceActionDisabledModal.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/components/modals/ServiceActionDisabledModal.tsx: error TS2339: Property 'actionID' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceActionDisabledModal.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceActionDisabledModal.tsx: error TS2339: Property 'actionID' does not exist on type *.
@@ -2790,25 +2301,18 @@ plugins/services/src/js/components/modals/ServiceActionDisabledModal.tsx: error 
 plugins/services/src/js/components/modals/ServiceActionDisabledModal.tsx: error TS2339: Property 'open' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceActionDisabledModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceActionDisabledModal.tsx: error TS2339: Property 'service' does not exist on type *.
-plugins/services/src/js/components/modals/ServiceActionDisabledModal.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/services/src/js/components/modals/ServiceActionDisabledModal.tsx: error TS2339: Property 'open' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceActionDisabledModal.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceActionDisabledModal.tsx: error TS2339: Property 'service' does not exist on type *.
-plugins/services/src/js/components/modals/ServiceDestroyModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/ServiceDestroyModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/ServiceDestroyModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/ServiceDestroyModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
+plugins/services/src/js/components/modals/ServiceDestroyModal.tsx: error TS2345: Argument of type 'null' is not assignable to parameter of type 'string'.
 plugins/services/src/js/components/modals/ServiceDestroyModal.tsx: error TS2571: Object is of type 'unknown'.
 plugins/services/src/js/components/modals/ServiceDestroyModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceDestroyModal.tsx: error TS2339: Property 'deleteItem' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceDestroyModal.tsx: error TS2339: Property 'service' does not exist on type *.
-plugins/services/src/js/components/modals/ServiceDestroyModal.tsx: error TS2339: Property 'serviceNameConfirmationValue' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/ServiceDestroyModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/modals/ServiceDestroyModal.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceDestroyModal.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceDestroyModal.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceDestroyModal.tsx: error TS2339: Property 'service' does not exist on type *.
-plugins/services/src/js/components/modals/ServiceDestroyModal.tsx: error TS2339: Property 'serviceNameConfirmationValue' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/modals/ServiceDestroyModal.tsx: error TS2339: Property 'open' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceDestroyModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceDestroyModal.tsx: error TS2339: Property 'isPending' does not exist on type *.
@@ -2816,10 +2320,8 @@ plugins/services/src/js/components/modals/ServiceDestroyModal.tsx: error TS2322:
 plugins/services/src/js/components/modals/ServiceDestroyModal.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceDestroyModal.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
 plugins/services/src/js/components/modals/ServiceDestroyModal.tsx: error TS2571: Object is of type 'unknown'.
-plugins/services/src/js/components/modals/ServiceDestroyModal.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/services/src/js/components/modals/ServiceDestroyModal.tsx: error TS2339: Property 'isPending' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceDestroyModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/services/src/js/components/modals/ServiceGroupFormModal.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/services/src/js/components/modals/ServiceGroupFormModal.tsx: error TS2339: Property 'isPending' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceGroupFormModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceGroupFormModal.tsx: error TS2339: Property 'parentGroupId' does not exist on type *.
@@ -2883,37 +2385,27 @@ plugins/services/src/js/components/modals/ServiceRestartModal.tsx: error TS2339:
 plugins/services/src/js/components/modals/ServiceRestartModal.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceRestartModal.tsx: error TS2339: Property 'restartService' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceRestartModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/services/src/js/components/modals/ServiceRestartModal.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/services/src/js/components/modals/ServiceRestartModal.tsx: error TS2339: Property 'isPending' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceRestartModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
-plugins/services/src/js/components/modals/ServiceRestartModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/ServiceRestartModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/ServiceRestartModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
+plugins/services/src/js/components/modals/ServiceRestartModal.tsx: error TS2345: Argument of type 'null' is not assignable to parameter of type 'string'.
 plugins/services/src/js/components/modals/ServiceRestartModal.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceRestartModal.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceResumeModal.tsx: error TS2339: Property 'service' does not exist on type *.
-plugins/services/src/js/components/modals/ServiceResumeModal.tsx: error TS2339: Property 'service' does not exist on type *.
-plugins/services/src/js/components/modals/ServiceResumeModal.tsx: error TS2339: Property 'instancesFieldValue' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/ServiceResumeModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/ServiceResumeModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
+plugins/services/src/js/components/modals/ServiceResumeModal.tsx: error TS2345: Argument of type 'null' is not assignable to parameter of type 'string'.
 plugins/services/src/js/components/modals/ServiceResumeModal.tsx: error TS2339: Property 'isPending' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceResumeModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceResumeModal.tsx: error TS2339: Property 'open' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceResumeModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/services/src/js/components/modals/ServiceResumeModal.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/services/src/js/components/modals/ServiceResumeModal.tsx: error TS2339: Property 'isPending' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceResumeModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceResumeModal.tsx: error TS2339: Property 'open' does not exist on type *.
-plugins/services/src/js/components/modals/ServiceResumeModal.tsx: error TS2339: Property 'instancesFieldValue' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/ServiceResumeModal.tsx: error TS2339: Property 'instancesFieldValue' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/components/modals/ServiceResumeModal.tsx: error TS2339: Property 'resumeService' does not exist on type *.
-plugins/services/src/js/components/modals/ServiceResumeModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/ServiceRootGroupModal/index.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
+plugins/services/src/js/components/modals/ServiceResumeModal.tsx: error TS2339: Property 'service' does not exist on type *.
+plugins/services/src/js/components/modals/ServiceRootGroupModal/index.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/components/modals/ServiceRootGroupModal/index.tsx: error TS2322: Type 'true' is not assignable to type *.
 plugins/services/src/js/components/modals/ServiceRootGroupModal/index.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/components/modals/ServiceRootGroupModal/index.tsx: error TS2322: Type 'false' is not assignable to type *.
 plugins/services/src/js/components/modals/ServiceRootGroupModal/index.tsx: error TS2322: type * is not assignable to type *.
-plugins/services/src/js/components/modals/ServiceScaleFormModal.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceScaleFormModal.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceScaleFormModal.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceScaleFormModal.tsx: error TS2339: Property 'service' does not exist on type *.
@@ -2922,12 +2414,10 @@ plugins/services/src/js/components/modals/ServiceScaleFormModal.tsx: error TS233
 plugins/services/src/js/components/modals/ServiceScaleFormModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceScaleFormModal.tsx: error TS2339: Property 'open' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceScaleFormModal.tsx: error TS2339: Property 'scaleItem' does not exist on type *.
-plugins/services/src/js/components/modals/ServiceScaleFormModal.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/services/src/js/components/modals/ServiceScaleFormModal.tsx: error TS2339: Property 'isPending' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceScaleFormModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
-plugins/services/src/js/components/modals/ServiceScaleFormModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/ServiceScaleFormModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/ServiceScaleFormModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
+plugins/services/src/js/components/modals/ServiceScaleFormModal.tsx: error TS2345: Argument of type 'null' is not assignable to parameter of type 'string'.
+plugins/services/src/js/components/modals/ServiceScaleFormModal.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceScaleFormModal.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceStopModal.tsx: error TS2339: Property 'isPending' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceStopModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
@@ -2935,12 +2425,9 @@ plugins/services/src/js/components/modals/ServiceStopModal.tsx: error TS2339: Pr
 plugins/services/src/js/components/modals/ServiceStopModal.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceStopModal.tsx: error TS2339: Property 'stopItem' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceStopModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/services/src/js/components/modals/ServiceStopModal.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/services/src/js/components/modals/ServiceStopModal.tsx: error TS2339: Property 'isPending' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceStopModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
-plugins/services/src/js/components/modals/ServiceStopModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/ServiceStopModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/components/modals/ServiceStopModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
+plugins/services/src/js/components/modals/ServiceStopModal.tsx: error TS2345: Argument of type 'null' is not assignable to parameter of type 'string'.
 plugins/services/src/js/components/modals/ServiceStopModal.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceStopModal.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/components/modals/ServiceStopModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
@@ -2961,21 +2448,20 @@ plugins/services/src/js/components/modals/__tests__/EditServiceModal-test.tsx: e
 plugins/services/src/js/components/modals/__tests__/EditServiceModal-test.tsx: error TS2540: Cannot assign to 'serviceDataReceived' because it is a read-only property.
 plugins/services/src/js/components/modals/__tests__/EditServiceModal-test.tsx: error TS2540: Cannot assign to 'serviceDataReceived' because it is a read-only property.
 plugins/services/src/js/components/modals/__tests__/EditServiceModal-test.tsx: error TS2540: Cannot assign to 'serviceDataReceived' because it is a read-only property.
+plugins/services/src/js/containers/framework-configuration/FrameworkConfigurationContainer.tsx: error TS2531: Object is possibly 'null'.
+plugins/services/src/js/containers/framework-configuration/FrameworkConfigurationContainer.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/containers/framework-configuration/FrameworkConfigurationContainer.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
 plugins/services/src/js/containers/framework-configuration/FrameworkConfigurationContainer.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/containers/framework-configuration/FrameworkConfigurationContainer.tsx: error TS2531: Object is possibly 'null'.
 plugins/services/src/js/containers/framework-configuration/FrameworkConfigurationContainer.tsx: error TS2531: Object is possibly 'null'.
 plugins/services/src/js/containers/framework-configuration/FrameworkConfigurationContainer.tsx: error TS2339: Property 'service' does not exist on type *.
-plugins/services/src/js/containers/framework-configuration/FrameworkConfigurationContainer.tsx: error TS2339: Property 'frameworkData' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/framework-configuration/FrameworkConfigurationContainer.tsx: error TS2339: Property 'packageDetails' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/framework-configuration/FrameworkConfigurationContainer.tsx: error TS2339: Property 'cosmosError' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/pod-debug/PodContainerTerminationTable.tsx: error TS2339: Property 'containers' does not exist on type *.
-plugins/services/src/js/containers/pod-debug/PodContainerTerminationTable.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
+plugins/services/src/js/containers/framework-configuration/FrameworkConfigurationContainer.tsx: error TS2531: Object is possibly 'null'.
 plugins/services/src/js/containers/pod-debug/PodContainerTerminationTable.tsx: error TS6133: 'prop' is declared but its value is never read.
 plugins/services/src/js/containers/pod-debug/PodContainerTerminationTable.tsx: error TS6133: 'prop' is declared but its value is never read.
 plugins/services/src/js/containers/pod-debug/PodContainerTerminationTable.tsx: error TS6133: 'prop' is declared but its value is never read.
 plugins/services/src/js/containers/pod-debug/PodContainerTerminationTable.tsx: error TS6133: 'prop' is declared but its value is never read.
 plugins/services/src/js/containers/pod-debug/PodContainerTerminationTable.tsx: error TS2339: Property 'className' does not exist on type *.
+plugins/services/src/js/containers/pod-debug/PodContainerTerminationTable.tsx: error TS2339: Property 'containers' does not exist on type *.
 plugins/services/src/js/containers/pod-debug/PodDebugContainer.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/services/src/js/containers/pod-debug/PodDebugContainer.tsx: error TS2322: Type 'string' is not assignable to type 'null'.
 plugins/services/src/js/containers/pod-debug/PodDebugContainer.tsx: error TS2339: Property 'offerSummaryRef' does not exist on type 'PodDebugTabView'.
@@ -3002,8 +2488,6 @@ plugins/services/src/js/containers/pod-detail/PodDetail.tsx: error TS2322: type 
 plugins/services/src/js/containers/pod-detail/PodDetail.tsx: error TS2322: Type 'string' is not assignable to type 'never'.
 plugins/services/src/js/containers/pod-detail/PodDetail.tsx: error TS2322: Type 'string' is not assignable to type 'never'.
 plugins/services/src/js/containers/pod-detail/PodDetail.tsx: error TS2322: type * is not assignable to type 'never'.
-plugins/services/src/js/containers/pod-detail/PodDetail.tsx: error TS2339: Property 'actionDisabledModalOpen' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/pod-detail/PodDetail.tsx: error TS2339: Property 'actionDisabledID' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/containers/pod-detail/PodDetail.tsx: error TS2533: Object is possibly 'null' or 'undefined'.
 plugins/services/src/js/containers/pod-detail/PodDetail.tsx: error TS2339: Property 'type' does not exist on type *.
 plugins/services/src/js/containers/pod-detail/PodDetail.tsx: error TS2769: No overload matches this call.
@@ -3018,7 +2502,6 @@ plugins/services/src/js/containers/pod-detail/PodHeader.tsx: error TS2339: Prope
 plugins/services/src/js/containers/pod-detail/PodHeader.tsx: error TS2339: Property 'pod' does not exist on type *.
 plugins/services/src/js/containers/pod-detail/PodHeader.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/services/src/js/containers/pod-detail/PodHeader.tsx: error TS2339: Property 'tabs' does not exist on type *.
-plugins/services/src/js/containers/pod-detail/PodHeader.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/services/src/js/containers/pod-detail/PodHeader.tsx: error TS2339: Property 'pod' does not exist on type *.
 plugins/services/src/js/containers/pod-detail/PodHeader.tsx: error TS2339: Property 'onScale' does not exist on type *.
 plugins/services/src/js/containers/pod-detail/PodHeader.tsx: error TS2339: Property 'onEdit' does not exist on type *.
@@ -3045,19 +2528,15 @@ plugins/services/src/js/containers/pod-instances/PodInstancesContainer.tsx: erro
 plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS2322: Type '\\"top-right\\"' is not assignable to type 'Direction'.
 plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS2322: Type '\\"top-right\\"' is not assignable to type 'Direction'.
 plugins/services/src/js/containers/pod-instances/PodInstancesTable.tsx: error TS2322: type * is not assignable to type *.
-plugins/services/src/js/containers/pod-instances/PodInstancesView.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/containers/pod-instances/PodInstancesView.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/containers/pod-instances/PodInstancesView.tsx: error TS2339: Property 'instances' does not exist on type *.
 plugins/services/src/js/containers/pod-instances/PodInstancesView.tsx: error TS2339: Property 'totalInstances' does not exist on type *.
 plugins/services/src/js/containers/pod-instances/PodInstancesView.tsx: error TS2339: Property 'handleExpressionChange' does not exist on type *.
 plugins/services/src/js/containers/pod-instances/PodInstancesView.tsx: error TS2339: Property 'filterExpression' does not exist on type *.
 plugins/services/src/js/containers/pod-instances/PodInstancesView.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/services/src/js/containers/pod-instances/PodInstancesView.tsx: error TS2339: Property 'selectedItems' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/containers/pod-instances/PodInstancesView.tsx: error TS2339: Property 'filterParams' does not exist on type 'never'.
 plugins/services/src/js/containers/pod-instances/PodInstancesView.tsx: error TS2339: Property 'pod' does not exist on type *.
 plugins/services/src/js/containers/pod-instances/PodInstancesView.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
-plugins/services/src/js/containers/pod-instances/PodInstancesView.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/services/src/js/containers/pod-instances/PodInstancesView.tsx: error TS2339: Property 'selectedItems' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/pod-instances/PodInstancesView.tsx: error TS2339: Property 'selectedItems' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/containers/pod-instances/PodInstancesView.tsx: error TS2339: Property 'filters' does not exist on type *.
 plugins/services/src/js/containers/pod-instances/PodInstancesView.tsx: error TS2339: Property 'filterExpression' does not exist on type *.
 plugins/services/src/js/containers/pod-instances/PodInstancesView.tsx: error TS2339: Property 'handleExpressionChange' does not exist on type *.
@@ -3071,7 +2550,6 @@ plugins/services/src/js/containers/pod-instances/__tests__/PodInstancesTable-tes
 plugins/services/src/js/containers/pod-instances/__tests__/PodInstancesTable-test.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/containers/pod-instances/__tests__/PodInstancesTable-test.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/containers/service-configuration/ServiceConfiguration.tsx: error TS2339: Property 'service' does not exist on type *.
-plugins/services/src/js/containers/service-configuration/ServiceConfiguration.tsx: error TS2339: Property 'selectedVersionID' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/containers/service-configuration/ServiceConfiguration.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 plugins/services/src/js/containers/service-configuration/ServiceConfiguration.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/containers/service-configuration/ServiceConfiguration.tsx: error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
@@ -3080,21 +2558,14 @@ plugins/services/src/js/containers/service-configuration/ServiceConfiguration.ts
 plugins/services/src/js/containers/service-configuration/ServiceConfiguration.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/containers/service-configuration/ServiceConfiguration.tsx: error TS2322: Type 'unknown' is not assignable to type *.
 plugins/services/src/js/containers/service-configuration/ServiceConfiguration.tsx: error TS2322: Type 'unknown' is not assignable to type 'Date'.
-plugins/services/src/js/containers/service-configuration/ServiceConfiguration.tsx: error TS2339: Property 'selectedVersionID' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/containers/service-configuration/ServiceConfiguration.tsx: error TS2339: Property 'errors' does not exist on type *.
 plugins/services/src/js/containers/service-configuration/ServiceConfiguration.tsx: error TS2339: Property 'service' does not exist on type *.
-plugins/services/src/js/containers/service-configuration/ServiceConfiguration.tsx: error TS2339: Property 'selectedVersionID' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/containers/service-configuration/ServiceConfiguration.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
-plugins/services/src/js/containers/service-configuration/ServiceConfiguration.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/services/src/js/containers/service-configuration/ServiceConfiguration.tsx: error TS2339: Property 'store_listeners' does not exist on type 'ServiceConfiguration'.
 plugins/services/src/js/containers/service-configuration/ServiceConfiguration.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/containers/service-configuration/ServiceConfiguration.tsx: error TS2339: Property 'service' does not exist on type *.
-plugins/services/src/js/containers/service-configuration/ServiceConfiguration.tsx: error TS2339: Property 'selectedVersionID' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/containers/service-configuration/ServiceConfiguration.tsx: error TS2339: Property 'onEditClick' does not exist on type *.
 plugins/services/src/js/containers/service-configuration/ServiceConfiguration.tsx: error TS2339: Property 'service' does not exist on type *.
-plugins/services/src/js/containers/service-configuration/ServiceConfiguration.tsx: error TS2339: Property 'selectedVersionID' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/containers/service-configuration/ServiceConfiguration.tsx: error TS2339: Property 'service' does not exist on type *.
-plugins/services/src/js/containers/service-configuration/ServiceConfiguration.tsx: error TS2339: Property 'selectedVersionID' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/containers/service-configuration/ServiceConfiguration.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/containers/service-configuration/ServiceConfigurationContainer.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/containers/service-configuration/ServiceConfigurationContainer.tsx: error TS2339: Property 'service' does not exist on type *.
@@ -3107,21 +2578,17 @@ plugins/services/src/js/containers/service-connection/SDKServiceConnectionEndpoi
 plugins/services/src/js/containers/service-connection/SDKServiceConnectionEndpointList.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/containers/service-connection/SDKServiceConnectionEndpointList.tsx: error TS2339: Property 'endpointData' does not exist on type 'ServiceEndpoint'.
 plugins/services/src/js/containers/service-connection/SDKServiceConnectionEndpointList.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
-plugins/services/src/js/containers/service-connection/SDKServiceConnectionEndpointList.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/services/src/js/containers/service-connection/SDKServiceConnectionEndpointList.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/containers/service-connection/SDKServiceConnectionEndpointList.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/containers/service-connection/SDKServiceConnectionEndpointList.tsx: error TS2339: Property 'service' does not exist on type *.
-plugins/services/src/js/containers/service-connection/SDKServiceConnectionEndpointList.tsx: error TS2339: Property 'servicePreviousState' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/containers/service-connection/ServiceConnectionEndpointList.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/containers/service-connection/ServiceConnectionEndpointList.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
-plugins/services/src/js/containers/service-connection/ServiceConnectionEndpointList.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/services/src/js/containers/service-connection/ServiceConnectionEndpointList.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/containers/service-connection/ServicePodConnectionEndpointList.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/containers/service-connection/ServicePodConnectionEndpointList.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
-plugins/services/src/js/containers/service-connection/ServicePodConnectionEndpointList.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/services/src/js/containers/service-connection/ServicePodConnectionEndpointList.tsx: error TS2339: Property 'service' does not exist on type *.
-plugins/services/src/js/containers/service-connection/__tests__/SDKServiceConnectionEndpointList-test.tsx: error TS2322: Type 'Framework' is not assignable to type 'Service'.
-plugins/services/src/js/containers/service-connection/__tests__/ServiceConnectionEndpointList-test.tsx: error TS2322: Type 'Application' is not assignable to type 'Service'.
+plugins/services/src/js/containers/service-connection/__tests__/SDKServiceConnectionEndpointList-test.tsx: error TS2769: No overload matches this call.
+plugins/services/src/js/containers/service-connection/__tests__/ServiceConnectionEndpointList-test.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/containers/service-debug/ServiceDebugContainer.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/containers/service-debug/ServiceDebugContainer.tsx: error TS2322: Type 'Element' is not assignable to type 'string'.
 plugins/services/src/js/containers/service-debug/ServiceDebugContainer.tsx: error TS2339: Property 'service' does not exist on type *.
@@ -3133,15 +2600,14 @@ plugins/services/src/js/containers/service-debug/ServiceDebugContainer.tsx: erro
 plugins/services/src/js/containers/service-debug/ServiceDebugContainer.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/containers/service-debug/ServiceDebugContainer.tsx: error TS2531: Object is possibly 'null'.
 plugins/services/src/js/containers/service-debug/ServiceDebugContainer.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
-plugins/services/src/js/containers/service-debug/ServiceDebugContainer.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/services/src/js/containers/service-debug/ServiceDebugContainer.tsx: error TS2322: Type 'null' is not assignable to type *.
 plugins/services/src/js/containers/service-debug/ServiceDebugContainer.tsx: error TS2339: Property 'offerSummaryRef' does not exist on type 'ServiceDebugContainer'.
 plugins/services/src/js/containers/service-debug/ServiceDebugContainer.tsx: error TS2339: Property 'offerSummaryRef' does not exist on type 'ServiceDebugContainer'.
 plugins/services/src/js/containers/service-debug/ServiceDebugContainer.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/containers/service-debug/ServiceDebugContainer.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/containers/service-debug/ServiceDebugContainer.tsx: error TS2339: Property 'service' does not exist on type *.
-plugins/services/src/js/containers/service-debug/ServiceDebugContainer.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
 plugins/services/src/js/containers/service-debug/ServiceDebugContainer.tsx: error TS2339: Property 'service' does not exist on type *.
+plugins/services/src/js/containers/service-debug/ServiceDebugContainer.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
 plugins/services/src/js/containers/service-debug/ServiceDebugContainer.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/containers/service-debug/ServiceDebugContainer.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/containers/service-debug/TaskStatsTable.tsx: error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
@@ -3162,18 +2628,12 @@ plugins/services/src/js/containers/service-detail/ServiceDetail.tsx: error TS276
 plugins/services/src/js/containers/service-detail/ServiceDetail.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/containers/service-detail/ServiceDetail.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
 plugins/services/src/js/containers/service-detail/ServiceDetail.tsx: error TS2339: Property 'clearError' does not exist on type *.
-plugins/services/src/js/containers/service-instances/ServiceInstancesContainer.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/services/src/js/containers/service-instances/ServiceInstancesContainer.tsx: error TS2339: Property 'store_listeners' does not exist on type 'ServiceInstancesContainer'.
-plugins/services/src/js/containers/service-instances/ServiceInstancesContainer.tsx: error TS2339: Property 'lastUpdate' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/service-instances/ServiceInstancesContainer.tsx: error TS2339: Property 'mesosStateErrorCount' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/service-instances/ServiceInstancesContainer.tsx: error TS2339: Property 'mesosStateErrorCount' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/containers/service-instances/ServiceInstancesContainer.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/containers/service-instances/ServiceInstancesContainer.tsx: error TS2345: Argument of type '\\"lastMesosState\\"' is not assignable to parameter of type 'never'.
-plugins/services/src/js/containers/service-instances/ServiceInstancesContainer.tsx: error TS2339: Property 'mesosStateErrorCount' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/containers/service-instances/ServiceInstancesContainer.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/containers/service-instances/ServiceInstancesContainer.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/services/src/js/containers/service-instances/ServiceInstancesContainer.tsx: error TS2339: Property 'location' does not exist on type *.
-plugins/services/src/js/containers/service-instances/ServiceInstancesContainer.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/containers/service-instances/ServiceInstancesContainer.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/containers/services/ServiceTreeView.tsx: error TS2339: Property 'serviceTree' does not exist on type *.
 plugins/services/src/js/containers/services/ServiceTreeView.tsx: error TS2339: Property 'serviceTree' does not exist on type *.
 plugins/services/src/js/containers/services/ServiceTreeView.tsx: error TS2339: Property 'filterExpression' does not exist on type *.
@@ -3191,14 +2651,11 @@ plugins/services/src/js/containers/services/ServiceTreeView.tsx: error TS2339: P
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2571: Object is of type 'unknown'.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2571: Object is of type 'unknown'.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2571: Object is of type 'unknown'.
-plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'isLoading' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'dispatcher' does not exist on type 'ServicesContainer'.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'rolesSub' does not exist on type 'ServicesContainer'.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'dispatcher' does not exist on type 'ServicesContainer'.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'rolesSub' does not exist on type 'ServicesContainer'.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'rolesSub' does not exist on type 'ServicesContainer'.
-plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'lastUpdate' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'isLoading' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2556: Expected 1 arguments, but got 0 or more.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2556: Expected 1 arguments, but got 0 or more.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2556: Expected 2 arguments, but got 0 or more.
@@ -3207,31 +2664,22 @@ plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2556:
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2556: Expected 3 arguments, but got 0 or more.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2556: Expected 1 arguments, but got 0 or more.
-plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'fetchErrors' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2571: Object is of type 'unknown'.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2571: Object is of type 'unknown'.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'location' does not exist on type *.
-plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'actionErrors' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'pendingActions' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'actionErrors' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'pendingActions' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'actionErrors' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2554: Expected 2 arguments, but got 1.
-plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'actionErrors' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'pendingActions' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'modal' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'itemId' does not exist on type 'Readonly<{}>'.
+plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'modal' does not exist on type *.
+plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'itemId' does not exist on type *.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'routes' does not exist on type *.
-plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'routes' does not exist on type *.
-plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'actionErrors' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'routes' does not exist on type *.
-plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'filterExpression' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'roles' does not exist on type 'Readonly<{}>'.
+plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'defined' does not exist on type 'DSLExpression'.
+plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'filter' does not exist on type 'DSLExpression'.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'routes' does not exist on type *.
@@ -3240,36 +2688,30 @@ plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2554:
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2554: Expected 2 arguments, but got 1.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'routes' does not exist on type *.
-plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'fetchErrors' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'isLoading' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'itemId' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'itemId' does not exist on type 'Readonly<{}>'.
+plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'itemId' does not exist on type *.
+plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'itemId' does not exist on type *.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2571: Object is of type 'unknown'.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'childContextTypes' does not exist on type *.
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
 plugins/services/src/js/containers/services/ServicesContainer.tsx: error TS2339: Property 'routeConfig' does not exist on type *.
+plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2339: Property 'masterRegionName' does not exist on type *.
 plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2339: Property 'actionsRenderer' does not exist on type 'ServicesTable'.
-plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2339: Property 'regionRenderer' does not exist on type 'ServicesTable'.
-plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2339: Property 'regionRenderer' does not exist on type 'ServicesTable'.
 plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2554: Expected 5 arguments, but got 3.
-plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2339: Property 'sortColumn' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2339: Property 'sortDirection' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2339: Property 'sortDirection' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2339: Property 'sortColumn' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2339: Property 'data' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2339: Property 'sortDirection' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2339: Property 'sortColumn' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2339: Property 'actionDisabledService' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2339: Property 'actionDisabledID' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2339: Property 'data' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2339: Property 'sortColumn' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2339: Property 'sortDirection' does not exist on type 'Readonly<{}>'.
+plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2339: Property 'actionDisabledID' does not exist on type *.
 plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2339: Property 'isFiltered' does not exist on type *.
 plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2339: Property 'hideTable' does not exist on type *.
 plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2339: Property 'isFiltered' does not exist on type *.
+plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2684: The 'this' context of type * is not assignable to method's 'this' of type *.
 plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2339: Property 'isFiltered' does not exist on type *.
-plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2339: Property 'regionRenderer' does not exist on type 'ServicesTable'.
+plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2339: Property 'actionsRenderer' does not exist on type 'ServicesTable'.
 plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2322: type * is not assignable to type *.
@@ -3306,75 +2748,49 @@ plugins/services/src/js/containers/tasks/TaskTable.tsx: error TS2339: Property '
 plugins/services/src/js/containers/tasks/TaskTable.tsx: error TS2339: Property 'className' does not exist on type *.
 plugins/services/src/js/containers/tasks/TaskTable.tsx: error TS2339: Property 'onCheckboxChange' does not exist on type *.
 plugins/services/src/js/containers/tasks/TaskTable.tsx: error TS2339: Property 'tasks' does not exist on type *.
-plugins/services/src/js/containers/tasks/TaskTable.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/containers/tasks/TaskTable.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/containers/tasks/TaskTable.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
 plugins/services/src/js/containers/tasks/TaskTable.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/services/src/js/containers/tasks/TasksContainer.tsx: error TS2339: Property 'defaultFilterData' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/tasks/TasksContainer.tsx: error TS2339: Property 'defaultFilterData' does not exist on type 'Readonly<{}>'.
+plugins/services/src/js/containers/tasks/TasksContainer.tsx: error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'never'.
+plugins/services/src/js/containers/tasks/TasksContainer.tsx: error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'never'.
 plugins/services/src/js/containers/tasks/TasksContainer.tsx: error TS2345: Argument of type 'unknown[]' is not assignable to parameter of type 'never[]'.
 plugins/services/src/js/containers/tasks/TasksContainer.tsx: error TS2345: Argument of type 'unknown[]' is not assignable to parameter of type 'never[]'.
-plugins/services/src/js/containers/tasks/TasksContainer.tsx: error TS2339: Property 'actionErrors' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/tasks/TasksContainer.tsx: error TS2339: Property 'pendingActions' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/tasks/TasksContainer.tsx: error TS2339: Property 'actionErrors' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/tasks/TasksContainer.tsx: error TS2339: Property 'pendingActions' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/tasks/TasksContainer.tsx: error TS2339: Property 'actionErrors' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/tasks/TasksContainer.tsx: error TS2339: Property 'modal' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/tasks/TasksContainer.tsx: error TS2339: Property 'actionErrors' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/tasks/TasksContainer.tsx: error TS2339: Property 'pendingActions' does not exist on type 'Readonly<{}>'.
+plugins/services/src/js/containers/tasks/TasksContainer.tsx: error TS2339: Property 'modal' does not exist on type *.
 plugins/services/src/js/containers/tasks/TasksContainer.tsx: error TS2339: Property 'tasks' does not exist on type *.
 plugins/services/src/js/containers/tasks/TasksContainer.tsx: error TS2339: Property 'params' does not exist on type *.
-plugins/services/src/js/containers/tasks/TasksContainer.tsx: error TS2339: Property 'filterExpression' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/tasks/TasksContainer.tsx: error TS2339: Property 'filters' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/tasks/TasksContainer.tsx: error TS2339: Property 'defaultFilterData' does not exist on type 'Readonly<{}>'.
+plugins/services/src/js/containers/tasks/TasksContainer.tsx: error TS2339: Property 'defined' does not exist on type 'DSLExpression'.
+plugins/services/src/js/containers/tasks/TasksContainer.tsx: error TS2339: Property 'filter' does not exist on type 'DSLExpression'.
 plugins/services/src/js/containers/tasks/TasksContainer.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/containers/tasks/TasksContainer.tsx: error TS2339: Property 'childContextTypes' does not exist on type *.
 plugins/services/src/js/containers/tasks/TasksContainer.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
-plugins/services/src/js/containers/tasks/TasksContainer.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/services/src/js/containers/tasks/TasksContainer.tsx: error TS2339: Property 'dispatcher' does not exist on type 'TasksContainer'.
 plugins/services/src/js/containers/tasks/TasksContainer.tsx: error TS2339: Property 'dispatcher' does not exist on type 'TasksContainer'.
 plugins/services/src/js/containers/tasks/TasksContainer.tsx: error TS2556: Expected 3 arguments, but got 0 or more.
 plugins/services/src/js/containers/tasks/TasksContainer.tsx: error TS2339: Property 'location' does not exist on type *.
-plugins/services/src/js/containers/tasks/TasksView.tsx: error TS2339: Property 'i18n' does not exist on type *.
 plugins/services/src/js/containers/tasks/TasksView.tsx: error TS2339: Property 'tasks' does not exist on type *.
-plugins/services/src/js/containers/tasks/TasksView.tsx: error TS2339: Property 'checkedItems' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/containers/tasks/TasksView.tsx: error TS2339: Property 'filters' does not exist on type *.
 plugins/services/src/js/containers/tasks/TasksView.tsx: error TS2339: Property 'filterExpression' does not exist on type *.
 plugins/services/src/js/containers/tasks/TasksView.tsx: error TS2339: Property 'handleExpressionChange' does not exist on type *.
 plugins/services/src/js/containers/tasks/TasksView.tsx: error TS2339: Property 'defaultFilterData' does not exist on type *.
-plugins/services/src/js/containers/tasks/TasksView.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/containers/tasks/TasksView.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/containers/tasks/TasksView.tsx: error TS2339: Property 'tasks' does not exist on type *.
 plugins/services/src/js/containers/tasks/TasksView.tsx: error TS2339: Property 'totalTasks' does not exist on type *.
 plugins/services/src/js/containers/tasks/TasksView.tsx: error TS2339: Property 'handleExpressionChange' does not exist on type *.
 plugins/services/src/js/containers/tasks/TasksView.tsx: error TS2339: Property 'i18n' does not exist on type *.
-plugins/services/src/js/containers/tasks/TasksView.tsx: error TS2339: Property 'checkedItems' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/containers/tasks/TasksView.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
 plugins/services/src/js/containers/tasks/TasksView.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
-plugins/services/src/js/containers/tasks/TasksView.tsx: error TS2554: Expected 1-2 arguments, but got 0.
-plugins/services/src/js/containers/tasks/TasksView.tsx: error TS2339: Property 'checkedItems' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/tasks/TasksView.tsx: error TS2339: Property 'checkedItems' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/containers/tasks/TasksView.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/services/src/js/containers/tasks/TasksView.tsx: error TS2769: No overload matches this call.
+plugins/services/src/js/containers/tasks/TasksView.tsx: error TS2339: Property 'i18n' does not exist on type *.
 plugins/services/src/js/containers/tasks/__tests__/TaskTable-test.tsx: error TS2769: No overload matches this call.
-plugins/services/src/js/containers/volume-detail/PodVolumeContainer.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/services/src/js/containers/volume-detail/PodVolumeContainer.tsx: error TS2339: Property 'lastUpdate' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/volume-detail/PodVolumeContainer.tsx: error TS2339: Property 'isLoading' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/containers/volume-detail/PodVolumeContainer.tsx: error TS2339: Property 'params' does not exist on type *.
-plugins/services/src/js/containers/volume-detail/PodVolumeContainer.tsx: error TS2339: Property 'isLoading' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/containers/volume-detail/PodVolumeDetail.tsx: error TS2339: Property 'volume' does not exist on type *.
 plugins/services/src/js/containers/volume-detail/PodVolumeDetail.tsx: error TS2339: Property 'volume' does not exist on type *.
 plugins/services/src/js/containers/volume-detail/PodVolumeDetail.tsx: error TS2339: Property 'service' does not exist on type *.
 plugins/services/src/js/containers/volume-detail/PodVolumeDetail.tsx: error TS2339: Property 'volume' does not exist on type *.
-plugins/services/src/js/containers/volume-detail/ServiceVolumeContainer.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/services/src/js/containers/volume-detail/ServiceVolumeContainer.tsx: error TS2339: Property 'lastUpdate' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/volume-detail/ServiceVolumeContainer.tsx: error TS2339: Property 'isLoading' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/containers/volume-detail/ServiceVolumeContainer.tsx: error TS2339: Property 'params' does not exist on type *.
-plugins/services/src/js/containers/volume-detail/ServiceVolumeContainer.tsx: error TS2339: Property 'isLoading' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/volume-detail/TaskVolumeContainer.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/services/src/js/containers/volume-detail/TaskVolumeContainer.tsx: error TS2339: Property 'lastUpdate' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/containers/volume-detail/TaskVolumeContainer.tsx: error TS2339: Property 'isLoading' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/containers/volume-detail/TaskVolumeContainer.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/services/src/js/containers/volume-detail/TaskVolumeContainer.tsx: error TS2531: Object is possibly 'null'.
-plugins/services/src/js/containers/volume-detail/TaskVolumeContainer.tsx: error TS2339: Property 'isLoading' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/containers/volume-detail/VolumeDetail.tsx: error TS2339: Property 'volume' does not exist on type *.
 plugins/services/src/js/containers/volume-detail/VolumeDetail.tsx: error TS2339: Property 'volume' does not exist on type *.
 plugins/services/src/js/containers/volume-detail/VolumeDetail.tsx: error TS2339: Property 'service' does not exist on type *.
@@ -3412,26 +2828,15 @@ plugins/services/src/js/filters/TasksZoneFilter.ts: error TS6133: 'filterType' i
 plugins/services/src/js/filters/TasksZoneFilter.ts: error TS2339: Property 'zones' does not exist on type 'TasksZoneFilter'.
 plugins/services/src/js/filters/__tests__/TaskRegionFilter-test.ts: error TS2322: Type 'string' is not assignable to type 'never'.
 plugins/services/src/js/filters/__tests__/TaskZoneFilter-test.ts: error TS2322: Type 'string' is not assignable to type 'never'.
-plugins/services/src/js/pages/EditFrameworkConfiguration.tsx: error TS2339: Property 'packageDetails' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/pages/EditFrameworkConfiguration.tsx: error TS2339: Property 'deployErrors' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/pages/EditFrameworkConfiguration.tsx: error TS2339: Property 'formData' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/pages/EditFrameworkConfiguration.tsx: error TS2339: Property 'formErrors' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/pages/EditFrameworkConfiguration.tsx: error TS2339: Property 'cosmosErrors' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/pages/EditFrameworkConfiguration.tsx: error TS2339: Property 'defaultConfigWarning' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/pages/EditFrameworkConfiguration.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/pages/EditFrameworkConfiguration.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
-plugins/services/src/js/pages/EditFrameworkConfiguration.tsx: error TS2339: Property 'store_listeners' does not exist on type 'EditFrameworkConfiguration'.
 plugins/services/src/js/pages/EditFrameworkConfiguration.tsx: error TS2531: Object is possibly 'null'.
 plugins/services/src/js/pages/EditFrameworkConfiguration.tsx: error TS2531: Object is possibly 'null'.
 plugins/services/src/js/pages/EditFrameworkConfiguration.tsx: error TS2531: Object is possibly 'null'.
 plugins/services/src/js/pages/EditFrameworkConfiguration.tsx: error TS2339: Property 'params' does not exist on type *.
-plugins/services/src/js/pages/EditFrameworkConfiguration.tsx: error TS2339: Property 'formData' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/pages/EditFrameworkConfiguration.tsx: error TS2339: Property 'formData' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/pages/EditFrameworkConfiguration.tsx: error TS2554: Expected 2 arguments, but got 3.
-plugins/services/src/js/pages/EditFrameworkConfiguration.tsx: error TS2339: Property 'formErrors' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/pages/ServicesPage.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/services/src/js/pages/ServicesPage.tsx: error TS2339: Property 'store_listeners' does not exist on type 'ServicesPage'.
-plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'taskDirectoryErrorCount' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'routes' does not exist on type *.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2345: Argument of type 'null' is not assignable to parameter of type *.
@@ -3441,21 +2846,17 @@ plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Propert
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2531: Object is possibly 'null'.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2345: Argument of type '\\"innerPath\\"' is not assignable to parameter of type 'never'.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'params' does not exist on type *.
-plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'directory' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'selectedLogFile' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2345: Argument of type '\\"lastMesosState\\"' is not assignable to parameter of type 'never'.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2531: Object is possibly 'null'.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'store_listeners' does not exist on type 'TaskDetail'.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'onTaskDirectoryStoreNodeStateError' does not exist on type 'TaskDetail'.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'onTaskDirectoryStoreNodeStateSuccess' does not exist on type 'TaskDetail'.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2556: Expected 0 arguments, but got 1 or more.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'store_removeEventListenerForStoreID' does not exist on type 'TaskDetail'.
-plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'taskDirectoryErrorCount' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2345: Argument of type '\\"directory\\"' is not assignable to parameter of type 'never'.
 plugins/services/src/js/pages/task-details/TaskDetail.tsx: error TS2339: Property 'params' does not exist on type *.
@@ -3477,7 +2878,6 @@ plugins/services/src/js/pages/task-details/TaskFileBrowser.tsx: error TS2339: Pr
 plugins/services/src/js/pages/task-details/TaskFileBrowser.tsx: error TS2339: Property 'task' does not exist on type *.
 plugins/services/src/js/pages/task-details/TaskFileBrowser.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/pages/task-details/TaskFileViewer.tsx: error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
-plugins/services/src/js/pages/task-details/TaskFileViewer.tsx: error TS2339: Property 'currentFile' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/pages/task-details/TaskFileViewer.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/services/src/js/pages/task-details/TaskFileViewer.tsx: error TS2339: Property 'getName' does not exist on type 'never'.
 plugins/services/src/js/pages/task-details/TaskFileViewer.tsx: error TS2339: Property 'task' does not exist on type *.
@@ -3485,11 +2885,9 @@ plugins/services/src/js/pages/task-details/TaskFileViewer.tsx: error TS2322: typ
 plugins/services/src/js/pages/task-details/TaskFileViewer.tsx: error TS2339: Property 'task' does not exist on type *.
 plugins/services/src/js/pages/task-details/TaskFileViewer.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/pages/task-details/TaskFileViewer.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
-plugins/services/src/js/pages/task-details/TaskFileViewer.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/services/src/js/pages/task-details/TaskFileViewer.tsx: error TS2339: Property 'task' does not exist on type 'Readonly<{}>'.
+plugins/services/src/js/pages/task-details/TaskFileViewer.tsx: error TS2339: Property 'task' does not exist on type *.
 plugins/services/src/js/pages/task-details/TaskFileViewer.tsx: error TS2339: Property 'task' does not exist on type *.
 plugins/services/src/js/pages/task-details/TaskFileViewer.tsx: error TS2339: Property 'directory' does not exist on type *.
-plugins/services/src/js/pages/task-details/TaskFileViewer.tsx: error TS2339: Property 'currentFile' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/pages/task-details/TaskFileViewer.tsx: error TS2531: Object is possibly 'null'.
 plugins/services/src/js/pages/task-details/TaskFileViewer.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/services/src/js/pages/task-details/TaskFileViewer.tsx: error TS2339: Property 'routes' does not exist on type *.
@@ -3497,60 +2895,41 @@ plugins/services/src/js/pages/task-details/TaskFileViewer.tsx: error TS2339: Pro
 plugins/services/src/js/pages/task-details/TaskFileViewer.tsx: error TS2339: Property 'limitLogFiles' does not exist on type *.
 plugins/services/src/js/pages/task-details/TaskFileViewer.tsx: error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
 plugins/services/src/js/pages/task-details/TaskIpAddressesRow.tsx: error TS2339: Property 'taskId' does not exist on type *.
-plugins/services/src/js/pages/task-details/TaskLogsContainer.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/services/src/js/pages/task-details/TaskLogsContainer.tsx: error TS2339: Property 'store_listeners' does not exist on type 'TaskLogsContainer'.
-plugins/services/src/js/pages/task-details/TaskLogsContainer.tsx: error TS2339: Property 'isLoading' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/pages/task-details/TaskLogsContainer.tsx: error TS2339: Property 'isLoading' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/pages/task-details/TaskLogsContainer.tsx: error TS2339: Property 'fetch' does not exist on type 'ConfigStore'.
-plugins/services/src/js/pages/task-details/TaskLogsContainer.tsx: error TS2339: Property 'isLoading' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/pages/task-details/TaskLogsContainer.tsx: error TS2339: Property 'directory' does not exist on type *.
 plugins/services/src/js/pages/task-details/TaskLogsContainer.tsx: error TS2339: Property 'params' does not exist on type *.
 plugins/services/src/js/pages/task-details/TaskLogsContainer.tsx: error TS2339: Property 'routes' does not exist on type *.
 plugins/services/src/js/pages/task-details/TaskLogsContainer.tsx: error TS2339: Property 'selectedLogFile' does not exist on type *.
 plugins/services/src/js/pages/task-details/TaskLogsContainer.tsx: error TS2339: Property 'task' does not exist on type *.
-plugins/services/src/js/pages/task-details/TaskLogsContainer.tsx: error TS2322: type * is not assignable to type *.
-plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'streams' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'subscriptionID' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'isFetchingPrevious' does not exist on type 'Readonly<{}>'.
+plugins/services/src/js/pages/task-details/TaskLogsContainer.tsx: error TS2769: No overload matches this call.
+plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'subscriptionID' does not exist on type *.
 plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'isFetchingPrevious' does not exist on type *.
-plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'subscriptionID' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'isLoading' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'isFetchingPrevious' does not exist on type 'Readonly<{}>'.
+plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'subscriptionID' does not exist on type *.
 plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'isFetchingPrevious' does not exist on type *.
 plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS7030: Not all code paths return a value.
 plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'task' does not exist on type *.
-plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'isFetchingPrevious' does not exist on type 'Readonly<{}>'.
 plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'task' does not exist on type *.
-plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'subscriptionID' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'selectedStream' does not exist on type 'Readonly<{}>'.
+plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'subscriptionID' does not exist on type *.
+plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'selectedStream' does not exist on type *.
 plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'task' does not exist on type *.
-plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'subscriptionID' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'streams' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'selectedStream' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'streams' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'streams' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'selectedStream' does not exist on type 'Readonly<{}>'.
+plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'subscriptionID' does not exist on type *.
+plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'selectedStream' does not exist on type *.
+plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'selectedStream' does not exist on type *.
 plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'task' does not exist on type *.
-plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'selectedStream' does not exist on type 'Readonly<{}>'.
+plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'selectedStream' does not exist on type *.
 plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'highlightText' does not exist on type *.
 plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'onCountChange' does not exist on type *.
 plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'watching' does not exist on type *.
-plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'hasError' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'direction' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'fullLog' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'isLoading' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'selectedStream' does not exist on type 'Readonly<{}>'.
-plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'subscriptionID' does not exist on type 'Readonly<{}>'.
+plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'selectedStream' does not exist on type *.
+plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'subscriptionID' does not exist on type *.
 plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2741: Property 'isRequired' is missing in type 'Validator<object>' but required in type *.
-plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'store_listeners' does not exist on type 'TaskSystemLogsContainer'.
 plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
 plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'task' does not exist on type *.
 plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
-plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'subscriptionID' does not exist on type 'Readonly<{}>'.
+plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'subscriptionID' does not exist on type *.
 plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'highlightText' does not exist on type *.
 plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'task' does not exist on type *.
 plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.tsx: error TS2339: Property 'watching' does not exist on type *.
@@ -4088,14 +3467,14 @@ plugins/services/src/js/service-configuration/PodContainerArtifactsConfigSection
 plugins/services/src/js/service-configuration/PodContainerArtifactsConfigSection.tsx: error TS2339: Property 'artifacts' does not exist on type *.
 plugins/services/src/js/service-configuration/PodContainerArtifactsConfigSection.tsx: error TS2339: Property 'index' does not exist on type *.
 plugins/services/src/js/service-configuration/PodContainerArtifactsConfigSection.tsx: error TS2339: Property 'onEditClick' does not exist on type *.
-plugins/services/src/js/service-configuration/PodContainerArtifactsConfigSection.tsx: error TS2322: type * is not assignable to type *.
-plugins/services/src/js/service-configuration/PodContainerConfigSection.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/service-configuration/PodContainerArtifactsConfigSection.tsx: error TS2769: No overload matches this call.
+plugins/services/src/js/service-configuration/PodContainerConfigSection.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/service-configuration/PodEnvironmentVariablesConfigSection.tsx: error TS2322: Type 'Element' is not assignable to type 'never'.
 plugins/services/src/js/service-configuration/PodEnvironmentVariablesConfigSection.tsx: error TS2322: Type 'any' is not assignable to type 'never'.
 plugins/services/src/js/service-configuration/PodEnvironmentVariablesConfigSection.tsx: error TS2322: Type 'Element' is not assignable to type 'never'.
+plugins/services/src/js/service-configuration/PodEnvironmentVariablesConfigSection.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/service-configuration/PodEnvironmentVariablesConfigSection.tsx: error TS2322: type * is not assignable to type *.
-plugins/services/src/js/service-configuration/PodEnvironmentVariablesConfigSection.tsx: error TS2322: type * is not assignable to type *.
-plugins/services/src/js/service-configuration/PodGeneralConfigSection.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/service-configuration/PodGeneralConfigSection.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/service-configuration/PodGeneralConfigSection.tsx: error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.
 plugins/services/src/js/service-configuration/PodHealthChecksConfigSection.tsx: error TS2339: Property 'appConfig' does not exist on type *.
 plugins/services/src/js/service-configuration/PodHealthChecksConfigSection.tsx: error TS2339: Property 'command' does not exist on type *.
@@ -4105,10 +3484,10 @@ plugins/services/src/js/service-configuration/PodHealthChecksConfigSection.tsx: 
 plugins/services/src/js/service-configuration/PodHealthChecksConfigSection.tsx: error TS2339: Property 'protocol' does not exist on type *.
 plugins/services/src/js/service-configuration/PodHealthChecksConfigSection.tsx: error TS2339: Property 'endpoint' does not exist on type *.
 plugins/services/src/js/service-configuration/PodHealthChecksConfigSection.tsx: error TS2339: Property 'protocol' does not exist on type *.
-plugins/services/src/js/service-configuration/PodHealthChecksConfigSection.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/service-configuration/PodHealthChecksConfigSection.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/service-configuration/PodHealthChecksConfigSection.tsx: error TS2339: Property 'appConfig' does not exist on type *.
 plugins/services/src/js/service-configuration/PodHealthChecksConfigSection.tsx: error TS2322: type * is not assignable to type *.
-plugins/services/src/js/service-configuration/PodHealthChecksConfigSection.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/service-configuration/PodHealthChecksConfigSection.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/service-configuration/PodHealthChecksConfigSection.tsx: error TS2339: Property 'appConfig' does not exist on type *.
 plugins/services/src/js/service-configuration/PodHealthChecksConfigSection.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/service-configuration/PodHealthChecksConfigSection.tsx: error TS2769: No overload matches this call.
@@ -4118,11 +3497,11 @@ plugins/services/src/js/service-configuration/PodLabelsConfigSection.tsx: error 
 plugins/services/src/js/service-configuration/PodLabelsConfigSection.tsx: error TS2322: Type 'Element' is not assignable to type 'never'.
 plugins/services/src/js/service-configuration/PodLabelsConfigSection.tsx: error TS2322: Type 'any' is not assignable to type 'never'.
 plugins/services/src/js/service-configuration/PodLabelsConfigSection.tsx: error TS2322: Type 'Element' is not assignable to type 'never'.
-plugins/services/src/js/service-configuration/PodLabelsConfigSection.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/service-configuration/PodLabelsConfigSection.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/service-configuration/PodLabelsConfigSection.tsx: error TS2339: Property 'appConfig' does not exist on type *.
 plugins/services/src/js/service-configuration/PodLabelsConfigSection.tsx: error TS2322: type * is not assignable to type *.
-plugins/services/src/js/service-configuration/PodNetworkConfigSection.tsx: error TS2322: type * is not assignable to type *.
-plugins/services/src/js/service-configuration/PodNetworkConfigSection.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/service-configuration/PodNetworkConfigSection.tsx: error TS2769: No overload matches this call.
+plugins/services/src/js/service-configuration/PodNetworkConfigSection.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/service-configuration/PodNetworkConfigSection.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/service-configuration/PodNetworkConfigSection.tsx: error TS2339: Property 'onEditClick' does not exist on type *.
 plugins/services/src/js/service-configuration/PodNetworkConfigSection.tsx: error TS2339: Property 'i18n' does not exist on type *.
@@ -4131,16 +3510,16 @@ plugins/services/src/js/service-configuration/PodNetworkConfigSection.tsx: error
 plugins/services/src/js/service-configuration/PodNetworkConfigSection.tsx: error TS2554: Expected 2 arguments, but got 1.
 plugins/services/src/js/service-configuration/PodPlacementConstraintsConfigSection.tsx: error TS2339: Property 'appConfig' does not exist on type *.
 plugins/services/src/js/service-configuration/PodPlacementConstraintsConfigSection.tsx: error TS2339: Property 'onEditClick' does not exist on type *.
-plugins/services/src/js/service-configuration/PodPlacementConstraintsConfigSection.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/service-configuration/PodPlacementConstraintsConfigSection.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/service-configuration/PodPlacementConstraintsConfigSection.tsx: error TS2339: Property 'appConfig' does not exist on type *.
 plugins/services/src/js/service-configuration/PodPlacementConstraintsConfigSection.tsx: error TS2322: type * is not assignable to type *.
-plugins/services/src/js/service-configuration/PodStorageConfigSection.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/service-configuration/PodStorageConfigSection.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/service-configuration/PodStorageConfigSection.tsx: error TS2339: Property 'appConfig' does not exist on type *.
 plugins/services/src/js/service-configuration/PodStorageConfigSection.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/service-configuration/PodStorageConfigSection.tsx: error TS2339: Property 'onEditClick' does not exist on type *.
 plugins/services/src/js/service-configuration/PodStorageConfigSection.tsx: error TS2339: Property 'appConfig' does not exist on type *.
 plugins/services/src/js/service-configuration/ServiceConfigBaseSectionDisplay.tsx: error TS2339: Property 'appConfig' does not exist on type *.
-plugins/services/src/js/service-configuration/ServiceConfigBaseSectionDisplay.tsx: error TS2322: Type 'void' is not assignable to type 'string'.
+plugins/services/src/js/service-configuration/ServiceConfigBaseSectionDisplay.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/service-configuration/ServiceConfigBaseSectionDisplay.tsx: error TS2339: Property 'appConfig' does not exist on type *.
 plugins/services/src/js/service-configuration/ServiceConfigBaseSectionDisplay.tsx: error TS2339: Property 'onEditClick' does not exist on type *.
 plugins/services/src/js/service-configuration/ServiceConfigBaseSectionDisplay.tsx: error TS2339: Property 'tabViewID' does not exist on type *.
@@ -4155,7 +3534,7 @@ plugins/services/src/js/service-configuration/ServiceConfigBaseSectionDisplay.ts
 plugins/services/src/js/service-configuration/ServiceConfigBaseSectionDisplay.tsx: error TS2339: Property 'heading' does not exist on type 'never'.
 plugins/services/src/js/service-configuration/ServiceConfigBaseSectionDisplay.tsx: error TS2339: Property 'label' does not exist on type 'never'.
 plugins/services/src/js/service-configuration/ServiceConfigBaseSectionDisplay.tsx: error TS2339: Property 'type' does not exist on type 'never'.
-plugins/services/src/js/service-configuration/ServiceConfigDisplay.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/service-configuration/ServiceConfigDisplay.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/service-configuration/ServiceConfigDisplay.tsx: error TS2339: Property 'appConfig' does not exist on type *.
 plugins/services/src/js/service-configuration/ServiceConfigDisplay.tsx: error TS2339: Property 'errors' does not exist on type *.
 plugins/services/src/js/service-configuration/ServiceConfigDisplay.tsx: error TS2345: Argument of type * is not assignable to parameter of type 'PathTranslationRules[]'.
@@ -4215,7 +3594,7 @@ plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.tsx
 plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.tsx: error TS2339: Property 'onEditClick' does not exist on type *.
 plugins/services/src/js/service-configuration/ServicePlacementConstraintsConfigSection.tsx: error TS2339: Property 'appConfig' does not exist on type *.
 plugins/services/src/js/service-configuration/ServicePlacementConstraintsConfigSection.tsx: error TS2339: Property 'onEditClick' does not exist on type *.
-plugins/services/src/js/service-configuration/ServicePlacementConstraintsConfigSection.tsx: error TS2322: type * is not assignable to type *.
+plugins/services/src/js/service-configuration/ServicePlacementConstraintsConfigSection.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/service-configuration/ServicePlacementConstraintsConfigSection.tsx: error TS2339: Property 'appConfig' does not exist on type *.
 plugins/services/src/js/service-configuration/ServicePlacementConstraintsConfigSection.tsx: error TS2322: type * is not assignable to type *.
 plugins/services/src/js/service-configuration/ServiceStorageConfigSection.tsx: error TS2345: Argument of type '\\"EXTERNAL\\"' is not assignable to parameter of type *.
@@ -4274,16 +3653,8 @@ plugins/services/src/js/structs/Application.ts: error TS2339: Property 'tasksRun
 plugins/services/src/js/structs/Application.ts: error TS2416: Property 'getTasksSummary' in type 'Application' is not assignable to the same property in base type 'Service'.
 plugins/services/src/js/structs/Application.ts: error TS2339: Property 'tasksOverCapacity' does not exist on type *.
 plugins/services/src/js/structs/Application.ts: error TS2339: Property 'tasksRunning' does not exist on type *.
-plugins/services/src/js/structs/Application.ts: error TS2339: Property '_spec' does not exist on type 'Application'.
-plugins/services/src/js/structs/Application.ts: error TS2339: Property '_spec' does not exist on type 'Application'.
-plugins/services/src/js/structs/Application.ts: error TS2339: Property '_spec' does not exist on type 'Application'.
-plugins/services/src/js/structs/Application.ts: error TS2339: Property '_spec' does not exist on type 'Application'.
 plugins/services/src/js/structs/Application.ts: error TS2339: Property 'tasksRunning' does not exist on type *.
 plugins/services/src/js/structs/Framework.ts: error TS2339: Property 'tasksRunning' does not exist on type *.
-plugins/services/src/js/structs/Framework.ts: error TS2339: Property '_spec' does not exist on type 'Framework'.
-plugins/services/src/js/structs/Framework.ts: error TS2339: Property '_spec' does not exist on type 'Framework'.
-plugins/services/src/js/structs/Framework.ts: error TS2339: Property '_spec' does not exist on type 'Framework'.
-plugins/services/src/js/structs/Framework.ts: error TS2339: Property '_spec' does not exist on type 'Framework'.
 plugins/services/src/js/structs/LogBuffer.ts: error TS2554: Expected 1 arguments, but got 0.
 plugins/services/src/js/structs/LogBuffer.ts: error TS2339: Property 'configuration' does not exist on type 'LogBuffer'.
 plugins/services/src/js/structs/LogBuffer.ts: error TS2339: Property 'configuration' does not exist on type 'LogBuffer'.
@@ -4307,13 +3678,8 @@ plugins/services/src/js/structs/Pod.ts: error TS2339: Property '_spec' does not 
 plugins/services/src/js/structs/Pod.ts: error TS2322: Type 'boolean' is not assignable to type *.
 plugins/services/src/js/structs/Pod.ts: error TS2339: Property 'id' does not exist on type 'PodInstance'.
 plugins/services/src/js/structs/Pod.ts: error TS2339: Property '_spec' does not exist on type 'Pod'.
-plugins/services/src/js/structs/Pod.ts: error TS2339: Property '_regions' does not exist on type 'Pod'.
-plugins/services/src/js/structs/Pod.ts: error TS2339: Property '_regions' does not exist on type 'Pod'.
-plugins/services/src/js/structs/Pod.ts: error TS2339: Property '_regions' does not exist on type 'Pod'.
-plugins/services/src/js/structs/Service.ts: error TS2339: Property '_regions' does not exist on type 'Service'.
-plugins/services/src/js/structs/Service.ts: error TS2339: Property '_regions' does not exist on type 'Service'.
-plugins/services/src/js/structs/Service.ts: error TS2339: Property '_regions' does not exist on type 'Service'.
-plugins/services/src/js/structs/Service.ts: error TS2339: Property '_regions' does not exist on type 'Service'.
+plugins/services/src/js/structs/Pod.ts: error TS2322: Type 'string[]' is not assignable to type 'undefined'.
+plugins/services/src/js/structs/Service.ts: error TS2322: Type 'string[]' is not assignable to type 'undefined'.
 plugins/services/src/js/structs/ServiceTree.ts: error TS2339: Property 'enforceRole' does not exist on type 'ServiceTree'.
 plugins/services/src/js/structs/ServiceTree.ts: error TS2345: Argument of type 'this' is not assignable to parameter of type *.
 plugins/services/src/js/structs/ServiceTree.ts: error TS2339: Property 'getId' does not exist on type '{}'.
@@ -4652,13 +4018,9 @@ plugins/ui-update/utils/__tests__/index-test.ts: error TS2531: Object is possibl
 plugins/ui-update/utils/index.ts: error TS2531: Object is possibly 'null'.
 plugins/ui-update/utils/index.ts: error TS2345: Argument of type * is not assignable to parameter of type *.
 plugins/ui-update/utils/index.ts: error TS2345: Argument of type * is not assignable to parameter of type *.
-src/js/components/AccessDeniedPage.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-src/js/components/BaseConfig.tsx: error TS2322: Type 'void' is not assignable to type 'string'.
+src/js/components/BaseConfig.tsx: error TS2769: No overload matches this call.
 src/js/components/BaseConfig.tsx: error TS2322: type * is not assignable to type *.
 src/js/components/BatchContainer.tsx: error TS2769: No overload matches this call.
-src/js/components/CheckboxTable.tsx: error TS2339: Property 'allowMultipleSelect' does not exist on type *.
-src/js/components/CheckboxTable.tsx: error TS2339: Property 'checkedItemsMap' does not exist on type *.
-src/js/components/CheckboxTable.tsx: error TS2339: Property 'disabledItemsMap' does not exist on type *.
 src/js/components/CheckboxTable.tsx: error TS2339: Property 'data' does not exist on type *.
 src/js/components/CheckboxTable.tsx: error TS6133: 'prop' is declared but its value is never read.
 src/js/components/CheckboxTable.tsx: error TS2339: Property 'checkedItemsMap' does not exist on type *.
@@ -4673,7 +4035,6 @@ src/js/components/CheckboxTable.tsx: error TS2339: Property 'data' does not exis
 src/js/components/CheckboxTable.tsx: error TS2339: Property 'getColGroup' does not exist on type *.
 src/js/components/CheckboxTable.tsx: error TS2339: Property 'sortOrder' does not exist on type *.
 src/js/components/CheckboxTable.tsx: error TS2339: Property 'sortProp' does not exist on type *.
-src/js/components/CheckboxTable.tsx: error TS2554: Expected 1-2 arguments, but got 0.
 src/js/components/CheckboxTable.tsx: error TS6133: 'prevCheckboxState' is declared but its value is never read.
 src/js/components/CheckboxTable.tsx: error TS2339: Property 'allowMultipleSelect' does not exist on type *.
 src/js/components/CheckboxTable.tsx: error TS2339: Property 'checkedItemsMap' does not exist on type *.
@@ -4685,32 +4046,30 @@ src/js/components/CheckboxTable.tsx: error TS2339: Property 'uniqueProperty' doe
 src/js/components/CheckboxTable.tsx: error TS2339: Property 'disabledItemsMap' does not exist on type *.
 src/js/components/CheckboxTable.tsx: error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
 src/js/components/CheckboxTable.tsx: error TS2339: Property 'labelClass' does not exist on type *.
+src/js/components/CheckboxTable.tsx: error TS2339: Property 'allowMultipleSelect' does not exist on type *.
+src/js/components/CheckboxTable.tsx: error TS2339: Property 'checkedItemsMap' does not exist on type *.
+src/js/components/CheckboxTable.tsx: error TS2339: Property 'disabledItemsMap' does not exist on type *.
 src/js/components/ClickToSelect.tsx: error TS2339: Property 'nodeRef' does not exist on type 'ClickToSelect'.
 src/js/components/ClickToSelect.tsx: error TS2531: Object is possibly 'null'.
 src/js/components/ClickToSelect.tsx: error TS2531: Object is possibly 'null'.
 src/js/components/ClickToSelect.tsx: error TS2339: Property 'nodeRef' does not exist on type 'ClickToSelect'.
 src/js/components/ClickToSelect.tsx: error TS2339: Property 'nodeRef' does not exist on type 'ClickToSelect'.
 src/js/components/ClickToSelect.tsx: error TS2554: Expected 1-2 arguments, but got 0.
-src/js/components/ClipboardTrigger.tsx: error TS2554: Expected 1-2 arguments, but got 0.
-src/js/components/ClipboardTrigger.tsx: error TS2339: Property 'copyButtonRef' does not exist on type 'ClipboardTrigger'.
-src/js/components/ClipboardTrigger.tsx: error TS2339: Property 'copyButtonRef' does not exist on type 'ClipboardTrigger'.
 src/js/components/ClipboardTrigger.tsx: error TS2339: Property 'clipboard' does not exist on type 'ClipboardTrigger'.
-src/js/components/ClipboardTrigger.tsx: error TS2339: Property 'copyButtonRef' does not exist on type 'ClipboardTrigger'.
 src/js/components/ClipboardTrigger.tsx: error TS2339: Property 'copyText' does not exist on type *.
 src/js/components/ClipboardTrigger.tsx: error TS2339: Property 'clipboard' does not exist on type 'ClipboardTrigger'.
 src/js/components/ClipboardTrigger.tsx: error TS2339: Property 'clipboard' does not exist on type 'ClipboardTrigger'.
 src/js/components/ClipboardTrigger.tsx: error TS2339: Property 'clipboard' does not exist on type 'ClipboardTrigger'.
 src/js/components/ClipboardTrigger.tsx: error TS2339: Property 'className' does not exist on type *.
-src/js/components/ClipboardTrigger.tsx: error TS2339: Property 'copyButtonRef' does not exist on type 'ClipboardTrigger'.
-src/js/components/ClipboardTrigger.tsx: error TS2339: Property 'copyButtonRef' does not exist on type 'ClipboardTrigger'.
+src/js/components/ClipboardTrigger.tsx: error TS2322: Type 'RefObject<unknown>' is not assignable to type *.
+src/js/components/ClipboardTrigger.tsx: error TS2322: Type 'RefObject<unknown>' is not assignable to type *.
 src/js/components/ClipboardTrigger.tsx: error TS2339: Property 'onTextCopy' does not exist on type *.
 src/js/components/ClipboardTrigger.tsx: error TS2339: Property 'onTextCopy' does not exist on type *.
 src/js/components/ClipboardTrigger.tsx: error TS2339: Property 'useTooltip' does not exist on type *.
-src/js/components/ClipboardTrigger.tsx: error TS2339: Property 'hasCopiedToClipboard' does not exist on type 'Readonly<{}>'.
 src/js/components/ClusterDropdown.tsx: error TS2339: Property 'menuItems' does not exist on type *.
 src/js/components/ClusterDropdown.tsx: error TS2339: Property 'clusterName' does not exist on type *.
 src/js/components/ClusterDropdown.tsx: error TS2741: Property 'onTrigger' is missing in type * but required in type *.
-src/js/components/ClusterHeader.tsx: error TS2322: type * is not assignable to type *.
+src/js/components/ClusterHeader.tsx: error TS2769: No overload matches this call.
 src/js/components/ClusterHeader.tsx: error TS2339: Property 'onUpdate' does not exist on type *.
 src/js/components/ClusterHeader.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
 src/js/components/ClusterHeader.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
@@ -4721,50 +4080,34 @@ src/js/components/ClusterHeader.tsx: error TS2345: Argument of type '\\"metadata
 src/js/components/ClusterHeader.tsx: error TS2531: Object is possibly 'null'.
 src/js/components/ClusterHeader.tsx: error TS2531: Object is possibly 'null'.
 src/js/components/ClusterHeader.tsx: error TS2531: Object is possibly 'null'.
-src/js/components/CollapsingString.tsx: error TS2339: Property 'parentWidth' does not exist on type 'Readonly<{}>'.
-src/js/components/CollapsingString.tsx: error TS2339: Property 'parentWidth' does not exist on type 'Readonly<{}>'.
-src/js/components/CollapsingString.tsx: error TS2339: Property 'collapsed' does not exist on type 'Readonly<{}>'.
-src/js/components/CollapsingString.tsx: error TS2339: Property 'parentWidth' does not exist on type 'Readonly<{}>'.
-src/js/components/CollapsingString.tsx: error TS2339: Property 'parentWidth' does not exist on type 'Readonly<{}>'.
-src/js/components/CollapsingString.tsx: error TS2339: Property 'collapsed' does not exist on type 'Readonly<{}>'.
-src/js/components/CollapsingString.tsx: error TS2339: Property 'fullStringRef' does not exist on type 'CollapsingString'.
+src/js/components/CollapsingString.tsx: error TS2531: Object is possibly 'null'.
+src/js/components/CollapsingString.tsx: error TS2531: Object is possibly 'null'.
 src/js/components/CollapsingString.tsx: error TS2339: Property 'string' does not exist on type *.
 src/js/components/CollapsingString.tsx: error TS2339: Property 'endLength' does not exist on type *.
-src/js/components/CollapsingString.tsx: error TS2339: Property 'collapsed' does not exist on type 'Readonly<{}>'.
 src/js/components/CollapsingString.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 src/js/components/CollapsingString.tsx: error TS2339: Property 'truncatedStringEndClassName' does not exist on type *.
 src/js/components/CollapsingString.tsx: error TS2339: Property 'wrapperClassName' does not exist on type *.
 src/js/components/CollapsingString.tsx: error TS2339: Property 'fullStringClassName' does not exist on type *.
-src/js/components/CollapsingString.tsx: error TS2339: Property 'fullStringRef' does not exist on type 'CollapsingString'.
+src/js/components/CollapsingString.tsx: error TS2322: Type 'RefObject<unknown>' is not assignable to type *.
 src/js/components/CollapsingString.tsx: error TS2339: Property 'truncatedWrapperClassName' does not exist on type *.
 src/js/components/CollapsingString.tsx: error TS2339: Property 'truncatedStringStartClassName' does not exist on type *.
-src/js/components/CollapsingString.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-src/js/components/CollapsingString.tsx: error TS2339: Property 'fullStringRef' does not exist on type 'CollapsingString'.
 src/js/components/CollapsingString.tsx: error TS2339: Property 'parentSelector' does not exist on type *.
 src/js/components/CollapsingString.tsx: error TS2339: Property 'parentSelector' does not exist on type *.
 src/js/components/CollapsingString.tsx: error TS2322: Type 'HTMLElement' is not assignable to type 'null'.
-src/js/components/CollapsingString.tsx: error TS2339: Property 'fullStringRef' does not exist on type 'CollapsingString'.
-src/js/components/CollapsingString.tsx: error TS2339: Property 'fullStringRef' does not exist on type 'CollapsingString'.
 src/js/components/ComponentList.tsx: error TS2339: Property 'units' does not exist on type *.
 src/js/components/ComponentList.tsx: error TS2339: Property 'displayCount' does not exist on type *.
 src/js/components/CosmosErrorMessage.tsx: error TS2339: Property 'error' does not exist on type *.
 src/js/components/CosmosErrorMessage.tsx: error TS2339: Property 'error' does not exist on type *.
 src/js/components/CreateServiceModalCatalogPanelOption.tsx: error TS2307: Cannot find module '../../img/service-picker-options/service-image-package-large@2x.png' or its corresponding type declarations.
 src/js/components/CreateServiceModalServicePickerOption.tsx: error TS2339: Property 'type' does not exist on type *.
+src/js/components/DSLFilterField.tsx: error TS2322: type * is not assignable to type *.
+src/js/components/DSLFilterField.tsx: error TS2769: No overload matches this call.
+src/js/components/DSLFilterField.tsx: error TS2339: Property 'expression' does not exist on type *.
+src/js/components/DSLFilterField.tsx: error TS2339: Property 'filters' does not exist on type *.
 src/js/components/DSLFilterField.tsx: error TS2339: Property 'expression' does not exist on type *.
 src/js/components/DSLFilterField.tsx: error TS2339: Property 'formSections' does not exist on type *.
 src/js/components/DSLFilterField.tsx: error TS2339: Property 'onChange' does not exist on type *.
 src/js/components/DSLFilterField.tsx: error TS2339: Property 'defaultData' does not exist on type *.
-src/js/components/DSLFilterField.tsx: error TS2339: Property 'dropdownVisible' does not exist on type 'Readonly<{}>'.
-src/js/components/DSLFilterField.tsx: error TS2322: type * is not assignable to type *.
-src/js/components/DSLFilterField.tsx: error TS2322: type * is not assignable to type *.
-src/js/components/DSLFilterField.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-src/js/components/DSLFilterField.tsx: error TS2339: Property 'expression' does not exist on type *.
-src/js/components/DSLFilterField.tsx: error TS2339: Property 'filters' does not exist on type *.
-src/js/components/DSLFilterField.tsx: error TS2339: Property 'dropdownVisible' does not exist on type 'Readonly<{}>'.
-src/js/components/DSLFilterField.tsx: error TS2339: Property 'dropdownVisible' does not exist on type 'Readonly<{}>'.
-src/js/components/DSLFilterField.tsx: error TS2339: Property 'dropdownVisible' does not exist on type 'Readonly<{}>'.
-src/js/components/DSLFormDropdownPanel.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 src/js/components/DSLFormDropdownPanel.tsx: error TS2339: Property 'expression' does not exist on type *.
 src/js/components/DSLFormDropdownPanel.tsx: error TS2339: Property 'isVisible' does not exist on type *.
 src/js/components/DSLFormDropdownPanel.tsx: error TS2339: Property 'expression' does not exist on type *.
@@ -4772,10 +4115,8 @@ src/js/components/DSLFormDropdownPanel.tsx: error TS2339: Property 'sections' do
 src/js/components/DSLFormDropdownPanel.tsx: error TS2339: Property 'expression' does not exist on type *.
 src/js/components/DSLFormDropdownPanel.tsx: error TS2339: Property 'isVisible' does not exist on type *.
 src/js/components/DSLFormDropdownPanel.tsx: error TS2339: Property 'onChange' does not exist on type *.
-src/js/components/DSLFormDropdownPanel.tsx: error TS2339: Property 'expression' does not exist on type 'Readonly<{}>'.
 src/js/components/DSLFormDropdownPanel.tsx: error TS2339: Property 'onClose' does not exist on type *.
 src/js/components/DSLFormDropdownPanel.tsx: error TS2339: Property 'onChange' does not exist on type *.
-src/js/components/DSLFormDropdownPanel.tsx: error TS2339: Property 'expression' does not exist on type 'Readonly<{}>'.
 src/js/components/DSLFormDropdownPanel.tsx: error TS2339: Property 'sections' does not exist on type *.
 src/js/components/DSLFormDropdownPanel.tsx: error TS2339: Property 'isVisible' does not exist on type *.
 src/js/components/DSLFormDropdownPanel.tsx: error TS2339: Property 'defaultData' does not exist on type *.
@@ -4787,24 +4128,18 @@ src/js/components/DSLFormWithExpressionUpdates.tsx: error TS2339: Property 'item
 src/js/components/DSLFormWithExpressionUpdates.tsx: error TS2339: Property 'parts' does not exist on type *.
 src/js/components/DSLFormWithExpressionUpdates.tsx: error TS2339: Property 'updatePolicy' does not exist on type *.
 src/js/components/DSLFormWithExpressionUpdates.tsx: error TS2339: Property 'enabled' does not exist on type *.
-src/js/components/DSLFormWithExpressionUpdates.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 src/js/components/DSLFormWithExpressionUpdates.tsx: error TS2339: Property 'onChange' does not exist on type *.
 src/js/components/DSLFormWithExpressionUpdates.tsx: error TS2339: Property 'parts' does not exist on type *.
 src/js/components/DSLFormWithExpressionUpdates.tsx: error TS2339: Property 'onChange' does not exist on type *.
 src/js/components/DSLFormWithExpressionUpdates.tsx: error TS2339: Property 'parts' does not exist on type *.
-src/js/components/DSLInputField.tsx: error TS2339: Property 'onBlur' does not exist on type *.
 src/js/components/DSLInputField.tsx: error TS2339: Property 'onChange' does not exist on type *.
-src/js/components/DSLInputField.tsx: error TS2339: Property 'expression' does not exist on type 'Readonly<{}>'.
 src/js/components/DSLInputField.tsx: error TS2339: Property 'onFocus' does not exist on type *.
 src/js/components/DSLInputField.tsx: error TS2339: Property 'onChange' does not exist on type *.
-src/js/components/DSLInputField.tsx: error TS2339: Property 'expression' does not exist on type 'Readonly<{}>'.
-src/js/components/DSLInputField.tsx: error TS2339: Property 'expression' does not exist on type 'Readonly<{}>'.
 src/js/components/DSLInputField.tsx: error TS2339: Property 'inverseStyle' does not exist on type *.
 src/js/components/DSLInputField.tsx: error TS2339: Property 'dropdownVisible' does not exist on type *.
 src/js/components/DSLInputField.tsx: error TS2339: Property 'hasDropdown' does not exist on type *.
 src/js/components/DSLInputField.tsx: error TS2339: Property 'inverseStyle' does not exist on type *.
 src/js/components/DSLInputField.tsx: error TS2339: Property 'onDropdownClick' does not exist on type *.
-src/js/components/DSLInputField.tsx: error TS2339: Property 'expression' does not exist on type 'Readonly<{}>'.
 src/js/components/DSLInputField.tsx: error TS2339: Property 'inverseStyle' does not exist on type *.
 src/js/components/DSLInputField.tsx: error TS2339: Property 'placeholder' does not exist on type *.
 src/js/components/DSLInputField.tsx: error TS2339: Property 'i18n' does not exist on type *.
@@ -4812,15 +4147,11 @@ src/js/components/DSLInputField.tsx: error TS2339: Property 'inputField' does no
 src/js/components/DSLInputField.tsx: error TS2339: Property 'className' does not exist on type *.
 src/js/components/DSLInputField.tsx: error TS2339: Property 'inputContainerClass' does not exist on type *.
 src/js/components/DSLInputField.tsx: error TS2339: Property 'inverseStyle' does not exist on type *.
-src/js/components/DSLInputField.tsx: error TS2339: Property 'expression' does not exist on type 'Readonly<{}>'.
-src/js/components/DSLInputField.tsx: error TS2339: Property 'focus' does not exist on type 'Readonly<{}>'.
-src/js/components/DSLInputField.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 src/js/components/DSLInputField.tsx: error TS2339: Property 'expression' does not exist on type *.
-src/js/components/DSLInputField.tsx: error TS2339: Property 'expression' does not exist on type 'Readonly<{}>'.
 src/js/components/DSLInputField.tsx: error TS6133: 'prevProps' is declared but its value is never read.
-src/js/components/DSLInputField.tsx: error TS2339: Property 'focus' does not exist on type 'Readonly<{}>'.
 src/js/components/DSLInputField.tsx: error TS2339: Property 'inputField' does not exist on type 'DSLInputField'.
 src/js/components/DSLInputField.tsx: error TS2339: Property 'inputField' does not exist on type 'DSLInputField'.
+src/js/components/DSLInputField.tsx: error TS2339: Property 'onBlur' does not exist on type *.
 src/js/components/DetailViewHeader.tsx: error TS2448: Block-scoped variable 'classPropType' used before its declaration.
 src/js/components/DetailViewHeader.tsx: error TS2448: Block-scoped variable 'classPropType' used before its declaration.
 src/js/components/DetailViewHeader.tsx: error TS2448: Block-scoped variable 'classPropType' used before its declaration.
@@ -4865,9 +4196,6 @@ src/js/components/FilterButtons.tsx: error TS2339: Property 'itemList' does not 
 src/js/components/FilterButtons.tsx: error TS2339: Property 'selectedFilter' does not exist on type *.
 src/js/components/FilterButtons.tsx: error TS2339: Property 'renderButtonContent' does not exist on type *.
 src/js/components/FluidGeminiScrollbar.tsx: error TS2339: Property 'className' does not exist on type *.
-src/js/components/FluidGeminiScrollbar.tsx: error TS2339: Property 'geminiRef' does not exist on type 'FluidGeminiScrollbar'.
-src/js/components/FluidGeminiScrollbar.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-src/js/components/FluidGeminiScrollbar.tsx: error TS2339: Property 'geminiRef' does not exist on type 'FluidGeminiScrollbar'.
 src/js/components/FluidGeminiScrollbar.tsx: error TS2531: Object is possibly 'null'.
 src/js/components/FluidGeminiScrollbar.tsx: error TS2322: Type 'HTMLStyleElement' is not assignable to type 'null'.
 src/js/components/FluidGeminiScrollbar.tsx: error TS2531: Object is possibly 'null'.
@@ -4878,7 +4206,6 @@ src/js/components/FluidGeminiScrollbar.tsx: error TS2345: Argument of type 'null
 src/js/components/FluidGeminiScrollbar.tsx: error TS2358: The left-hand side of an 'instanceof' expression must be of type 'any', an object type or a type parameter.
 src/js/components/FluidGeminiScrollbar.tsx: error TS2531: Object is possibly 'null'.
 src/js/components/FluidGeminiScrollbar.tsx: error TS2531: Object is possibly 'null'.
-src/js/components/FormModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
 src/js/components/FormModal.tsx: error TS2322: type * is not assignable to type 'string'.
 src/js/components/FormModal.tsx: error TS2339: Property 'disabled' does not exist on type *.
 src/js/components/FormModal.tsx: error TS2339: Property 'extraFooterContent' does not exist on type *.
@@ -4886,26 +4213,19 @@ src/js/components/FormModal.tsx: error TS2339: Property 'disabled' does not exis
 src/js/components/FormModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
 src/js/components/FormModal.tsx: error TS2339: Property 'open' does not exist on type *.
 src/js/components/FormModal.tsx: error TS2339: Property 'modalProps' does not exist on type *.
-src/js/components/FormModal.tsx: error TS2339: Property 'formWrapperRef' does not exist on type 'FormModal'.
+src/js/components/FormModal.tsx: error TS2322: Type 'RefObject<unknown>' is not assignable to type *.
 src/js/components/FormModal.tsx: error TS2339: Property 'contentClasses' does not exist on type *.
 src/js/components/FormModal.tsx: error TS2339: Property 'contentFooter' does not exist on type *.
 src/js/components/FormModal.tsx: error TS2339: Property 'definition' does not exist on type *.
 src/js/components/FormModal.tsx: error TS2339: Property 'onSubmit' does not exist on type *.
 src/js/components/FormModal.tsx: error TS2339: Property 'onChange' does not exist on type *.
 src/js/components/FormModal.tsx: error TS2339: Property 'contentFooter' does not exist on type *.
-src/js/components/FormModal.tsx: error TS2554: Expected 1-2 arguments, but got 0.
-src/js/components/FormModal.tsx: error TS2339: Property 'triggerSubmit' does not exist on type 'FormModal'.
-src/js/components/FormModal.tsx: error TS2339: Property 'formWrapperRef' does not exist on type 'FormModal'.
 src/js/components/FormModal.tsx: error TS2339: Property 'open' does not exist on type *.
-src/js/components/FormModal.tsx: error TS2339: Property 'triggerSubmit' does not exist on type 'FormModal'.
-src/js/components/FormModal.tsx: error TS2339: Property 'triggerSubmit' does not exist on type 'FormModal'.
-src/js/components/FormModal.tsx: error TS2339: Property 'triggerSubmit' does not exist on type 'FormModal'.
-src/js/components/FormModal.tsx: error TS2339: Property 'formWrapperRef' does not exist on type 'FormModal'.
-src/js/components/FormModal.tsx: error TS2339: Property 'formWrapperRef' does not exist on type 'FormModal'.
-src/js/components/FormModal.tsx: error TS2339: Property 'formWrapperRef' does not exist on type 'FormModal'.
+src/js/components/FormModal.tsx: error TS2571: Object is of type 'unknown'.
 src/js/components/FormModal.tsx: error TS2339: Property 'buttonDefinition' does not exist on type *.
 src/js/components/FormModal.tsx: error TS2339: Property 'disabled' does not exist on type *.
 src/js/components/FormModal.tsx: error TS2322: Type 'string' is not assignable to type *.
+src/js/components/FormModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
 src/js/components/FrameworkConfiguration.tsx: error TS2339: Property 'handleRun' does not exist on type *.
 src/js/components/FrameworkConfiguration.tsx: error TS2339: Property 'reviewActive' does not exist on type 'Readonly<{}>'.
 src/js/components/FrameworkConfiguration.tsx: error TS2339: Property 'submitButton' does not exist on type 'FrameworkConfiguration'.
@@ -4968,7 +4288,6 @@ src/js/components/FrameworkConfigurationForm.tsx: error TS2339: Property 'liveVa
 src/js/components/FrameworkConfigurationForm.tsx: error TS2339: Property 'schemaForm' does not exist on type 'FrameworkConfigurationForm'.
 src/js/components/FrameworkConfigurationForm.tsx: error TS2339: Property 'onFormErrorChange' does not exist on type *.
 src/js/components/FrameworkConfigurationForm.tsx: error TS2339: Property 'packageDetails' does not exist on type *.
-src/js/components/FrameworkConfigurationForm.tsx: error TS2339: Property 'errorSchema' does not exist on type 'Readonly<{}>'.
 src/js/components/FrameworkConfigurationForm.tsx: error TS2339: Property 'packageDetails' does not exist on type *.
 src/js/components/FrameworkConfigurationForm.tsx: error TS2339: Property 'jsonEditorActive' does not exist on type *.
 src/js/components/FrameworkConfigurationForm.tsx: error TS2339: Property 'formData' does not exist on type *.
@@ -4982,11 +4301,13 @@ src/js/components/FrameworkConfigurationForm.tsx: error TS2322: Type 'Element' i
 src/js/components/FrameworkConfigurationForm.tsx: error TS2769: No overload matches this call.
 src/js/components/FrameworkConfigurationForm.tsx: error TS2339: Property 'schemaForm' does not exist on type 'FrameworkConfigurationForm'.
 src/js/components/FrameworkConfigurationForm.tsx: error TS2322: type * is not assignable to type *.
-src/js/components/FrameworkConfigurationForm.tsx: error TS2339: Property 'editorWidth' does not exist on type 'Readonly<{}>'.
-src/js/components/FrameworkConfigurationForm.tsx: error TS2339: Property 'editorWidth' does not exist on type 'Readonly<{}>'.
-src/js/components/FrameworkConfigurationForm.tsx: error TS2339: Property 'errorSchema' does not exist on type 'Readonly<{}>'.
+src/js/components/FrameworkConfigurationForm.tsx: error TS2339: Property 'editorWidth' does not exist on type *.
+src/js/components/FrameworkConfigurationForm.tsx: error TS2339: Property 'editorWidth' does not exist on type *.
 src/js/components/FrameworkConfigurationForm.tsx: error TS2339: Property 'formData' does not exist on type *.
 src/js/components/FrameworkConfigurationForm.tsx: error TS2339: Property 'handleFocusFieldChange' does not exist on type *.
+src/js/components/FrameworkConfigurationForm.tsx: error TS2531: Object is possibly 'null'.
+src/js/components/FrameworkConfigurationForm.tsx: error TS2531: Object is possibly 'null'.
+src/js/components/FrameworkConfigurationForm.tsx: error TS2531: Object is possibly 'null'.
 src/js/components/FrameworkConfigurationReviewScreen.tsx: error TS2339: Property 'frameworkData' does not exist on type *.
 src/js/components/FrameworkConfigurationReviewScreen.tsx: error TS2339: Property 'frameworkData' does not exist on type *.
 src/js/components/FrameworkConfigurationReviewScreen.tsx: error TS2339: Property 'title' does not exist on type *.
@@ -4995,7 +4316,6 @@ src/js/components/FrameworkConfigurationReviewScreen.tsx: error TS2339: Property
 src/js/components/FrameworkConfigurationReviewScreen.tsx: error TS2339: Property 'frameworkMeta' does not exist on type *.
 src/js/components/HashMapDisplay.tsx: error TS2339: Property 'emptyValue' does not exist on type *.
 src/js/components/HashMapDisplay.tsx: error TS2339: Property 'emptyValue' does not exist on type *.
-src/js/components/HashMapDisplay.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 src/js/components/HashMapDisplay.tsx: error TS2339: Property 'headline' does not exist on type *.
 src/js/components/HashMapDisplay.tsx: error TS2339: Property 'headlineClassName' does not exist on type *.
 src/js/components/HashMapDisplay.tsx: error TS2339: Property 'headingLevel' does not exist on type *.
@@ -5004,21 +4324,17 @@ src/js/components/HashMapDisplay.tsx: error TS2339: Property 'headline' does not
 src/js/components/HashMapDisplay.tsx: error TS2339: Property 'hash' does not exist on type *.
 src/js/components/HashMapDisplay.tsx: error TS2339: Property 'renderKeys' does not exist on type *.
 src/js/components/HashMapDisplay.tsx: error TS2339: Property 'hash' does not exist on type *.
-src/js/components/Image.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 src/js/components/Image.tsx: error TS2339: Property 'src' does not exist on type *.
 src/js/components/Image.tsx: error TS2339: Property 'fallbackSrc' does not exist on type *.
 src/js/components/Image.tsx: error TS2339: Property 'fallbackSrc' does not exist on type *.
-src/js/components/Image.tsx: error TS2339: Property 'imageErrorCount' does not exist on type 'Readonly<{}>'.
-src/js/components/Image.tsx: error TS2339: Property 'imageErrorCount' does not exist on type 'Readonly<{}>'.
 src/js/components/Image.tsx: error TS2339: Property 'className' does not exist on type *.
 src/js/components/Image.tsx: error TS2339: Property 'src' does not exist on type *.
-src/js/components/ImageViewer.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-src/js/components/ImageViewer.tsx: error TS2339: Property 'selectedImage' does not exist on type 'Readonly<{}>'.
 src/js/components/ImageViewer.tsx: error TS2339: Property 'images' does not exist on type *.
-src/js/components/ImageViewer.tsx: error TS2339: Property 'selectedImage' does not exist on type 'Readonly<{}>'.
+src/js/components/ImageViewer.tsx: error TS2531: Object is possibly 'null'.
+src/js/components/ImageViewer.tsx: error TS2322: Type 'number' is not assignable to type 'null'.
 src/js/components/ImageViewer.tsx: error TS2339: Property 'images' does not exist on type *.
+src/js/components/ImageViewer.tsx: error TS2531: Object is possibly 'null'.
 src/js/components/ImageViewer.tsx: error TS2339: Property 'images' does not exist on type *.
-src/js/components/ImageViewer.tsx: error TS2339: Property 'selectedImage' does not exist on type 'Readonly<{}>'.
 src/js/components/ImageViewer.tsx: error TS2322: type * is not assignable to type *.
 src/js/components/JSONEditor.tsx: error TS2339: Property 'externalErrors' does not exist on type 'JSONEditor'.
 src/js/components/JSONEditor.tsx: error TS2339: Property 'errors' does not exist on type *.
@@ -5090,14 +4406,10 @@ src/js/components/Loader.tsx: error TS2339: Property 'flip' does not exist on ty
 src/js/components/Loader.tsx: error TS2339: Property 'size' does not exist on type *.
 src/js/components/Loader.tsx: error TS2339: Property 'type' does not exist on type *.
 src/js/components/Loader.tsx: error TS2339: Property 'suppressHorizontalCenter' does not exist on type *.
-src/js/components/ManualBreadcrumbs.tsx: error TS2339: Property 'collapsed' does not exist on type 'Readonly<{}>'.
-src/js/components/ManualBreadcrumbs.tsx: error TS2339: Property 'collapsed' does not exist on type 'Readonly<{}>'.
 src/js/components/ManualBreadcrumbs.tsx: error TS2339: Property 'breadcrumbClasses' does not exist on type *.
 src/js/components/ManualBreadcrumbs.tsx: error TS2339: Property 'crumbs' does not exist on type *.
 src/js/components/ManualBreadcrumbs.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-src/js/components/ManualBreadcrumbs.tsx: error TS2339: Property 'collapsed' does not exist on type 'Readonly<{}>'.
-src/js/components/ManualBreadcrumbs.tsx: error TS2339: Property 'expandedWidth' does not exist on type 'Readonly<{}>'.
-src/js/components/Modals.tsx: error TS2322: type * is not assignable to type *.
+src/js/components/Modals.tsx: error TS2769: No overload matches this call.
 src/js/components/Modals.tsx: error TS2345: Argument of type '\\"isVisible\\"' is not assignable to parameter of type 'never'.
 src/js/components/Modals.tsx: error TS2322: type * is not assignable to type *.
 src/js/components/Modals.tsx: error TS2339: Property 'modalErrorMsg' does not exist on type *.
@@ -5106,7 +4418,7 @@ src/js/components/NestedServiceLinks.tsx: error TS2339: Property 'serviceID' doe
 src/js/components/NestedServiceLinks.tsx: error TS2345: Argument of type 'Element' is not assignable to parameter of type 'never'.
 src/js/components/NestedServiceLinks.tsx: error TS2345: Argument of type 'Element' is not assignable to parameter of type 'never'.
 src/js/components/NestedServiceLinks.tsx: error TS2339: Property 'serviceLink' does not exist on type *.
-src/js/components/Page.tsx: error TS2322: type * is not assignable to type *.
+src/js/components/Page.tsx: error TS2769: No overload matches this call.
 src/js/components/PageHeaderActions.tsx: error TS2339: Property 'supplementalContent' does not exist on type *.
 src/js/components/PageHeaderActions.tsx: error TS2322: type * is not assignable to type *.
 src/js/components/PageHeaderActions.tsx: error TS7030: Not all code paths return a value.
@@ -5124,7 +4436,6 @@ src/js/components/PageHeaderNavigationDropdown.tsx: error TS2339: Property 'item
 src/js/components/PageHeaderNavigationDropdown.tsx: error TS2339: Property 'handleNavigationItemSelection' does not exist on type *.
 src/js/components/PageHeaderTabs.tsx: error TS2769: No overload matches this call.
 src/js/components/PageHeaderTabs.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
-src/js/components/PageHeaderTabs.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 src/js/components/PageHeaderTabs.tsx: error TS2339: Property 'tabs' does not exist on type *.
 src/js/components/PageHeaderTabs.tsx: error TS2339: Property 'tabs' does not exist on type *.
 src/js/components/PageHeaderTabs.tsx: error TS2339: Property 'tabs' does not exist on type *.
@@ -5181,7 +4492,7 @@ src/js/components/SchemaField.tsx: error TS2339: Property 'errorSchema' does not
 src/js/components/SchemaField.tsx: error TS2339: Property 'schema' does not exist on type *.
 src/js/components/SchemaField.tsx: error TS2339: Property 'required' does not exist on type *.
 src/js/components/SchemaField.tsx: error TS2339: Property 'name' does not exist on type *.
-src/js/components/SchemaField.tsx: error TS2322: type * is not assignable to type *.
+src/js/components/SchemaField.tsx: error TS2769: No overload matches this call.
 src/js/components/SchemaField.tsx: error TS2339: Property 'schema' does not exist on type *.
 src/js/components/SchemaField.tsx: error TS2339: Property 'errorSchema' does not exist on type *.
 src/js/components/SchemaField.tsx: error TS2339: Property 'uiSchema' does not exist on type *.
@@ -5195,14 +4506,8 @@ src/js/components/SchemaField.tsx: error TS2322: type * is not assignable to typ
 src/js/components/ServerErrorModal.tsx: error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
 src/js/components/ServerErrorModal.tsx: error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
 src/js/components/ServerErrorModal.tsx: error TS2554: Expected 1-2 arguments, but got 0.
-src/js/components/ServerErrorModal.tsx: error TS2339: Property 'store_listeners' does not exist on type 'ServerErrorModal'.
-src/js/components/ServerErrorModal.tsx: error TS2339: Property 'store_listeners' does not exist on type 'ServerErrorModal'.
 src/js/components/ServerErrorModal.tsx: error TS2322: type * is not assignable to type 'never'.
-src/js/components/ServerErrorModal.tsx: error TS2339: Property 'errors' does not exist on type 'Readonly<{}>'.
-src/js/components/ServerErrorModal.tsx: error TS2339: Property 'errors' does not exist on type 'Readonly<{}>'.
-src/js/components/ServerErrorModal.tsx: error TS2339: Property 'isOpen' does not exist on type 'Readonly<{}>'.
-src/js/components/SideTabs.tsx: error TS2554: Expected 1-2 arguments, but got 0.
-src/js/components/SideTabs.tsx: error TS2339: Property 'dropdownOpen' does not exist on type 'Readonly<{}>'.
+src/js/components/ServerErrorModal.tsx: error TS2769: No overload matches this call.
 src/js/components/SideTabs.tsx: error TS2339: Property 'onTabClick' does not exist on type *.
 src/js/components/SideTabs.tsx: error TS2339: Property 'selectedTab' does not exist on type *.
 src/js/components/SideTabs.tsx: error TS2339: Property 'selectedTab' does not exist on type *.
@@ -5210,14 +4515,16 @@ src/js/components/SideTabs.tsx: error TS2339: Property 'tabs' does not exist on 
 src/js/components/SideTabs.tsx: error TS2339: Property 'className' does not exist on type *.
 src/js/components/SideTabs.tsx: error TS2339: Property 'selectedTab' does not exist on type *.
 src/js/components/SideTabs.tsx: error TS2339: Property 'tabs' does not exist on type *.
-src/js/components/SideTabs.tsx: error TS2339: Property 'dropdownOpen' does not exist on type 'Readonly<{}>'.
-src/js/components/Sidebar.tsx: error TS2339: Property 'expandedItems' does not exist on type 'Readonly<{}>'.
+src/js/components/Sidebar.tsx: error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
+src/js/components/Sidebar.tsx: error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
 src/js/components/Sidebar.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
-src/js/components/Sidebar.tsx: error TS2339: Property 'expandedItems' does not exist on type 'Readonly<{}>'.
+src/js/components/Sidebar.tsx: error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
 src/js/components/Sidebar.tsx: error TS2322: type * is not assignable to type 'boolean'.
+src/js/components/SplitPanel.tsx: error TS2339: Property 'sidePanelWidth' does not exist on type *.
+src/js/components/SplitPanel.tsx: error TS2339: Property 'sidePanelWidth' does not exist on type *.
+src/js/components/SplitPanel.tsx: error TS2339: Property 'sidePanelWidth' does not exist on type *.
 src/js/components/TabButton.tsx: error TS2448: Block-scoped variable 'classProps' used before its declaration.
 src/js/components/TabButton.tsx: error TS2448: Block-scoped variable 'classProps' used before its declaration.
-src/js/components/TabButton.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 src/js/components/TabButton.tsx: error TS2339: Property 'activeTab' does not exist on type *.
 src/js/components/TabButton.tsx: error TS2339: Property 'onClick' does not exist on type *.
 src/js/components/TabButton.tsx: error TS2533: Object is possibly 'null' or 'undefined'.
@@ -5245,30 +4552,22 @@ src/js/components/TabButtonList.tsx: error TS2339: Property 'active' does not ex
 src/js/components/TabButtonList.tsx: error TS2769: No overload matches this call.
 src/js/components/TabButtonList.tsx: error TS2339: Property 'className' does not exist on type *.
 src/js/components/TabButtonList.tsx: error TS2339: Property 'vertical' does not exist on type *.
-src/js/components/TabForm.tsx: error TS2339: Property 'currentTab' does not exist on type 'Readonly<{}>'.
 src/js/components/TabForm.tsx: error TS2339: Property 'navigationContentClassNames' does not exist on type *.
-src/js/components/TabForm.tsx: error TS2339: Property 'currentTab' does not exist on type 'Readonly<{}>'.
 src/js/components/TabForm.tsx: error TS2339: Property 'definition' does not exist on type *.
 src/js/components/TabForm.tsx: error TS2339: Property 'formContentClassNames' does not exist on type *.
 src/js/components/TabForm.tsx: error TS2339: Property 'formRowClass' does not exist on type *.
 src/js/components/TabForm.tsx: error TS2339: Property 'onChange' does not exist on type *.
-src/js/components/TabForm.tsx: error TS2339: Property 'renderGemini' does not exist on type 'Readonly<{}>'.
-src/js/components/TabForm.tsx: error TS2339: Property 'geminiRef' does not exist on type 'TabForm'.
 src/js/components/TabForm.tsx: error TS2339: Property 'className' does not exist on type *.
 src/js/components/TabForm.tsx: error TS2339: Property 'definition' does not exist on type *.
 src/js/components/TabForm.tsx: error TS2448: Block-scoped variable 'classPropType' used before its declaration.
 src/js/components/TabForm.tsx: error TS2448: Block-scoped variable 'classPropType' used before its declaration.
 src/js/components/TabForm.tsx: error TS2448: Block-scoped variable 'classPropType' used before its declaration.
 src/js/components/TabForm.tsx: error TS2448: Block-scoped variable 'classPropType' used before its declaration.
-src/js/components/TabForm.tsx: error TS2554: Expected 1-2 arguments, but got 0.
-src/js/components/TabForm.tsx: error TS2339: Property 'geminiRef' does not exist on type 'TabForm'.
-src/js/components/TabForm.tsx: error TS2339: Property 'triggerSubmit' does not exist on type 'TabForm'.
 src/js/components/TabForm.tsx: error TS2339: Property 'model' does not exist on type 'TabForm'.
 src/js/components/TabForm.tsx: error TS2339: Property 'submitMap' does not exist on type 'TabForm'.
 src/js/components/TabForm.tsx: error TS2339: Property 'defaultTab' does not exist on type *.
 src/js/components/TabForm.tsx: error TS2339: Property 'definition' does not exist on type *.
 src/js/components/TabForm.tsx: error TS2339: Property 'getTriggerSubmit' does not exist on type *.
-src/js/components/TabForm.tsx: error TS2339: Property 'geminiRef' does not exist on type 'TabForm'.
 src/js/components/TabForm.tsx: error TS2339: Property 'onTabClick' does not exist on type *.
 src/js/components/TabForm.tsx: error TS2662: Cannot find name 'arguments'. Did you mean the static member 'TabForm.arguments'?
 src/js/components/TabForm.tsx: error TS2339: Property 'isFormValidated' does not exist on type 'TabForm'.
@@ -5311,7 +4610,6 @@ src/js/components/TimeAgo.tsx: error TS2448: Block-scoped variable 'MINUTE' used
 src/js/components/TimeAgo.tsx: error TS2339: Property 'className' does not exist on type *.
 src/js/components/TimeAgo.tsx: error TS2448: Block-scoped variable 'HOUR' used before its declaration.
 src/js/components/TimeAgo.tsx: error TS2448: Block-scoped variable 'DAY' used before its declaration.
-src/js/components/ToggleValue.tsx: error TS2339: Property 'toggled' does not exist on type 'Readonly<{}>'.
 src/js/components/ToggleValue.tsx: error TS2339: Property 'primaryValue' does not exist on type *.
 src/js/components/ToggleValue.tsx: error TS2339: Property 'secondaryValue' does not exist on type *.
 src/js/components/Typeahead.tsx: error TS2339: Property 'emptyLabel' does not exist on type *.
@@ -5322,34 +4620,24 @@ src/js/components/Typeahead.tsx: error TS2339: Property 'selected' does not exis
 src/js/components/Typeahead.tsx: error TS2769: No overload matches this call.
 src/js/components/Typeahead.tsx: error TS2554: Expected 2 arguments, but got 1.
 src/js/components/Typeahead.tsx: error TS2417: Class static side 'typeof Typeahead' incorrectly extends base class static side 'typeof FilterInputText'.
-src/js/components/UnitHealthDropdown.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 src/js/components/UnitHealthDropdown.tsx: error TS2339: Property 'dropdown' does not exist on type 'UnitHealthDropdown'.
 src/js/components/UnitHealthDropdown.tsx: error TS2339: Property 'className' does not exist on type *.
 src/js/components/UnitHealthDropdown.tsx: error TS2339: Property 'dropdownMenuClassName' does not exist on type *.
 src/js/components/UnitHealthDropdown.tsx: error TS2339: Property 'initialID' does not exist on type *.
 src/js/components/UnitHealthDropdown.tsx: error TS2339: Property 'onHealthSelection' does not exist on type *.
-src/js/components/UnitHealthDropdown.tsx: error TS2339: Property 'dropdownItems' does not exist on type 'Readonly<{}>'.
 src/js/components/UnitHealthDropdown.tsx: error TS2339: Property 'dropdown' does not exist on type 'UnitHealthDropdown'.
 src/js/components/UnitHealthNodesTable.tsx: error TS2339: Property 'nodes' does not exist on type *.
-src/js/components/UnitHealthNodesTable.tsx: error TS2554: Expected 1-2 arguments, but got 0.
 src/js/components/UnitHealthNodesTable.tsx: error TS2339: Property 'params' does not exist on type *.
 src/js/components/UnitHealthNodesTable.tsx: error TS6133: 'prop' is declared but its value is never read.
-src/js/components/UnitsHealthNodeDetail.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-src/js/components/UnitsHealthNodeDetail.tsx: error TS2339: Property 'store_listeners' does not exist on type 'UnitsHealthNodeDetail'.
 src/js/components/UnitsHealthNodeDetail.tsx: error TS2556: Expected 0 arguments, but got 1 or more.
 src/js/components/UnitsHealthNodeDetail.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
 src/js/components/UnitsHealthNodeDetail.tsx: error TS2339: Property 'params' does not exist on type *.
-src/js/components/UnitsHealthNodeDetail.tsx: error TS2339: Property 'hasError' does not exist on type 'Readonly<{}>'.
-src/js/components/UnitsHealthNodeDetail.tsx: error TS2339: Property 'isLoadingNode' does not exist on type 'Readonly<{}>'.
-src/js/components/UnitsHealthNodeDetail.tsx: error TS2339: Property 'isLoadingUnit' does not exist on type 'Readonly<{}>'.
 src/js/components/UnitsHealthNodeDetail.tsx: error TS2339: Property 'params' does not exist on type *.
 src/js/components/UnitsHealthNodeDetail.tsx: error TS2339: Property 'routes' does not exist on type *.
 src/js/components/UnitsHealthNodeDetail.tsx: error TS2322: type * is not assignable to type *.
 src/js/components/UnitsHealthNodeDetail.tsx: error TS2339: Property 'params' does not exist on type *.
 src/js/components/UserAccountDropdown.tsx: error TS2339: Property 'getTrigger' does not exist on type 'UserAccountDropdown'.
 src/js/components/UserAccountDropdown.tsx: error TS2339: Property 'getMenuItems' does not exist on type 'UserAccountDropdown'.
-src/js/components/UserAccountDropdownTrigger.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-src/js/components/UserAccountDropdownTrigger.tsx: error TS2339: Property 'store_listeners' does not exist on type 'UserAccountDropdownTrigger'.
 src/js/components/UserAccountDropdownTrigger.tsx: error TS2339: Property 'onUpdate' does not exist on type *.
 src/js/components/UserAccountDropdownTrigger.tsx: error TS2339: Property 'onUpdate' does not exist on type *.
 src/js/components/UserAccountDropdownTrigger.tsx: error TS2339: Property 'content' does not exist on type *.
@@ -5390,9 +4678,9 @@ src/js/components/__tests__/ProgressBar-test.tsx: error TS2769: No overload matc
 src/js/components/__tests__/SplitPanel-test.tsx: error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
 src/js/components/__tests__/SplitPanel-test.tsx: error TS2322: type * is not assignable to type *.
 src/js/components/__tests__/SplitPanel-test.tsx: error TS2322: type * is not assignable to type *.
-src/js/components/__tests__/TabButton-test.tsx: error TS2322: type * is not assignable to type *.
-src/js/components/__tests__/TabButton-test.tsx: error TS2322: type * is not assignable to type *.
-src/js/components/__tests__/TabButton-test.tsx: error TS2322: type * is not assignable to type *.
+src/js/components/__tests__/TabButton-test.tsx: error TS2769: No overload matches this call.
+src/js/components/__tests__/TabButton-test.tsx: error TS2769: No overload matches this call.
+src/js/components/__tests__/TabButton-test.tsx: error TS2769: No overload matches this call.
 src/js/components/charts/Chart.tsx: error TS7030: Not all code paths return a value.
 src/js/components/charts/ChartStripes.tsx: error TS2554: Expected 1-3 arguments, but got 0.
 src/js/components/charts/ChartStripes.tsx: error TS6133: 'v' is declared but its value is never read.
@@ -5403,43 +4691,33 @@ src/js/components/charts/DialChart.tsx: error TS2683: 'this' implicitly has type
 src/js/components/charts/DialChart.tsx: error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
 src/js/components/charts/DialChart.tsx: error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
 src/js/components/charts/DialChart.tsx: error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
-src/js/components/charts/HostTimeSeriesChart.tsx: error TS2322: type * is not assignable to type *.
+src/js/components/charts/HostTimeSeriesChart.tsx: error TS2769: No overload matches this call.
 src/js/components/charts/ResourceTimeSeriesChart.tsx: error TS2554: Expected 5 arguments, but got 2.
 src/js/components/charts/ResourceTimeSeriesChart.tsx: error TS2554: Expected 5 arguments, but got 2.
-src/js/components/charts/ResourceTimeSeriesChart.tsx: error TS2322: type * is not assignable to type *.
+src/js/components/charts/ResourceTimeSeriesChart.tsx: error TS2769: No overload matches this call.
 src/js/components/charts/ResourceTimeSeriesChart.tsx: error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
 src/js/components/charts/ResourceTimeSeriesChart.tsx: error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
-src/js/components/charts/TimeSeriesChart.tsx: error TS2345: Argument of type * is not assignable to parameter of type *.
-src/js/components/charts/TimeSeriesChart.tsx: error TS2345: Argument of type * is not assignable to parameter of type *.
 src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'movingElsRef' does not exist on type 'TimeSeriesChart'.
-src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'clipPathID' does not exist on type 'TimeSeriesChart'.
-src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'clipPathID' does not exist on type 'TimeSeriesChart'.
 src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'y' does not exist on type *.
 src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'y' does not exist on type *.
 src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'xAxisRef' does not exist on type 'TimeSeriesChart'.
 src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'yAxisRef' does not exist on type 'TimeSeriesChart'.
 src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'gridRef' does not exist on type 'TimeSeriesChart'.
-src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'clipPathID' does not exist on type 'TimeSeriesChart'.
-src/js/components/charts/TimeSeriesChart.tsx: error TS2554: Expected 1 arguments, but got 0.
 src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'data' does not exist on type *.
 src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'height' does not exist on type *.
 src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'margin' does not exist on type *.
 src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'maxY' does not exist on type *.
 src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'refreshRate' does not exist on type *.
-src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'maskID' does not exist on type 'TimeSeriesChart'.
-src/js/components/charts/TimeSeriesChart.tsx: error TS2554: Expected 1 arguments, but got 0.
 src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'width' does not exist on type *.
 src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'yFormat' does not exist on type *.
 src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'y' does not exist on type *.
+src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'values' does not exist on type 'never'.
 src/js/components/charts/TimeSeriesChart.tsx: error TS2345: Argument of type * is not assignable to parameter of type *.
 src/js/components/charts/TimeSeriesChart.tsx: error TS2345: Argument of type * is not assignable to parameter of type *.
-src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'clipPathID' does not exist on type 'TimeSeriesChart'.
-src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'maskID' does not exist on type 'TimeSeriesChart'.
 src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'gridRef' does not exist on type 'TimeSeriesChart'.
 src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'yAxisRef' does not exist on type 'TimeSeriesChart'.
 src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'xAxisRef' does not exist on type 'TimeSeriesChart'.
 src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'data' does not exist on type *.
-src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'values' does not exist on type 'never'.
 src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'movingElsRef' does not exist on type 'TimeSeriesChart'.
 src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'axisConfiguration' does not exist on type *.
 src/js/components/charts/TimeSeriesChart.tsx: error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
@@ -5448,18 +4726,15 @@ src/js/components/charts/TimeSeriesChart.tsx: error TS2345: Argument of type * i
 src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'data' does not exist on type *.
 src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'y' does not exist on type *.
 src/js/components/charts/TimeSeriesChart.tsx: error TS2339: Property 'y' does not exist on type *.
+src/js/components/charts/TimeSeriesChart.tsx: error TS2345: Argument of type * is not assignable to parameter of type *.
+src/js/components/charts/TimeSeriesChart.tsx: error TS2345: Argument of type * is not assignable to parameter of type *.
 src/js/components/charts/__tests__/TasksChart-test.tsx: error TS2769: No overload matches this call.
-src/js/components/charts/__tests__/TimeSeriesChart-test.tsx: error TS2322: type * is not assignable to type *.
-src/js/components/form/AdvancedSection.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-src/js/components/form/AdvancedSection.tsx: error TS2339: Property 'isExpanded' does not exist on type 'Readonly<{}>'.
+src/js/components/charts/__tests__/TimeSeriesChart-test.tsx: error TS2769: No overload matches this call.
 src/js/components/form/AdvancedSection.tsx: error TS2533: Object is possibly 'null' or 'undefined'.
 src/js/components/form/AdvancedSection.tsx: error TS2339: Property 'type' does not exist on type *.
 src/js/components/form/AdvancedSection.tsx: error TS2769: No overload matches this call.
-src/js/components/form/AdvancedSection.tsx: error TS2339: Property 'isExpanded' does not exist on type 'Readonly<{}>'.
 src/js/components/form/AdvancedSection.tsx: error TS2533: Object is possibly 'null' or 'undefined'.
 src/js/components/form/AdvancedSection.tsx: error TS2339: Property 'type' does not exist on type *.
-src/js/components/form/AdvancedSection.tsx: error TS2339: Property 'isExpanded' does not exist on type 'Readonly<{}>'.
-src/js/components/form/AdvancedSection.tsx: error TS2339: Property 'className' does not exist on type *.
 src/js/components/form/FieldAutofocus.ts: error TS2339: Property 'focus' does not exist on type 'Element'.
 src/js/components/form/FieldAutofocus.ts: error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
 src/js/components/form/FormGroup.tsx: error TS2339: Property 'type' does not exist on type *.
@@ -5473,25 +4748,16 @@ src/js/components/modals/ActionsModal.tsx: error TS7030: Not all code paths retu
 src/js/components/modals/ActionsModal.tsx: error TS7030: Not all code paths return a value.
 src/js/components/modals/ActionsModal.tsx: error TS2339: Property 'action' does not exist on type *.
 src/js/components/modals/ActionsModal.tsx: error TS2339: Property 'actionText' does not exist on type *.
-src/js/components/modals/ActionsModal.tsx: error TS2339: Property 'pendingRequest' does not exist on type 'Readonly<{}>'.
-src/js/components/modals/ActionsModal.tsx: error TS2339: Property 'pendingRequest' does not exist on type 'Readonly<{}>'.
 src/js/components/modals/ActionsModal.tsx: error TS2339: Property 'handleButtonConfirm' does not exist on type 'ActionsModal'.
 src/js/components/modals/ActionsModal.tsx: error TS2339: Property 'handleButtonConfirm' does not exist on type 'ActionsModal'.
 src/js/components/modals/ActionsModal.tsx: error TS2339: Property 'handleButtonConfirm' does not exist on type 'ActionsModal'.
 src/js/components/modals/ActionsModal.tsx: error TS2339: Property 'selectedItems' does not exist on type *.
 src/js/components/modals/ActionsModal.tsx: error TS6133: 'nextProps' is declared but its value is never read.
-src/js/components/modals/ActionsModal.tsx: error TS2339: Property 'requestsRemaining' does not exist on type 'Readonly<{}>'.
 src/js/components/modals/ActionsModal.tsx: error TS2339: Property 'selectedItems' does not exist on type *.
 src/js/components/modals/ActionsModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
-src/js/components/modals/ActionsModal.tsx: error TS2339: Property 'requestErrors' does not exist on type 'Readonly<{}>'.
-src/js/components/modals/ActionsModal.tsx: error TS2339: Property 'requestErrors' does not exist on type 'Readonly<{}>'.
-src/js/components/modals/ActionsModal.tsx: error TS2339: Property 'requestsRemaining' does not exist on type 'Readonly<{}>'.
-src/js/components/modals/ActionsModal.tsx: error TS2339: Property 'requestsRemaining' does not exist on type 'Readonly<{}>'.
+src/js/components/modals/ActionsModal.tsx: error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
 src/js/components/modals/ActionsModal.tsx: error TS2339: Property 'itemType' does not exist on type *.
-src/js/components/modals/ActionsModal.tsx: error TS2339: Property 'requestErrors' does not exist on type 'Readonly<{}>'.
-src/js/components/modals/ActionsModal.tsx: error TS2339: Property 'validationError' does not exist on type 'Readonly<{}>'.
 src/js/components/modals/FullScreenModal.tsx: error TS2322: Type '\\"100%\\"' is not assignable to type 'null'.
-src/js/components/modals/ImageViewerModal.tsx: error TS2339: Property 'isLoadingImage' does not exist on type 'Readonly<{}>'.
 src/js/components/modals/ImageViewerModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
 src/js/components/modals/ImageViewerModal.tsx: error TS2339: Property 'open' does not exist on type *.
 src/js/components/modals/ImageViewerModal.tsx: error TS2339: Property 'images' does not exist on type *.
@@ -5509,28 +4775,19 @@ src/js/components/modals/ImageViewerModal.tsx: error TS2339: Property 'selectedI
 src/js/components/modals/JobStopRunModal.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 src/js/components/modals/JobStopRunModal.tsx: error TS2339: Property 'jobID' does not exist on type *.
 src/js/components/modals/JobStopRunModal.tsx: error TS2339: Property 'jobRunID' does not exist on type *.
-src/js/components/modals/JobStopRunModal.tsx: error TS2339: Property 'pendingRequest' does not exist on type 'Readonly<{}>'.
 src/js/components/modals/JobStopRunModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
 src/js/components/modals/JobStopRunModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
-src/js/components/modals/JobStopRunModal.tsx: error TS2339: Property 'pendingRequest' does not exist on type 'Readonly<{}>'.
 src/js/components/modals/JobStopRunModal.tsx: error TS2339: Property 'jobRunID' does not exist on type *.
-src/js/components/modals/LanguagePreferenceFormModal.tsx: error TS2339: Property 'isOpen' does not exist on type 'Readonly<{}>'.
+src/js/components/modals/LanguagePreferenceFormModal.tsx: error TS2339: Property 'isOpen' does not exist on type *.
 src/js/components/modals/LanguagePreferenceFormModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
 src/js/components/modals/LanguagePreferenceFormModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
-src/js/components/modals/LanguagePreferenceFormModal.tsx: error TS2339: Property 'isOpen' does not exist on type 'Readonly<{}>'.
-src/js/components/modals/UserFormModal.tsx: error TS2339: Property 'errorMsg' does not exist on type 'Readonly<{}>'.
-src/js/components/modals/UserFormModal.tsx: error TS2339: Property 'disableNewUser' does not exist on type 'Readonly<{}>'.
-src/js/components/modals/UserFormModal.tsx: error TS2554: Expected 1-2 arguments, but got 0.
 src/js/components/modals/UserFormModal.tsx: error TS2339: Property 'open' does not exist on type *.
-src/js/components/modals/UserFormModal.tsx: error TS2339: Property 'store_listeners' does not exist on type 'UserFormModal'.
 src/js/components/modals/UserFormModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
 src/js/components/modals/UserFormModal.tsx: error TS6133: 'userID' is declared but its value is never read.
 src/js/components/modals/UserFormModal.tsx: error TS2339: Property 'onClose' does not exist on type *.
 src/js/components/modals/UserFormModal.tsx: error TS2339: Property 'i18n' does not exist on type *.
-src/js/components/modals/UserFormModal.tsx: error TS2339: Property 'disableNewUser' does not exist on type 'Readonly<{}>'.
 src/js/components/modals/UsersActionsModal.ts: error TS2339: Property 'itemID' does not exist on type *.
 src/js/components/modals/UsersActionsModal.ts: error TS2339: Property 'selectedItems' does not exist on type *.
-src/js/components/modals/UsersActionsModal.ts: error TS2339: Property 'store_listeners' does not exist on type 'UsersActionsModal'.
 src/js/components/modals/__tests__/CliInstallModal-test.tsx: error TS2339: Property '__defineGetter__' does not exist on type 'Navigator'.
 src/js/components/modals/__tests__/LanguagePreferenceFormModal-test.tsx: error TS2322: type * is not assignable to type *.
 src/js/components/modals/__tests__/LanguagePreferenceFormModal-test.tsx: error TS2571: Object is of type 'unknown'.
@@ -5591,42 +4848,28 @@ src/js/mesos-proto.ts: error TS2322: type * is not assignable to type 'IField'.
 src/js/mesos-proto.ts: error TS2322: type * is not assignable to type 'IField'.
 src/js/mesos-proto.ts: error TS2322: type * is not assignable to type 'IField'.
 src/js/mesos-proto.ts: error TS2322: type * is not assignable to type 'IField'.
-src/js/pages/DashboardPage.tsx: error TS2339: Property 'store_listeners' does not exist on type 'DashboardPage'.
-src/js/pages/DashboardPage.tsx: error TS2339: Property 'mesosState' does not exist on type 'Readonly<{}>'.
-src/js/pages/DashboardPage.tsx: error TS2339: Property 'mesosState' does not exist on type 'Readonly<{}>'.
-src/js/pages/DashboardPage.tsx: error TS2339: Property 'dcosServices' does not exist on type 'Readonly<{}>'.
+src/js/pages/DashboardPage.tsx: error TS2339: Property 'getServiceStatus' does not exist on type 'never'.
+src/js/pages/DashboardPage.tsx: error TS2339: Property 'getServiceStatus' does not exist on type 'never'.
 src/js/pages/DashboardPage.tsx: error TS2339: Property 'servicesListLength' does not exist on type *.
-src/js/pages/DashboardPage.tsx: error TS2339: Property 'unitHealthUnits' does not exist on type 'Readonly<{}>'.
-src/js/pages/DashboardPage.tsx: error TS2339: Property 'dcosServices' does not exist on type 'Readonly<{}>'.
 src/js/pages/DashboardPage.tsx: error TS2339: Property 'servicesListLength' does not exist on type *.
-src/js/pages/DashboardPage.tsx: error TS2339: Property 'mesosState' does not exist on type 'Readonly<{}>'.
-src/js/pages/DashboardPage.tsx: error TS2345: Argument of type '\\"states\\"' is not assignable to parameter of type 'never'.
+src/js/pages/DashboardPage.tsx: error TS2322: Type 'null' is not assignable to type 'number'.
 src/js/pages/DashboardPage.tsx: error TS2322: type * is not assignable to type *.
-src/js/pages/DashboardPage.tsx: error TS2531: Object is possibly 'null'.
+src/js/pages/DashboardPage.tsx: error TS2345: Argument of type '\\"states\\"' is not assignable to parameter of type 'never'.
 src/js/pages/DashboardPage.tsx: error TS2531: Object is possibly 'null'.
 src/js/pages/DashboardPage.tsx: error TS2339: Property 'componentsListLength' does not exist on type *.
-src/js/pages/DashboardPage.tsx: error TS2339: Property 'unitHealthUnits' does not exist on type 'Readonly<{}>'.
 src/js/pages/DashboardPage.tsx: error TS2531: Object is possibly 'null'.
-src/js/pages/catalog/DeployFrameworkConfiguration.tsx: error TS2339: Property 'packageDetails' does not exist on type 'Readonly<{}>'.
-src/js/pages/catalog/DeployFrameworkConfiguration.tsx: error TS2339: Property 'deployErrors' does not exist on type 'Readonly<{}>'.
-src/js/pages/catalog/DeployFrameworkConfiguration.tsx: error TS2339: Property 'formData' does not exist on type 'Readonly<{}>'.
-src/js/pages/catalog/DeployFrameworkConfiguration.tsx: error TS2339: Property 'formErrors' does not exist on type 'Readonly<{}>'.
-src/js/pages/catalog/DeployFrameworkConfiguration.tsx: error TS2339: Property 'hasError' does not exist on type 'Readonly<{}>'.
+src/js/pages/DashboardPage.tsx: error TS2531: Object is possibly 'null'.
 src/js/pages/catalog/DeployFrameworkConfiguration.tsx: error TS2322: type * is not assignable to type *.
-src/js/pages/catalog/DeployFrameworkConfiguration.tsx: error TS2339: Property 'isPending' does not exist on type 'Readonly<{}>'.
 src/js/pages/catalog/DeployFrameworkConfiguration.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
-src/js/pages/catalog/DeployFrameworkConfiguration.tsx: error TS2339: Property 'store_listeners' does not exist on type 'DeployFrameworkConfiguration'.
 src/js/pages/catalog/DeployFrameworkConfiguration.tsx: error TS2531: Object is possibly 'null'.
 src/js/pages/catalog/DeployFrameworkConfiguration.tsx: error TS6133: 'name' is declared but its value is never read.
 src/js/pages/catalog/DeployFrameworkConfiguration.tsx: error TS6133: 'version' is declared but its value is never read.
 src/js/pages/catalog/DeployFrameworkConfiguration.tsx: error TS2339: Property 'params' does not exist on type *.
 src/js/pages/catalog/DeployFrameworkConfiguration.tsx: error TS2339: Property 'location' does not exist on type *.
-src/js/pages/catalog/DeployFrameworkConfiguration.tsx: error TS2339: Property 'packageDetails' does not exist on type 'Readonly<{}>'.
-src/js/pages/catalog/DeployFrameworkConfiguration.tsx: error TS2339: Property 'formData' does not exist on type 'Readonly<{}>'.
+src/js/pages/catalog/DeployFrameworkConfiguration.tsx: error TS2531: Object is possibly 'null'.
+src/js/pages/catalog/DeployFrameworkConfiguration.tsx: error TS2531: Object is possibly 'null'.
 src/js/pages/catalog/DeployFrameworkConfiguration.tsx: error TS7030: Not all code paths return a value.
-src/js/pages/catalog/DeployFrameworkConfiguration.tsx: error TS2339: Property 'formData' does not exist on type 'Readonly<{}>'.
 src/js/pages/catalog/DeployFrameworkConfiguration.tsx: error TS7030: Not all code paths return a value.
-src/js/pages/catalog/DeployFrameworkConfiguration.tsx: error TS2339: Property 'formErrors' does not exist on type 'Readonly<{}>'.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2556: Expected 0 arguments, but got 1 or more.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'params' does not exist on type *.
@@ -5637,74 +4880,44 @@ src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'location' doe
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'location' does not exist on type *.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS7030: Not all code paths return a value.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
-src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'runningPackageNames' does not exist on type 'Readonly<{}>'.
-src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'isLoadingSelectedVersion' does not exist on type 'Readonly<{}>'.
+src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'data' does not exist on type *.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2307: Cannot find module '#PLUGINS/services/src/img/icon-service-default-large@2x.png' or its corresponding type declarations.
-src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'version' does not exist on type 'Readonly<{}>'.
-src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'version' does not exist on type 'Readonly<{}>'.
+src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'version' does not exist on type *.
+src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'version' does not exist on type *.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2345: Argument of type * is not assignable to parameter of type *.
-src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'version' does not exist on type 'Readonly<{}>'.
+src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'version' does not exist on type *.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2531: Object is possibly 'null'.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2531: Object is possibly 'null'.
+src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'location' does not exist on type *.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'location' does not exist on type *.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'location' does not exist on type *.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'key' does not exist on type 'never'.
-src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'location' does not exist on type *.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'value' does not exist on type 'never'.
-src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'hasError' does not exist on type 'Readonly<{}>'.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'params' does not exist on type *.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2322: type * is not assignable to type 'null'.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2531: Object is possibly 'null'.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2531: Object is possibly 'null'.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2322: type * is not assignable to type *.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2322: Type 'null' is not assignable to type *.
-src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'runningPackageNames' does not exist on type 'Readonly<{}>'.
-src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'isLoadingSelectedVersion' does not exist on type 'Readonly<{}>'.
-src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'isLoadingSelectedVersion' does not exist on type 'Readonly<{}>'.
-src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'isLoadingSelectedVersion' does not exist on type 'Readonly<{}>'.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2322: Type '\\"top-left\\"' is not assignable to type 'Direction'.
-src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'isConfirmOpen' does not exist on type 'Readonly<{}>'.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2322: type * is not assignable to type *.
-src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'isLoadingSelectedVersion' does not exist on type 'Readonly<{}>'.
 src/js/pages/catalog/PackageDetailTab.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
-src/js/pages/catalog/PackageDetailTab.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-src/js/pages/catalog/PackageDetailTab.tsx: error TS2339: Property 'store_listeners' does not exist on type 'PackageDetailTab'.
-src/js/pages/catalog/PackagesTab.tsx: error TS2554: Expected 1-2 arguments, but got 0.
-src/js/pages/catalog/PackagesTab.tsx: error TS2339: Property 'store_listeners' does not exist on type 'PackagesTab'.
 src/js/pages/catalog/PackagesTab.tsx: error TS2556: Expected 0 arguments, but got 1 or more.
 src/js/pages/catalog/PackagesTab.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
-src/js/pages/catalog/PackagesTab.tsx: error TS2339: Property 'errorMessage' does not exist on type 'Readonly<{}>'.
 src/js/pages/catalog/PackagesTab.tsx: error TS2307: Cannot find module '../../../../plugins/services/src/img/icon-service-default-medium@2x.png' or its corresponding type declarations.
-src/js/pages/catalog/PackagesTab.tsx: error TS2339: Property 'searchString' does not exist on type 'Readonly<{}>'.
-src/js/pages/catalog/PackagesTab.tsx: error TS2339: Property 'searchFilter' does not exist on type 'Readonly<{}>'.
 src/js/pages/catalog/PackagesTab.tsx: error TS2769: No overload matches this call.
-src/js/pages/catalog/PackagesTab.tsx: error TS2339: Property 'searchString' does not exist on type 'Readonly<{}>'.
-src/js/pages/catalog/PackagesTab.tsx: error TS2339: Property 'errorMessage' does not exist on type 'Readonly<{}>'.
-src/js/pages/catalog/PackagesTab.tsx: error TS2339: Property 'isLoading' does not exist on type 'Readonly<{}>'.
-src/js/pages/catalog/PackagesTab.tsx: error TS2339: Property 'searchString' does not exist on type 'Readonly<{}>'.
-src/js/pages/catalog/PackagesTab.tsx: error TS2339: Property 'searchFilter' does not exist on type 'Readonly<{}>'.
 src/js/pages/catalog/PackagesTab.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
-src/js/pages/catalog/__tests__/PackageDetailTab-test.tsx: error TS2322: type * is not assignable to type *.
+src/js/pages/catalog/__tests__/PackageDetailTab-test.tsx: error TS2769: No overload matches this call.
 src/js/pages/network/VirtualNetworksTab.tsx: error TS2339: Property 'routeConfig' does not exist on type *.
-src/js/pages/network/VirtualNetworksTab.tsx: error TS2339: Property 'store_listeners' does not exist on type 'VirtualNetworksTabContent'.
-src/js/pages/network/VirtualNetworksTab.tsx: error TS2339: Property 'errorCount' does not exist on type 'Readonly<{}>'.
-src/js/pages/network/VirtualNetworksTab.tsx: error TS2339: Property 'receivedVirtualNetworks' does not exist on type 'Readonly<{}>'.
-src/js/pages/network/VirtualNetworksTab.tsx: error TS2339: Property 'errorCount' does not exist on type 'Readonly<{}>'.
-src/js/pages/network/VirtualNetworksTab.tsx: error TS2339: Property 'searchString' does not exist on type 'Readonly<{}>'.
 src/js/pages/network/VirtualNetworksTab.tsx: error TS2339: Property 'i18n' does not exist on type *.
-src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.tsx: error TS2741: Property 'overlay' is missing in type * but required in type *.
-src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.tsx: error TS2339: Property 'params' does not exist on type *.
 src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.tsx: error TS2339: Property 'params' does not exist on type *.
 src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.tsx: error TS2339: Property 'params' does not exist on type *.
 src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.tsx: error TS2741: Property 'overlayID' is missing in type * but required in type *.
 src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.tsx: error TS2769: No overload matches this call.
-src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.tsx: error TS2339: Property 'store_listeners' does not exist on type 'VirtualNetworkDetail'.
-src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.tsx: error TS2339: Property 'errorCount' does not exist on type 'Readonly<{}>'.
 src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.tsx: error TS2339: Property 'params' does not exist on type *.
 src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.tsx: error TS2741: Property 'overlay' is missing in type * but required in type *.
-src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.tsx: error TS2339: Property 'errorCount' does not exist on type 'Readonly<{}>'.
-src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.tsx: error TS2339: Property 'receivedVirtualNetworks' does not exist on type 'Readonly<{}>'.
+src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.tsx: error TS2741: Property 'overlay' is missing in type * but required in type *.
+src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.tsx: error TS2339: Property 'params' does not exist on type *.
 src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.tsx: error TS2339: Property 'primary' does not exist on type '{}'.
 src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.tsx: error TS2339: Property 'secondary' does not exist on type '{}'.
 src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.tsx: error TS2339: Property 'overlay' does not exist on type *.
@@ -5713,33 +4926,19 @@ src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.tsx: error TS2
 src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.tsx: error TS6133: 'prop' is declared but its value is never read.
 src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.tsx: error TS6133: 'prop' is declared but its value is never read.
 src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
-src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.tsx: error TS2339: Property 'errorMessage' does not exist on type 'Readonly<{}>'.
-src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.tsx: error TS2339: Property 'searchString' does not exist on type 'Readonly<{}>'.
 src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.tsx: error TS2339: Property 'overlay' does not exist on type *.
 src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.tsx: error TS2339: Property 'i18n' does not exist on type *.
 src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
-src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.tsx: error TS2339: Property 'store_listeners' does not exist on type 'VirtualNetworkTaskTab'.
-src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.tsx: error TS2339: Property 'tasksDataReceived' does not exist on type 'Readonly<{}>'.
-src/js/pages/settings/UISettingsPage.tsx: error TS2339: Property 'configRefreshRateOpen' does not exist on type 'Readonly<{}>'.
 src/js/pages/settings/UISettingsPage.tsx: error TS2339: Property 'routeConfig' does not exist on type *.
-src/js/pages/settings/UISettingsPage.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-src/js/pages/settings/UISettingsPage.tsx: error TS2339: Property 'configRefreshRateOpen' does not exist on type 'Readonly<{}>'.
 src/js/pages/settings/UISettingsPage.tsx: error TS2339: Property 'i18n' does not exist on type *.
 src/js/pages/system/ComponentsUnitsHealthNodeDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
-src/js/pages/system/ComponentsUnitsHealthNodeDetailPage.tsx: error TS2339: Property 'hasError' does not exist on type 'Readonly<{}>'.
-src/js/pages/system/ComponentsUnitsHealthNodeDetailPage.tsx: error TS2339: Property 'isLoadingNode' does not exist on type 'Readonly<{}>'.
-src/js/pages/system/ComponentsUnitsHealthNodeDetailPage.tsx: error TS2339: Property 'isLoadingUnit' does not exist on type 'Readonly<{}>'.
 src/js/pages/system/ComponentsUnitsHealthNodeDetailPage.tsx: error TS2322: type * is not assignable to type *.
 src/js/pages/system/ComponentsUnitsHealthNodeDetailPage.tsx: error TS2339: Property 'routes' does not exist on type *.
 src/js/pages/system/ComponentsUnitsHealthNodeDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
-src/js/pages/system/ComponentsUnitsHealthNodeDetailPage.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-src/js/pages/system/ComponentsUnitsHealthNodeDetailPage.tsx: error TS2339: Property 'store_listeners' does not exist on type 'UnitsHealthNodeDetail'.
 src/js/pages/system/ComponentsUnitsHealthNodeDetailPage.tsx: error TS2556: Expected 0 arguments, but got 1 or more.
 src/js/pages/system/ComponentsUnitsHealthNodeDetailPage.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
 src/js/pages/system/ComponentsUnitsHealthNodeDetailPage.tsx: error TS2339: Property 'params' does not exist on type *.
 src/js/pages/system/OrganizationTab.tsx: error TS6133: 'prevCheckboxState' is declared but its value is never read.
-src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'checkedCount' does not exist on type 'Readonly<{}>'.
 src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'selectedIDSet' does not exist on type 'OrganizationTab'.
 src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'selectedIDSet' does not exist on type 'OrganizationTab'.
 src/js/pages/system/OrganizationTab.tsx: error TS6133: 'prevCheckboxState' is declared but its value is never read.
@@ -5748,28 +4947,20 @@ src/js/pages/system/OrganizationTab.tsx: error TS6133: 'prop' is declared but it
 src/js/pages/system/OrganizationTab.tsx: error TS6133: 'prop' is declared but its value is never read.
 src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'itemID' does not exist on type *.
 src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'remoteIDSet' does not exist on type 'OrganizationTab'.
-src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'checkableCount' does not exist on type 'Readonly<{}>'.
-src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'checkedCount' does not exist on type 'Readonly<{}>'.
 src/js/pages/system/OrganizationTab.tsx: error TS2322: Type 'false' is not assignable to type 'null'.
 src/js/pages/system/OrganizationTab.tsx: error TS2322: Type 'true' is not assignable to type 'null'.
 src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'selectedIDSet' does not exist on type 'OrganizationTab'.
-src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'checkedCount' does not exist on type 'Readonly<{}>'.
-src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'checkableCount' does not exist on type 'Readonly<{}>'.
 src/js/pages/system/OrganizationTab.tsx: error TS6133: 'prop' is declared but its value is never read.
 src/js/pages/system/OrganizationTab.tsx: error TS6133: 'sortBy' is declared but its value is never read.
 src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'itemID' does not exist on type *.
-src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'showActionDropdown' does not exist on type 'Readonly<{}>'.
 src/js/pages/system/OrganizationTab.tsx: error TS2322: type * is not assignable to type 'null'.
-src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'selectedAction' does not exist on type 'Readonly<{}>'.
 src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'selectedIDSet' does not exist on type 'OrganizationTab'.
-src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'searchString' does not exist on type 'Readonly<{}>'.
 src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'itemID' does not exist on type *.
 src/js/pages/system/OrganizationTab.tsx: error TS2322: type * is not assignable to type *.
 src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'selectedIDSet' does not exist on type 'OrganizationTab'.
 src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'itemID' does not exist on type *.
 src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'selectedIDSet' does not exist on type 'OrganizationTab'.
 src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'selectedIDSet' does not exist on type 'OrganizationTab'.
-src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'checkableCount' does not exist on type 'Readonly<{}>'.
 src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'items' does not exist on type *.
 src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'itemID' does not exist on type *.
 src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'selectedIDSet' does not exist on type 'OrganizationTab'.
@@ -5777,23 +4968,18 @@ src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'remoteIDSet' do
 src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'items' does not exist on type *.
 src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'itemID' does not exist on type *.
 src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'itemName' does not exist on type *.
-src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'selectedAction' does not exist on type 'Readonly<{}>'.
 src/js/pages/system/OrganizationTab.tsx: error TS2769: No overload matches this call.
-src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'searchString' does not exist on type 'Readonly<{}>'.
 src/js/pages/system/OrganizationTab.tsx: error TS2322: type * is not assignable to type *.
-src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'openNewUserModal' does not exist on type 'Readonly<{}>'.
 src/js/pages/system/OrganizationTab.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'store_listeners' does not exist on type 'OrganizationTab'.
 src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'selectedIDSet' does not exist on type 'OrganizationTab'.
 src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'items' does not exist on type *.
 src/js/pages/system/OrganizationTab.tsx: error TS2556: Expected 2-3 arguments, but got 0 or more.
 src/js/pages/system/OrganizationTab.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
-src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'searchString' does not exist on type 'Readonly<{}>'.
 src/js/pages/system/OrganizationTab.tsx: error TS2339: Property 'items' does not exist on type *.
 src/js/pages/system/OverviewDetailTab.tsx: error TS2571: Object is of type 'unknown'.
-src/js/pages/system/OverviewDetailTab.tsx: error TS2339: Property 'dcosVersion' does not exist on type 'Readonly<{}>'.
 src/js/pages/system/OverviewDetailTab.tsx: error TS2769: No overload matches this call.
 src/js/pages/system/OverviewDetailTab.tsx: error TS2571: Object is of type 'unknown'.
+src/js/pages/system/OverviewDetailTab.tsx: error TS2322: Type 'Element' is not assignable to type 'undefined'.
 src/js/pages/system/OverviewDetailTab.tsx: error TS2322: Type 'unknown' is not assignable to type 'ReactNode'.
 src/js/pages/system/OverviewDetailTab.tsx: error TS2769: No overload matches this call.
 src/js/pages/system/OverviewDetailTab.tsx: error TS2571: Object is of type 'unknown'.
@@ -5802,60 +4988,38 @@ src/js/pages/system/OverviewDetailTab.tsx: error TS2571: Object is of type 'unkn
 src/js/pages/system/OverviewDetailTab.tsx: error TS2571: Object is of type 'unknown'.
 src/js/pages/system/OverviewDetailTab.tsx: error TS2571: Object is of type 'unknown'.
 src/js/pages/system/OverviewDetailTab.tsx: error TS2345: Argument of type '\\"metadata\\"' is not assignable to parameter of type 'never'.
-src/js/pages/system/OverviewDetailTab.tsx: error TS2339: Property 'masterInfo' does not exist on type 'Readonly<{}>'.
-src/js/pages/system/OverviewDetailTab.tsx: error TS2339: Property 'cluster' does not exist on type 'Readonly<{}>'.
-src/js/pages/system/OverviewDetailTab.tsx: error TS2339: Property 'version' does not exist on type 'Readonly<{}>'.
-src/js/pages/system/OverviewDetailTab.tsx: error TS2339: Property 'buildTime' does not exist on type 'Readonly<{}>'.
-src/js/pages/system/OverviewDetailTab.tsx: error TS2339: Property 'startTime' does not exist on type 'Readonly<{}>'.
-src/js/pages/system/OverviewDetailTab.tsx: error TS2339: Property 'electedTime' does not exist on type 'Readonly<{}>'.
-src/js/pages/system/OverviewDetailTab.tsx: error TS2339: Property 'buildUser' does not exist on type 'Readonly<{}>'.
+src/js/pages/system/OverviewDetailTab.tsx: error TS2339: Property 'electedTime' does not exist on type *.
+src/js/pages/system/OverviewDetailTab.tsx: error TS2339: Property 'buildUser' does not exist on type *.
+src/js/pages/system/OverviewDetailTab.tsx: error TS2532: Object is possibly 'undefined'.
+src/js/pages/system/OverviewDetailTab.tsx: error TS2532: Object is possibly 'undefined'.
+src/js/pages/system/OverviewDetailTab.tsx: error TS2339: Property 'hostname' does not exist on type 'Element'.
+src/js/pages/system/OverviewDetailTab.tsx: error TS2339: Property 'port' does not exist on type 'Element'.
 src/js/pages/system/OverviewDetailTab.tsx: error TS2345: Argument of type '\\"dcosBuildInfo\\"' is not assignable to parameter of type 'never'.
 src/js/pages/system/OverviewDetailTab.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
 src/js/pages/system/OverviewDetailTab.tsx: error TS2322: Type 'Element' is not assignable to type 'null'.
-src/js/pages/system/OverviewDetailTab.tsx: error TS2339: Property 'isClusterBuildInfoOpen' does not exist on type 'Readonly<{}>'.
 src/js/pages/system/OverviewDetailTab.tsx: error TS2339: Property 'routeConfig' does not exist on type *.
-src/js/pages/system/OverviewDetailTab.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-src/js/pages/system/OverviewDetailTab.tsx: error TS2339: Property 'store_listeners' does not exist on type 'OverviewDetailTab'.
 src/js/pages/system/OverviewDetailTab.tsx: error TS2556: Expected 0 arguments, but got 1 or more.
 src/js/pages/system/OverviewDetailTab.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
 src/js/pages/system/UnitsHealthDetail.tsx: error TS2339: Property 'healthFilter' does not exist on type 'UnitsHealthDetail'.
-src/js/pages/system/UnitsHealthDetail.tsx: error TS2339: Property 'healthFilter' does not exist on type 'UnitsHealthDetail'.
-src/js/pages/system/UnitsHealthDetail.tsx: error TS2339: Property 'healthFilter' does not exist on type 'UnitsHealthDetail'.
 src/js/pages/system/UnitsHealthDetail.tsx: error TS6133: 'unit' is declared but its value is never read.
 src/js/pages/system/UnitsHealthDetail.tsx: error TS2339: Property 'params' does not exist on type *.
-src/js/pages/system/UnitsHealthDetail.tsx: error TS2339: Property 'hasError' does not exist on type 'Readonly<{}>'.
-src/js/pages/system/UnitsHealthDetail.tsx: error TS2339: Property 'isLoadingUnit' does not exist on type 'Readonly<{}>'.
-src/js/pages/system/UnitsHealthDetail.tsx: error TS2339: Property 'isLoadingNodes' does not exist on type 'Readonly<{}>'.
 src/js/pages/system/UnitsHealthDetail.tsx: error TS2339: Property 'params' does not exist on type *.
-src/js/pages/system/UnitsHealthDetail.tsx: error TS2339: Property 'healthFilter' does not exist on type 'Readonly<{}>'.
-src/js/pages/system/UnitsHealthDetail.tsx: error TS2339: Property 'searchString' does not exist on type 'Readonly<{}>'.
-src/js/pages/system/UnitsHealthDetail.tsx: error TS2339: Property 'hasError' does not exist on type 'Readonly<{}>'.
-src/js/pages/system/UnitsHealthDetail.tsx: error TS2339: Property 'isLoadingUnit' does not exist on type 'Readonly<{}>'.
-src/js/pages/system/UnitsHealthDetail.tsx: error TS2339: Property 'isLoadingNodes' does not exist on type 'Readonly<{}>'.
 src/js/pages/system/UnitsHealthDetail.tsx: error TS2339: Property 'i18n' does not exist on type *.
 src/js/pages/system/UnitsHealthDetail.tsx: error TS2339: Property 'params' does not exist on type *.
 src/js/pages/system/UnitsHealthDetail.tsx: error TS2339: Property 'healthFilter' does not exist on type 'UnitsHealthDetail'.
-src/js/pages/system/UnitsHealthDetail.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-src/js/pages/system/UnitsHealthDetail.tsx: error TS2339: Property 'store_listeners' does not exist on type 'UnitsHealthDetail'.
 src/js/pages/system/UnitsHealthDetail.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
 src/js/pages/system/UnitsHealthDetail.tsx: error TS2339: Property 'params' does not exist on type *.
 src/js/pages/system/UnitsHealthDetail.tsx: error TS2339: Property 'params' does not exist on type *.
-src/js/pages/system/UnitsHealthTab.tsx: error TS2339: Property 'healthFilter' does not exist on type 'Readonly<{}>'.
-src/js/pages/system/UnitsHealthTab.tsx: error TS2339: Property 'searchString' does not exist on type 'Readonly<{}>'.
+src/js/pages/system/UnitsHealthDetail.tsx: error TS2339: Property 'healthFilter' does not exist on type 'UnitsHealthDetail'.
+src/js/pages/system/UnitsHealthDetail.tsx: error TS2339: Property 'healthFilter' does not exist on type 'UnitsHealthDetail'.
 src/js/pages/system/UnitsHealthTab.tsx: error TS2339: Property 'i18n' does not exist on type *.
 src/js/pages/system/UnitsHealthTab.tsx: error TS2339: Property 'routeConfig' does not exist on type *.
-src/js/pages/system/UnitsHealthTab.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-src/js/pages/system/UnitsHealthTab.tsx: error TS2339: Property 'store_listeners' does not exist on type 'UnitsHealthTab'.
 src/js/pages/system/UnitsHealthTab.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
 src/js/pages/system/UnitsHealthTab.tsx: error TS6133: 'prop' is declared but its value is never read.
 src/js/pages/system/UnitsHealthTab.tsx: error TS6133: 'prop' is declared but its value is never read.
 src/js/pages/system/UnitsHealthTab.tsx: error TS2769: No overload matches this call.
 src/js/pages/system/UsersPage.tsx: error TS2339: Property 'routeConfig' does not exist on type *.
-src/js/pages/system/UsersPage.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
-src/js/pages/system/UsersPage.tsx: error TS2339: Property 'store_listeners' does not exist on type 'UsersPage'.
 src/js/pages/system/UsersPage.tsx: error TS2722: Cannot invoke an object which is possibly 'undefined'.
-src/js/pages/system/UsersPage.tsx: error TS2339: Property 'usersStoreError' does not exist on type 'Readonly<{}>'.
-src/js/pages/system/UsersPage.tsx: error TS2339: Property 'usersStoreSuccess' does not exist on type 'Readonly<{}>'.
 src/js/plugin-bridge/AppHooks.ts: error TS2339: Property 'SDK' does not exist on type *.
 src/js/plugin-bridge/AppHooks.ts: error TS2339: Property 'SDK' does not exist on type *.
 src/js/plugin-bridge/AppHooks.ts: error TS2339: Property 'SDK' does not exist on type *.
@@ -5907,43 +5071,29 @@ src/js/stores/CosmosPackagesStore.ts: error TS2345: Argument of type '\\"package
 src/js/stores/CosmosPackagesStore.ts: error TS2698: Spread types may only be created from object types.
 src/js/stores/CosmosPackagesStore.ts: error TS2345: Argument of type '\\"packagesVersions\\"' is not assignable to parameter of type 'never'.
 src/js/stores/CosmosPackagesStore.ts: error TS2698: Spread types may only be created from object types.
-src/js/stores/DCOSStore.ts: error TS2339: Property 'data' does not exist on type 'DCOSStore'.
 src/js/stores/DCOSStore.ts: error TS2571: Object is of type 'unknown'.
-src/js/stores/DCOSStore.ts: error TS2339: Property 'data' does not exist on type 'DCOSStore'.
 src/js/stores/DCOSStore.ts: error TS2571: Object is of type 'unknown'.
 src/js/stores/DCOSStore.ts: error TS2571: Object is of type 'unknown'.
 src/js/stores/DCOSStore.ts: error TS2416: Property 'emit' in type 'DCOSStore' is not assignable to the same property in base type 'EventEmitter'.
-src/js/stores/DCOSStore.ts: error TS2339: Property 'debouncedEvents' does not exist on type 'DCOSStore'.
-src/js/stores/DCOSStore.ts: error TS2339: Property 'debouncedEvents' does not exist on type 'DCOSStore'.
-src/js/stores/DCOSStore.ts: error TS2339: Property 'data' does not exist on type 'DCOSStore'.
-src/js/stores/DCOSStore.ts: error TS2339: Property 'data' does not exist on type 'DCOSStore'.
 src/js/stores/DCOSStore.ts: error TS2345: Argument of type 'null' is not assignable to parameter of type 'never'.
 src/js/stores/DCOSStore.ts: error TS2345: Argument of type 'null' is not assignable to parameter of type 'never'.
-src/js/stores/DCOSStore.ts: error TS2339: Property 'data' does not exist on type 'DCOSStore'.
-src/js/stores/DCOSStore.ts: error TS2339: Property 'data' does not exist on type 'DCOSStore'.
 src/js/stores/DCOSStore.ts: error TS2345: Argument of type '\\"states\\"' is not assignable to parameter of type 'never'.
 src/js/stores/DCOSStore.ts: error TS2358: The left-hand side of an 'instanceof' expression must be of type 'any', an object type or a type parameter.
-src/js/stores/DCOSStore.ts: error TS2556: Expected 0 arguments, but got 1 or more.
-src/js/stores/DCOSStore.ts: error TS2339: Property 'data' does not exist on type 'DCOSStore'.
 src/js/stores/DCOSStore.ts: error TS2339: Property 'store' does not exist on type 'never'.
 src/js/stores/DCOSStore.ts: error TS2339: Property 'event' does not exist on type 'never'.
 src/js/stores/DCOSStore.ts: error TS2339: Property 'handler' does not exist on type 'never'.
 src/js/stores/DCOSStore.ts: error TS2339: Property 'store' does not exist on type 'never'.
 src/js/stores/DCOSStore.ts: error TS2339: Property 'event' does not exist on type 'never'.
 src/js/stores/DCOSStore.ts: error TS2339: Property 'handler' does not exist on type 'never'.
-src/js/stores/DCOSStore.ts: error TS2339: Property 'data' does not exist on type 'DCOSStore'.
 src/js/stores/DCOSStore.ts: error TS2551: Property '_serviceTree' does not exist on type 'DCOSStore'. Did you mean 'serviceTree'?
 src/js/stores/DCOSStore.ts: error TS2551: Property '_serviceTree' does not exist on type 'DCOSStore'. Did you mean 'serviceTree'?
 src/js/stores/DCOSStore.ts: error TS2551: Property '_serviceTree' does not exist on type 'DCOSStore'. Did you mean 'serviceTree'?
 src/js/stores/DCOSStore.ts: error TS2339: Property '_flatServiceTree' does not exist on type 'DCOSStore'.
-src/js/stores/DCOSStore.ts: error TS2339: Property 'data' does not exist on type 'DCOSStore'.
-src/js/stores/DCOSStore.ts: error TS2339: Property 'data' does not exist on type 'DCOSStore'.
 src/js/stores/DCOSStore.ts: error TS2351: This expression is not constructable.
+src/js/stores/DCOSStore.ts: error TS2556: Expected 0 arguments, but got 1 or more.
 src/js/stores/DCOSStore.ts: error TS2339: Property '_flatServiceTree' does not exist on type 'DCOSStore'.
 src/js/stores/DCOSStore.ts: error TS2339: Property '_flatServiceTree' does not exist on type 'DCOSStore'.
 src/js/stores/DCOSStore.ts: error TS2339: Property '_flatServiceTree' does not exist on type 'DCOSStore'.
-src/js/stores/DCOSStore.ts: error TS2339: Property 'data' does not exist on type 'DCOSStore'.
-src/js/stores/DCOSStore.ts: error TS2339: Property 'debouncedEvents' does not exist on type 'DCOSStore'.
 src/js/stores/DCOSStore.ts: error TS2322: Type 'string' is not assignable to type 'never'.
 src/js/stores/DCOSStore.ts: error TS2322: type * is not assignable to type 'never'.
 src/js/stores/DCOSStore.ts: error TS2322: Type 'MesosSummaryStore' is not assignable to type 'never'.
@@ -6059,7 +5209,7 @@ src/js/stores/__tests__/CosmosPackagesStore-test.ts: error TS2339: Property 'get
 src/js/stores/__tests__/CosmosPackagesStore-test.ts: error TS2339: Property 'get' does not exist on type '{}'.
 src/js/stores/__tests__/CosmosPackagesStore-test.ts: error TS2531: Object is possibly 'null'.
 src/js/stores/__tests__/CosmosPackagesStore-test.ts: error TS2531: Object is possibly 'null'.
-src/js/stores/__tests__/DCOSStore-test.ts: error TS2339: Property 'data' does not exist on type 'DCOSStore'.
+src/js/stores/__tests__/DCOSStore-test.ts: error TS2339: Property 'id' does not exist on type 'Deployment'.
 src/js/stores/__tests__/DCOSStore-test.ts: error TS2769: No overload matches this call.
 src/js/stores/__tests__/DCOSStore-test.ts: error TS2769: No overload matches this call.
 src/js/stores/__tests__/DCOSStore-test.ts: error TS2769: No overload matches this call.
@@ -6101,20 +5251,6 @@ src/js/structs/CompositeState.ts: error TS2551: Property '_data' does not exist 
 src/js/structs/CompositeState.ts: error TS2551: Property '_nodesList' does not exist on type 'CompositeState'. Did you mean 'getNodesList'?
 src/js/structs/CompositeState.ts: error TS2551: Property '_nodesList' does not exist on type 'CompositeState'. Did you mean 'getNodesList'?
 src/js/structs/CompositeState.ts: error TS2551: Property '_nodesList' does not exist on type 'CompositeState'. Did you mean 'getNodesList'?
-src/js/structs/CompositeState.ts: error TS2339: Property '_refCount' does not exist on type 'CompositeState'.
-src/js/structs/CompositeState.ts: error TS2339: Property 'masterInfo' does not exist on type 'CompositeState'.
-src/js/structs/CompositeState.ts: error TS2339: Property 'nodeHealthData' does not exist on type 'CompositeState'.
-src/js/structs/CompositeState.ts: error TS2339: Property '_refCount' does not exist on type 'CompositeState'.
-src/js/structs/CompositeState.ts: error TS2339: Property '_refCount' does not exist on type 'CompositeState'.
-src/js/structs/CompositeState.ts: error TS2339: Property '_refCount' does not exist on type 'CompositeState'.
-src/js/structs/CompositeState.ts: error TS2339: Property '_refCount' does not exist on type 'CompositeState'.
-src/js/structs/CompositeState.ts: error TS2339: Property '_refCount' does not exist on type 'CompositeState'.
-src/js/structs/CompositeState.ts: error TS2339: Property 'nodeHealthData' does not exist on type 'CompositeState'.
-src/js/structs/CompositeState.ts: error TS2339: Property 'nodeHealthData' does not exist on type 'CompositeState'.
-src/js/structs/CompositeState.ts: error TS2339: Property 'masterInfo' does not exist on type 'CompositeState'.
-src/js/structs/CompositeState.ts: error TS2339: Property 'masterInfo' does not exist on type 'CompositeState'.
-src/js/structs/CompositeState.ts: error TS2339: Property 'masterInfo' does not exist on type 'CompositeState'.
-src/js/structs/CompositeState.ts: error TS2339: Property 'nodeHealthData' does not exist on type 'CompositeState'.
 src/js/structs/DSLASTNodes.ts: error TS2339: Property 'position' does not exist on type 'ASTNode'.
 src/js/structs/DSLASTNodes.ts: error TS2339: Property 'children' does not exist on type 'ASTNode'.
 src/js/structs/DSLASTNodes.ts: error TS2322: Type 'any' is not assignable to type 'never'.
@@ -6158,15 +5294,6 @@ src/js/structs/StateSummary.ts: error TS2339: Property 'snapshot' does not exist
 src/js/structs/SummaryList.ts: error TS2556: Expected 1 arguments, but got 0 or more.
 src/js/structs/SummaryList.ts: error TS2339: Property 'maxLength' does not exist on type 'SummaryList'.
 src/js/structs/SummaryList.ts: error TS2339: Property 'maxLength' does not exist on type 'SummaryList'.
-src/js/structs/SummaryList.ts: error TS2339: Property 'getSnapshotDate' does not exist on type '{}'.
-src/js/structs/SummaryList.ts: error TS2339: Property 'isSnapshotSuccessful' does not exist on type '{}'.
-src/js/structs/SummaryList.ts: error TS2339: Property 'getActiveSlaves' does not exist on type '{}'.
-src/js/structs/SummaryList.ts: error TS2339: Property 'isSnapshotSuccessful' does not exist on type '{}'.
-src/js/structs/SummaryList.ts: error TS2339: Property 'isSnapshotSuccessful' does not exist on type '{}'.
-src/js/structs/SummaryList.ts: error TS2339: Property 'getNodesList' does not exist on type '{}'.
-src/js/structs/SummaryList.ts: error TS2339: Property 'getNodesList' does not exist on type '{}'.
-src/js/structs/SummaryList.ts: error TS2339: Property 'getSnapshotDate' does not exist on type '{}'.
-src/js/structs/SummaryList.ts: error TS2339: Property 'getClusterName' does not exist on type '{}'.
 src/js/structs/SummaryList.ts: error TS2339: Property 'maxLength' does not exist on type 'SummaryList'.
 src/js/structs/SummaryList.ts: error TS2339: Property 'maxLength' does not exist on type '{}'.
 src/js/structs/Tree.ts: error TS2351: This expression is not constructable.
@@ -6227,7 +5354,6 @@ src/js/structs/__tests__/NodesList-test.ts: error TS2322: type * is not assignab
 src/js/structs/__tests__/NodesList-test.ts: error TS2322: type * is not assignable to type 'Node[]'.
 src/js/structs/__tests__/NodesList-test.ts: error TS2322: type * is not assignable to type 'Node[]'.
 src/js/structs/__tests__/NodesList-test.ts: error TS2322: Type 'Node[]' is not assignable to type *.
-src/js/structs/__tests__/SummaryList-test.ts: error TS2339: Property 'isSnapshotSuccessful' does not exist on type '{}'.
 src/js/structs/__tests__/SummaryList-test.ts: error TS2554: Expected 1 arguments, but got 0.
 src/js/structs/__tests__/SummaryList-test.ts: error TS2554: Expected 3 arguments, but got 2.
 src/js/structs/__tests__/SummaryList-test.ts: error TS2554: Expected 1 arguments, but got 0.

--- a/src/js/components/AccessDeniedPage.tsx
+++ b/src/js/components/AccessDeniedPage.tsx
@@ -8,9 +8,6 @@ import Config from "../config/Config";
 import MetadataStore from "../stores/MetadataStore";
 
 export default class AccessDeniedPage extends React.Component {
-  constructor(...args) {
-    super(...args);
-  }
   handleUserLogout = () => {
     AuthStore.logout();
   };

--- a/src/js/components/CheckboxTable.tsx
+++ b/src/js/components/CheckboxTable.tsx
@@ -33,9 +33,6 @@ class CheckboxTable extends React.Component {
     sortOrder: PropTypes.string,
     uniqueProperty: PropTypes.string.isRequired,
   };
-  constructor() {
-    super();
-  }
   handleCheckboxChange = (prevCheckboxState, eventObject) => {
     const {
       allowMultipleSelect,

--- a/src/js/components/ClipboardTrigger.tsx
+++ b/src/js/components/ClipboardTrigger.tsx
@@ -19,15 +19,8 @@ class ClipboardTrigger extends React.Component {
     onTextCopy: PropTypes.func,
     useTooltip: PropTypes.bool,
   };
-  constructor() {
-    super();
-
-    this.state = {
-      hasCopiedToClipboard: false,
-    };
-
-    this.copyButtonRef = React.createRef();
-  }
+  state = { hasCopiedToClipboard: false };
+  copyButtonRef = React.createRef();
 
   componentDidMount() {
     if (this.copyButtonRef) {

--- a/src/js/components/CollapsingString.tsx
+++ b/src/js/components/CollapsingString.tsx
@@ -26,17 +26,14 @@ class CollapsingString extends React.Component {
     truncatedWrapperClassName: PropTypes.string,
     wrapperClassName: PropTypes.string,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      collapsed: false,
-      parentWidth: null,
-      stringWidth: null,
-    };
+  state = {
+    collapsed: false,
+    parentWidth: null,
+    stringWidth: null,
+  };
 
-    this.fullStringRef = React.createRef();
-  }
+  fullStringRef = React.createRef();
 
   componentDidMount() {
     if (global != null) {

--- a/src/js/components/DSLFilterField.tsx
+++ b/src/js/components/DSLFilterField.tsx
@@ -20,13 +20,8 @@ class DSLFilterField extends React.Component {
     formSections: PropTypes.array,
     onChange: PropTypes.func,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      dropdownVisible: false,
-    };
-  }
+  state = { dropdownVisible: false };
 
   /**
    * Listen for body-wide events for dismissing the panel

--- a/src/js/components/DSLFormDropdownPanel.tsx
+++ b/src/js/components/DSLFormDropdownPanel.tsx
@@ -26,13 +26,8 @@ class DSLFormDropdownPanel extends React.Component {
     onClose: PropTypes.func,
     sections: PropTypes.array.isRequired,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      expression: this.props.expression,
-    };
-  }
+  state = { expression: this.props.expression };
 
   shouldComponentUpdate(nextProps) {
     return (

--- a/src/js/components/DSLFormWithExpressionUpdates.tsx
+++ b/src/js/components/DSLFormWithExpressionUpdates.tsx
@@ -40,9 +40,6 @@ class DSLFormWithExpressionUpdates extends React.Component {
       Object.keys(DSLUpdatePolicy).map((key) => DSLUpdatePolicy[key])
     ),
   };
-  constructor(...args) {
-    super(...args);
-  }
   handleFormBlur = (event) => {
     const { target } = event;
     const { onChange, parts } = this.props;

--- a/src/js/components/DSLInputField.tsx
+++ b/src/js/components/DSLInputField.tsx
@@ -57,14 +57,11 @@ class DSLInputField extends React.Component {
     placeholder: PropTypes.string,
     expression: PropTypes.instanceOf(DSLExpression).isRequired,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      expression: this.props.expression,
-      focus: false,
-    };
-  }
+  state = {
+    expression: this.props.expression,
+    focus: false,
+  };
 
   /**
    * Import component property updates.

--- a/src/js/components/FluidGeminiScrollbar.tsx
+++ b/src/js/components/FluidGeminiScrollbar.tsx
@@ -37,11 +37,8 @@ class FluidGeminiScrollbar extends React.Component {
   static propTypes = {
     className: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   };
-  constructor(...args) {
-    super(...args);
 
-    this.geminiRef = null;
-  }
+  geminiRef = null;
 
   componentDidMount() {
     // If the browser's scrollbar width is larger than zero and this is the

--- a/src/js/components/FormModal.tsx
+++ b/src/js/components/FormModal.tsx
@@ -44,12 +44,10 @@ export default class FormModal extends React.Component {
     onSubmit: PropTypes.func,
     open: PropTypes.bool,
   };
-  constructor() {
-    super();
-    this.triggerSubmit = () => {};
 
-    this.formWrapperRef = React.createRef();
-  }
+  formWrapperRef = React.createRef();
+
+  triggerSubmit = () => {};
 
   componentDidMount() {
     this.focusOnField();

--- a/src/js/components/FrameworkConfigurationForm.tsx
+++ b/src/js/components/FrameworkConfigurationForm.tsx
@@ -82,13 +82,8 @@ class FrameworkConfigurationForm extends React.Component {
     submitRef: PropTypes.func,
     liveValidate: PropTypes.bool,
   };
-  constructor(props) {
-    super(props);
 
-    this.state = {
-      errorSchema: null,
-    };
-  }
+  state = { errorSchema: null };
   handleBadgeClick = (activeTab, event) => {
     event.stopPropagation();
 

--- a/src/js/components/FrameworkConfigurationReviewScreen.tsx
+++ b/src/js/components/FrameworkConfigurationReviewScreen.tsx
@@ -25,9 +25,6 @@ class FrameworkConfigurationReviewScreen extends React.Component {
     title: PropTypes.string,
     frameworkMeta: PropTypes.string,
   };
-  constructor(props) {
-    super(props);
-  }
   getHashMapRenderKeys = (formData) => {
     if (!Util.isObject(formData)) {
       return {};

--- a/src/js/components/HashMapDisplay.tsx
+++ b/src/js/components/HashMapDisplay.tsx
@@ -22,9 +22,6 @@ class HashMapDisplay extends React.PureComponent {
     renderKeys: PropTypes.object,
     emptyValue: PropTypes.string,
   };
-  constructor(...args) {
-    super(...args);
-  }
 
   getHeadline() {
     const { headline, headlineClassName, headingLevel } = this.props;

--- a/src/js/components/Image.tsx
+++ b/src/js/components/Image.tsx
@@ -15,13 +15,8 @@ class Image extends React.Component {
       PropTypes.string,
     ]),
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      imageErrorCount: 0,
-    };
-  }
+  state = { imageErrorCount: 0 };
 
   UNSAFE_componentWillReceiveProps(nextProps) {
     const { src, fallbackSrc } = this.props;

--- a/src/js/components/ImageViewer.tsx
+++ b/src/js/components/ImageViewer.tsx
@@ -10,11 +10,8 @@ class ImageViewer extends React.Component {
   static propTypes = {
     images: PropTypes.arrayOf(PropTypes.string),
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = { selectedImage: null };
-  }
+  state = { selectedImage: null };
   handleImageViewerModalClose = () => {
     this.setState({ selectedImage: null });
   };

--- a/src/js/components/ManualBreadcrumbs.tsx
+++ b/src/js/components/ManualBreadcrumbs.tsx
@@ -25,14 +25,13 @@ class ManualBreadcrumbs extends React.Component {
     ]),
     crumbs: PropTypes.array,
   };
+  state = {
+    availableWidth: null,
+    collapsed: false,
+    expandedWidth: null,
+  };
   constructor(...args) {
     super(...args);
-
-    this.state = {
-      availableWidth: null,
-      collapsed: false,
-      expandedWidth: null,
-    };
 
     this.handleResize = this.handleResize.bind(this);
   }

--- a/src/js/components/PageHeaderTabs.tsx
+++ b/src/js/components/PageHeaderTabs.tsx
@@ -21,9 +21,6 @@ class PageHeaderTabs extends React.Component {
       })
     ),
   };
-  constructor(...args) {
-    super(...args);
-  }
 
   shouldComponentUpdate(nextProps) {
     return !isEqual(this.props.tabs, nextProps.tabs);

--- a/src/js/components/PlacementConstraintsSchemaField.tsx
+++ b/src/js/components/PlacementConstraintsSchemaField.tsx
@@ -49,9 +49,7 @@ export default class PlacementConstraintsSchemaField extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = {
-      batch: new Batch(),
-    };
+    this.state = { batch: new Batch() };
     this.state.batch = this.generateBatchFromInput();
 
     this.handleBatchChange = this.handleBatchChange.bind(this);

--- a/src/js/components/ServerErrorModal.tsx
+++ b/src/js/components/ServerErrorModal.tsx
@@ -22,15 +22,11 @@ function getEventsFromStoreListeners(storeListeners) {
 }
 
 export default class ServerErrorModal extends mixin(StoreMixin) {
+  state = { isOpen: false, errors: [] };
+
+  store_listeners = Hooks.applyFilter("serverErrorModalListeners", []);
   constructor() {
     super();
-
-    this.state = {
-      isOpen: false,
-      errors: [],
-    };
-
-    this.store_listeners = Hooks.applyFilter("serverErrorModalListeners", []);
 
     const events = getEventsFromStoreListeners.call(this, this.store_listeners);
     events.forEach((event) => {

--- a/src/js/components/SideTabs.tsx
+++ b/src/js/components/SideTabs.tsx
@@ -14,13 +14,8 @@ class SideTabs extends React.Component {
     selectedTab: PropTypes.string,
     tabs: PropTypes.array,
   };
-  constructor() {
-    super();
 
-    this.state = {
-      dropdownOpen: false,
-    };
-  }
+  state = { dropdownOpen: false };
 
   handleTabClick(title) {
     const {

--- a/src/js/components/Sidebar.tsx
+++ b/src/js/components/Sidebar.tsx
@@ -43,11 +43,7 @@ export default class Sidebar extends React.Component<{
   geminiRef?: HTMLDivElement | null;
   sidebarWrapperRef?: HTMLDivElement | null;
 
-  constructor(props) {
-    super(props);
-
-    this.state = { expandedItems: [] };
-  }
+  state = { expandedItems: [] };
 
   UNSAFE_componentWillMount() {
     const pathnameSegments = this.props.location.pathname.split("/");

--- a/src/js/components/SplitPanel.tsx
+++ b/src/js/components/SplitPanel.tsx
@@ -127,6 +127,7 @@ function intersperse<A>(list: A[], sep: JSX.Element) {
 class SplitPanel extends React.PureComponent<SplitPanelProps, SplitPanelState> {
   public containerRef = React.createRef<HTMLDivElement>();
 
+  state = { isResizing: false };
   constructor(props: SplitPanelProps) {
     super(props);
 
@@ -134,10 +135,6 @@ class SplitPanel extends React.PureComponent<SplitPanelProps, SplitPanelState> {
     this.handleMouseUp = this.handleMouseUp.bind(this);
     this.handleMouseMove = this.handleMouseMove.bind(this);
     this.handleWindowResize = this.handleWindowResize.bind(this);
-
-    this.state = {
-      isResizing: false,
-    };
   }
 
   public componentDidMount() {

--- a/src/js/components/TabButton.tsx
+++ b/src/js/components/TabButton.tsx
@@ -17,9 +17,6 @@ class TabButton extends React.Component {
     description: PropTypes.node,
     onClickBadge: PropTypes.func,
   };
-  constructor(...args) {
-    super(...args);
-  }
 
   getChildren() {
     const { activeTab, children, onClick } = this.props;

--- a/src/js/components/TabForm.tsx
+++ b/src/js/components/TabForm.tsx
@@ -31,15 +31,12 @@ class TabForm extends React.Component {
     onSubmit: PropTypes.func,
     onTabClick: PropTypes.func,
   };
-  constructor() {
-    super();
 
-    this.state = { currentTab: "", renderGemini: false };
+  state = { currentTab: "", renderGemini: false };
 
-    this.geminiRef = React.createRef();
+  geminiRef = React.createRef();
 
-    this.triggerSubmit = () => {};
-  }
+  triggerSubmit = () => {};
 
   UNSAFE_componentWillMount() {
     this.model = {};

--- a/src/js/components/ToggleValue.tsx
+++ b/src/js/components/ToggleValue.tsx
@@ -6,13 +6,7 @@ class ToggleValue extends React.Component {
     primaryValue: PropTypes.string.isRequired,
     secondaryValue: PropTypes.string.isRequired,
   };
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      toggled: false,
-    };
-  }
+  state = { toggled: false };
 
   render() {
     const { toggled } = this.state;

--- a/src/js/components/UnitHealthDropdown.tsx
+++ b/src/js/components/UnitHealthDropdown.tsx
@@ -23,10 +23,7 @@ class UnitHealthDropdown extends React.PureComponent {
     initialID: PropTypes.string,
     onHealthSelection: PropTypes.func,
   };
-  constructor(...args) {
-    super(...args);
-    this.state = { dropdownItems: this.getDropdownItems() };
-  }
+  state = { dropdownItems: this.getDropdownItems() };
 
   getDropdownItems() {
     const keys = Object.keys(UnitHealthStatus).filter(

--- a/src/js/components/UnitHealthNodesTable.tsx
+++ b/src/js/components/UnitHealthNodesTable.tsx
@@ -14,9 +14,6 @@ class UnitHealthNodesTable extends React.Component {
     nodes: PropTypes.array.isRequired,
     params: PropTypes.object,
   };
-  constructor() {
-    super();
-  }
 
   getColGroup() {
     return (

--- a/src/js/components/UnitsHealthNodeDetail.tsx
+++ b/src/js/components/UnitsHealthNodeDetail.tsx
@@ -10,20 +10,16 @@ import UnitsHealthNodeDetailPanel from "../pages/system/units-health-node-detail
 import UnitSummaries from "../constants/UnitSummaries";
 
 class UnitsHealthNodeDetail extends mixin(StoreMixin) {
-  constructor(...args) {
-    super(...args);
+  state = {
+    hasError: false,
+    isLoadingUnit: true,
+    isLoadingNode: true,
+  };
 
-    this.state = {
-      hasError: false,
-      isLoadingUnit: true,
-      isLoadingNode: true,
-    };
-
-    // prettier-ignore
-    this.store_listeners = [
-      {name: "unitHealth", events: ["unitSuccess", "unitError", "nodeSuccess", "nodeError"], suppressUpdate: true}
-    ];
-  }
+  // prettier-ignore
+  store_listeners = [
+    {name: "unitHealth", events: ["unitSuccess", "unitError", "nodeSuccess", "nodeError"], suppressUpdate: true}
+  ];
 
   componentDidMount(...args) {
     super.componentDidMount(...args);

--- a/src/js/components/UserAccountDropdownTrigger.tsx
+++ b/src/js/components/UserAccountDropdownTrigger.tsx
@@ -9,13 +9,10 @@ export default class UserAccountDropdownTrigger extends mixin(StoreMixin) {
     onUpdate: PropTypes.func,
     onTrigger: PropTypes.func,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.store_listeners = [
-      { name: "metadata", events: ["success"], unmountWhen: () => true },
-    ];
-  }
+  store_listeners = [
+    { name: "metadata", events: ["success"], unmountWhen: () => true },
+  ];
 
   componentDidUpdate() {
     if (this.props.onUpdate) {

--- a/src/js/components/charts/TimeSeriesChart.tsx
+++ b/src/js/components/charts/TimeSeriesChart.tsx
@@ -31,15 +31,11 @@ export default class TimeSeriesChart extends React.Component {
     yFormat: ValueTypes.PERCENTAGE,
   };
 
+  clipPathID = `clip-${Util.uniqueID()}`;
+  maskID = `mask-${Util.uniqueID()}`;
+
   getHeight = ({ height, margin }) => height - margin.top - margin.bottom;
   getWidth = ({ margin, width }) => width - margin.left - margin.right;
-
-  constructor(props) {
-    super(props);
-
-    this.clipPathID = `clip-${Util.uniqueID()}`;
-    this.maskID = `mask-${Util.uniqueID()}`;
-  }
 
   getXScale(data = [], width, refreshRate) {
     const length = data[0]?.values?.length ?? width;

--- a/src/js/components/form/AdvancedSection.tsx
+++ b/src/js/components/form/AdvancedSection.tsx
@@ -1,32 +1,19 @@
 import classNames from "classnames/dedupe";
-import PropTypes from "prop-types";
 import * as React from "react";
 
 import AdvancedSectionContent from "./AdvancedSectionContent";
 import AdvancedSectionLabel from "./AdvancedSectionLabel";
 
-class AdvancedSection extends React.Component {
-  static propTypes = {
-    initialIsExpanded: PropTypes.bool,
-    children: PropTypes.node,
-    className: PropTypes.oneOfType([
-      PropTypes.array,
-      PropTypes.object,
-      PropTypes.string,
-    ]),
-    shouldExpand: PropTypes.bool,
-  };
+class AdvancedSection extends React.Component<{
+  className: string;
+  initialIsExpanded?: boolean;
+  shouldExpand?: boolean;
+}> {
   static getDerivedStateFromProps(nextProps) {
-    if (nextProps.shouldExpand) {
-      return { isExpanded: true };
-    }
-    return null;
+    return nextProps.shouldExpand ? { isExpanded: true } : null;
   }
-  constructor(props) {
-    super(...arguments);
 
-    this.state = { isExpanded: props.initialIsExpanded === true };
-  }
+  state = { isExpanded: this.props.initialIsExpanded === true };
   handleHeadingClick = () => {
     this.setState({ isExpanded: !this.state.isExpanded });
   };

--- a/src/js/components/modals/ActionsModal.tsx
+++ b/src/js/components/modals/ActionsModal.tsx
@@ -21,15 +21,15 @@ class ActionsModal extends mixin(StoreMixin) {
     onClose: PropTypes.func.isRequired,
     selectedItems: PropTypes.array.isRequired,
   };
+  state = {
+    pendingRequest: false,
+    requestErrors: [],
+    requestsRemaining: 0,
+    selectedItem: null,
+    validationError: null,
+  };
   constructor(props) {
     super(props);
-    this.state = {
-      pendingRequest: false,
-      requestErrors: [],
-      requestsRemaining: 0,
-      selectedItem: null,
-      validationError: null,
-    };
     this.handleButtonConfirm = this.handleButtonConfirm.bind(this);
   }
 

--- a/src/js/components/modals/ImageViewerModal.tsx
+++ b/src/js/components/modals/ImageViewerModal.tsx
@@ -22,10 +22,11 @@ class ImageViewerModal extends React.Component {
     onRightClick: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,
   };
+
+  state = { isLoadingImage: false };
+
   constructor(...args) {
     super(...args);
-
-    this.state = { isLoadingImage: false };
 
     if (this.props.open) {
       window.addEventListener("keydown", this.handleKeyPress, true);

--- a/src/js/components/modals/JobStopRunModal.tsx
+++ b/src/js/components/modals/JobStopRunModal.tsx
@@ -13,12 +13,9 @@ class JobStopRunModal extends React.Component {
     onClose: PropTypes.func.isRequired,
     jobRunID: PropTypes.string.isRequired,
   };
+  state = { pendingRequest: false };
   constructor(...args) {
     super(...args);
-
-    this.state = {
-      pendingRequest: false,
-    };
 
     this.handleButtonConfirm = this.handleButtonConfirm.bind(this);
   }

--- a/src/js/components/modals/LanguagePreferenceFormModal.tsx
+++ b/src/js/components/modals/LanguagePreferenceFormModal.tsx
@@ -8,12 +8,9 @@ import ModalHeading from "../modals/ModalHeading";
 import UserLanguageStore from "../../stores/UserLanguageStore";
 
 export class LanguagePreferenceFormModalComponent extends React.Component {
+  state = { isOpen: this.props.isOpen || false };
   constructor(props) {
     super(props);
-
-    this.state = {
-      isOpen: props.isOpen || false,
-    };
 
     this.handleClose = this.handleClose.bind(this);
     this.handleLanguagePrefSubmit = this.handleLanguagePrefSubmit.bind(this);

--- a/src/js/components/modals/UserFormModal.tsx
+++ b/src/js/components/modals/UserFormModal.tsx
@@ -12,20 +12,16 @@ import ModalHeading from "../modals/ModalHeading";
 import UserStore from "../../stores/UserStore";
 
 class UserFormModal extends mixin(StoreMixin) {
-  constructor() {
-    super();
+  state = {
+    disableNewUser: false,
+    errorMsg: false,
+    errorCode: null,
+  };
 
-    this.state = {
-      disableNewUser: false,
-      errorMsg: false,
-      errorCode: null,
-    };
-
-    // prettier-ignore
-    this.store_listeners = [
-      {name: "user", events: ["createSuccess", "createError"], suppressUpdate: true}
-    ];
-  }
+  // prettier-ignore
+  store_listeners = [
+    {name: "user", events: ["createSuccess", "createError"], suppressUpdate: true}
+  ];
   onUserStoreCreateSuccess = () => {
     this.setState({
       disableNewUser: false,

--- a/src/js/components/modals/UsersActionsModal.ts
+++ b/src/js/components/modals/UsersActionsModal.ts
@@ -2,14 +2,10 @@ import ActionsModal from "./ActionsModal";
 import UserStore from "../../stores/UserStore";
 
 class UsersActionsModal extends ActionsModal {
-  constructor(props) {
-    super(props);
-
-    // prettier-ignore
-    this.store_listeners = [
-      {name: "user", events: ["deleteError", "deleteSuccess"], suppressUpdate: true}
-    ];
-  }
+  // prettier-ignore
+  store_listeners = [
+    { name: "user", events: ["deleteError", "deleteSuccess"], suppressUpdate: true }
+  ];
 
   onUserStoreDeleteError(requestError) {
     this.onActionError(requestError);

--- a/src/js/pages/DashboardPage.tsx
+++ b/src/js/pages/DashboardPage.tsx
@@ -90,25 +90,17 @@ export default class DashboardPage extends mixin(StoreMixin) {
     servicesListLength: 5,
   };
 
-  constructor(props) {
-    super(props);
+  state = {
+    dcosServices: [],
+    unitHealthUnits: new HealthUnitsList({ items: [] }),
+    mesosState: getMesosState(),
+  };
 
-    this.state = {
-      dcosServices: [],
-      unitHealthUnits: new HealthUnitsList({ items: [] }),
-      mesosState: getMesosState(),
-    };
-
-    this.store_listeners = [
-      { name: "dcos", events: ["change"], suppressUpdate: true },
-      { name: "summary", events: ["success", "error"], suppressUpdate: true },
-      {
-        name: "unitHealth",
-        events: ["success", "error"],
-        suppressUpdate: true,
-      },
-    ];
-  }
+  store_listeners = [
+    { name: "dcos", events: ["change"], suppressUpdate: true },
+    { name: "summary", events: ["success", "error"], suppressUpdate: true },
+    { name: "unitHealth", events: ["success", "error"], suppressUpdate: true },
+  ];
 
   onDcosStoreChange = () => {
     this.setState({

--- a/src/js/pages/catalog/DeployFrameworkConfiguration.tsx
+++ b/src/js/pages/catalog/DeployFrameworkConfiguration.tsx
@@ -17,22 +17,23 @@ class DeployFrameworkConfiguration extends mixin(StoreMixin) {
   static propTypes = {
     params: PropTypes.object.isRequired,
   };
+
+  state = {
+    packageDetails: null,
+    deployErrors: null,
+    formErrors: {},
+    formData: null,
+    hasError: false,
+    isPending: false,
+  };
+
+  // prettier-ignore
+  store_listeners = [
+    {name: "cosmosPackages", events: ["packageDescriptionSuccess", "packageDescriptionError", "installSuccess", "installError"]}
+  ];
+
   constructor(props) {
     super(props);
-
-    this.state = {
-      packageDetails: null,
-      deployErrors: null,
-      formErrors: {},
-      formData: null,
-      hasError: false,
-      isPending: false,
-    };
-
-    // prettier-ignore
-    this.store_listeners = [
-      {name: "cosmosPackages", events: ["packageDescriptionSuccess", "packageDescriptionError", "installSuccess", "installError"]}
-    ];
 
     CosmosPackagesStore.fetchPackageDescription(
       props.params.packageName,

--- a/src/js/pages/catalog/PackageDetailTab.tsx
+++ b/src/js/pages/catalog/PackageDetailTab.tsx
@@ -78,22 +78,18 @@ const PackageDetailBreadcrumbs = ({ cosmosPackage, isLoading }) => {
 };
 
 class PackageDetailTab extends mixin(StoreMixin) {
-  constructor(...args) {
-    super(...args);
+  state = {
+    hasError: 0,
+    isConfirmOpen: false,
+    isLoadingSelectedVersion: false,
+    isLoadingVersions: false,
+    runningPackageNames: { state: "loading" },
+  };
 
-    this.state = {
-      hasError: 0,
-      isConfirmOpen: false,
-      isLoadingSelectedVersion: false,
-      isLoadingVersions: false,
-      runningPackageNames: { state: "loading" },
-    };
-
-    // prettier-ignore
-    this.store_listeners = [
+  // prettier-ignore
+  store_listeners = [
       {name: "cosmosPackages", events: ["packageDescriptionError", "packageDescriptionSuccess", "listVersionsSuccess", "listVersionsError"], suppressUpdate: true}
     ];
-  }
 
   retrievePackageInfo(packageName, version) {
     const cosmosPackage = CosmosPackagesStore.getPackageDetails();

--- a/src/js/pages/catalog/PackagesTab.tsx
+++ b/src/js/pages/catalog/PackagesTab.tsx
@@ -102,22 +102,18 @@ function renderPage(content) {
 }
 
 class PackagesTab extends mixin(StoreMixin) {
-  constructor() {
-    super();
+  state = {
+    errorMessage: false,
+    installModalPackage: null,
+    isLoading: true,
+    searchString: "",
+    searchFilter: Filters.certified,
+  };
 
-    this.state = {
-      errorMessage: false,
-      installModalPackage: null,
-      isLoading: true,
-      searchString: "",
-      searchFilter: Filters.certified,
-    };
-
-    // prettier-ignore
-    this.store_listeners = [
-      {name: "cosmosPackages", events: ["availableError", "availableSuccess"], suppressUpdate: true}
-    ];
-  }
+  // prettier-ignore
+  store_listeners = [
+    { name: "cosmosPackages", events: ["availableError", "availableSuccess"], suppressUpdate: true }
+  ];
 
   componentDidMount(...args) {
     super.componentDidMount(...args);

--- a/src/js/pages/network/VirtualNetworksTab.tsx
+++ b/src/js/pages/network/VirtualNetworksTab.tsx
@@ -59,19 +59,13 @@ const NetworksBreadcrumbs = () => {
 };
 
 class VirtualNetworksTabContent extends mixin(StoreMixin) {
-  constructor(props) {
-    super(props);
+  state = {
+    receivedVirtualNetworks: false,
+    searchString: "",
+    errorCount: 0,
+  };
 
-    this.state = {
-      receivedVirtualNetworks: false,
-      searchString: "",
-      errorCount: 0,
-    };
-
-    this.store_listeners = [
-      { name: "virtualNetworks", events: ["success", "error"] },
-    ];
-  }
+  store_listeners = [{ name: "virtualNetworks", events: ["success", "error"] }];
 
   handleSearchStringChange = (searchString = "") => {
     this.setState({ searchString });

--- a/src/js/pages/network/VirtualNetworksTab.tsx
+++ b/src/js/pages/network/VirtualNetworksTab.tsx
@@ -105,7 +105,7 @@ class VirtualNetworksTabContent extends mixin(StoreMixin) {
       return <Loader />;
     }
 
-    const overlayList = VirtualNetworksStore.getOverlays();
+    const overlayList = VirtualNetworksStore.overlays;
     const filteredOverlayList = getFilteredOverlayList(
       overlayList,
       searchString

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.tsx
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.tsx
@@ -115,7 +115,7 @@ export default class VirtualNetworkDetail extends mixin(StoreMixin) {
       { label: i18nMark("Details"), routePath: `${prefix}/details` },
     ];
 
-    const overlay = VirtualNetworksStore.getOverlays().find(
+    const overlay = VirtualNetworksStore.overlays.find(
       ({ name }) => name === this.props.params.overlayName
     );
 

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.tsx
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.tsx
@@ -50,19 +50,15 @@ const NetworksDetailBreadcrumbs = ({ overlayID, overlay }) => {
 export default class VirtualNetworkDetail extends mixin(StoreMixin) {
   static contextTypes = { router: routerShape };
 
-  constructor(...args) {
-    super(...args);
+  state = {
+    errorCount: 0,
+    receivedVirtualNetworks: false,
+  };
 
-    this.state = {
-      errorCount: 0,
-      receivedVirtualNetworks: false,
-    };
-
-    // prettier-ignore
-    this.store_listeners = [
-      { name: "virtualNetworks", events: ["success", "error"] }
-    ];
-  }
+  // prettier-ignore
+  store_listeners = [
+    { name: "virtualNetworks", events: ["success", "error"] }
+  ];
 
   onVirtualNetworksStoreError = () => {
     const errorCount = this.state.errorCount + 1;

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskPage.tsx
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskPage.tsx
@@ -88,7 +88,7 @@ const VirtualNetworkTaskPage = (props) => {
 
   const task = MesosStateStore.getTaskFromTaskID(taskID);
 
-  const overlay = VirtualNetworksStore.getOverlays().find(
+  const overlay = VirtualNetworksStore.overlays.find(
     ({ name }) => name === overlayName
   );
 

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.tsx
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.tsx
@@ -34,19 +34,16 @@ class VirtualNetworkTaskTab extends mixin(StoreMixin) {
   static propTypes = {
     overlay: PropTypes.instanceOf(Overlay),
   };
-  constructor(...args) {
-    super(...args);
 
-    this.state = {
-      errorMessage: null,
-      searchString: "",
-      tasksDataReceived: false,
-    };
+  state = {
+    errorMessage: null,
+    searchString: "",
+    tasksDataReceived: false,
+  };
 
-    this.store_listeners = [
-      { name: "state", events: ["success", "error"], suppressUpdate: true },
-    ];
-  }
+  store_listeners = [
+    { name: "state", events: ["success", "error"], suppressUpdate: true },
+  ];
 
   onStateStoreError(errorMessage) {
     this.setState({ tasksDataReceived: true, errorMessage });

--- a/src/js/pages/settings/UISettingsPage.tsx
+++ b/src/js/pages/settings/UISettingsPage.tsx
@@ -52,11 +52,9 @@ const ConfigurationRow = ({ keyValue, title, value, action }) => {
 };
 
 class UISettingsPage extends React.Component {
-  constructor(...args) {
-    super(...args);
-    this.state = {
-      configRefreshRateOpen: false,
-    };
+  state = { configRefreshRateOpen: false };
+  constructor(props) {
+    super(props);
     this.toggleRefreshModal = this.toggleRefreshModal.bind(this);
     this.saveRefreshRate = this.saveRefreshRate.bind(this);
   }

--- a/src/js/pages/system/ComponentsUnitsHealthNodeDetailPage.tsx
+++ b/src/js/pages/system/ComponentsUnitsHealthNodeDetailPage.tsx
@@ -64,20 +64,16 @@ const UnitHealthNodeDetailBreadcrumbs = ({ node, unit }) => {
 };
 
 class UnitsHealthNodeDetail extends mixin(StoreMixin) {
-  constructor(...args) {
-    super(...args);
+  state = {
+    hasError: false,
+    isLoadingUnit: true,
+    isLoadingNode: true,
+  };
 
-    this.state = {
-      hasError: false,
-      isLoadingUnit: true,
-      isLoadingNode: true,
-    };
-
-    // prettier-ignore
-    this.store_listeners = [
+  // prettier-ignore
+  store_listeners = [
       {name: "unitHealth", events: ["unitSuccess", "unitError", "nodeSuccess", "nodeError"], suppressUpdate: true}
     ];
-  }
 
   componentDidMount(...args) {
     super.componentDidMount(...args);

--- a/src/js/pages/system/OrganizationTab.tsx
+++ b/src/js/pages/system/OrganizationTab.tsx
@@ -51,24 +51,24 @@ class OrganizationTab extends mixin(StoreMixin) {
     itemID: PropTypes.string.isRequired,
     itemName: PropTypes.string.isRequired,
   };
+
+  state = {
+    checkableCount: 0,
+    checkedCount: 0,
+    openNewUserModal: false,
+    showActionDropdown: false,
+    searchString: "",
+    selectedAction: null,
+    usersStoreError: false,
+    usersStoreSuccess: false,
+  };
+
+  store_listeners = [
+    // prettier-ignore
+    { name: "user", events: ["createSuccess", "deleteSuccess"], suppressUpdate: true },
+  ];
   constructor(...args) {
     super(...args);
-
-    // prettier-ignore
-    this.store_listeners = [
-      {name: "user", events: ["createSuccess", "deleteSuccess"], suppressUpdate: true}
-    ];
-
-    this.state = {
-      checkableCount: 0,
-      checkedCount: 0,
-      openNewUserModal: false,
-      showActionDropdown: false,
-      searchString: "",
-      selectedAction: null,
-      usersStoreError: false,
-      usersStoreSuccess: false,
-    };
 
     Hooks.applyFilter(
       "organizationTabChangeEvents",

--- a/src/js/pages/system/OverviewDetailTab.tsx
+++ b/src/js/pages/system/OverviewDetailTab.tsx
@@ -52,25 +52,21 @@ const SystemOverviewBreadcrumbs = () => {
 };
 
 class OverviewDetailTab extends mixin(StoreMixin) {
-  constructor(...args) {
-    super(...args);
+  state = {
+    isClusterBuildInfoOpen: false,
+    masterInfo: undefined,
+    cluster: undefined,
+    version: undefined,
+    buildTime: undefined,
+    startTime: undefined,
+    dcosVersion: undefined,
+  };
 
-    this.state = {
-      isClusterBuildInfoOpen: false,
-      masterInfo: undefined,
-      cluster: undefined,
-      version: undefined,
-      buildTime: undefined,
-      startTime: undefined,
-      dcosVersion: undefined,
-    };
-
-    this.store_listeners = [
-      { name: "config", events: ["ccidSuccess"] },
-      { name: "marathon", events: ["instanceInfoSuccess"] },
-      { name: "metadata", events: ["dcosBuildInfoChange", "success"] },
-    ];
-  }
+  store_listeners = [
+    { name: "config", events: ["ccidSuccess"] },
+    { name: "marathon", events: ["instanceInfoSuccess"] },
+    { name: "metadata", events: ["dcosBuildInfoChange", "success"] },
+  ];
 
   componentDidMount(...args) {
     super.componentDidMount(...args);

--- a/src/js/pages/system/UnitsHealthDetail.tsx
+++ b/src/js/pages/system/UnitsHealthDetail.tsx
@@ -54,22 +54,18 @@ const UnitHealthDetailBreadcrumbs = ({ unit }) => {
 };
 
 class UnitsHealthDetail extends mixin(StoreMixin) {
-  constructor(...args) {
-    super(...args);
+  // prettier-ignore
+  store_listeners = [
+    {name: "unitHealth", events: ["unitSuccess", "unitError", "nodesSuccess", "nodesError"], suppressUpdate: true}
+  ];
 
-    // prettier-ignore
-    this.store_listeners = [
-      {name: "unitHealth", events: ["unitSuccess", "unitError", "nodesSuccess", "nodesError"], suppressUpdate: true}
-    ];
-
-    this.state = {
-      hasError: false,
-      healthFilter: "all",
-      isLoadingUnit: true,
-      isLoadingNodes: true,
-      searchString: "",
-    };
-  }
+  state = {
+    hasError: false,
+    healthFilter: "all",
+    isLoadingUnit: true,
+    isLoadingNodes: true,
+    searchString: "",
+  };
 
   componentDidMount() {
     super.componentDidMount();

--- a/src/js/pages/system/UnitsHealthTab.tsx
+++ b/src/js/pages/system/UnitsHealthTab.tsx
@@ -40,19 +40,15 @@ const UnitHealthBreadcrumbs = () => {
 };
 
 class UnitsHealthTab extends mixin(StoreMixin) {
-  constructor(...args) {
-    super(...args);
+  // prettier-ignore
+  store_listeners = [
+    { name: "unitHealth", events: ["success", "error"], suppressUpdate: false }
+  ];
 
-    // prettier-ignore
-    this.store_listeners = [
-      {name: "unitHealth", events: ["success", "error"], suppressUpdate: false}
-    ];
-
-    this.state = {
-      healthFilter: "all",
-      searchString: "",
-    };
-  }
+  state = {
+    healthFilter: "all",
+    searchString: "",
+  };
 
   componentDidMount() {
     super.componentDidMount();

--- a/src/js/pages/system/UsersPage.tsx
+++ b/src/js/pages/system/UsersPage.tsx
@@ -36,18 +36,12 @@ class UsersPage extends mixin(StoreMixin) {
   static propTypes = {
     params: PropTypes.object,
   };
-  constructor(...args) {
-    super(...args);
 
-    this.store_listeners = Hooks.applyFilter("usersPageStoreListeners", [
-      { name: "users", events: ["success", "error"], suppressUpdate: true },
-    ]);
+  store_listeners = Hooks.applyFilter("usersPageStoreListeners", [
+    { name: "users", events: ["success", "error"], suppressUpdate: true },
+  ]);
 
-    this.state = {
-      usersStoreError: false,
-      usersStoreSuccess: false,
-    };
-  }
+  state = { usersStoreError: false, usersStoreSuccess: false };
 
   componentDidMount() {
     super.componentDidMount();

--- a/src/js/stores/DCOSStore.ts
+++ b/src/js/stores/DCOSStore.ts
@@ -24,6 +24,19 @@ const EVENT_DEBOUNCE_TIME = 250;
 const events = { change: DCOS_CHANGE };
 
 class DCOSStore extends EventEmitter {
+  data = {
+    marathon: {
+      serviceTree: new ServiceTree(),
+      queue: new Map(),
+      deploymentsList: new DeploymentsList(),
+      versions: new Map(),
+      dataReceived: false,
+    },
+    mesos: new SummaryList(),
+  };
+
+  debouncedEvents = new Map();
+
   constructor(...args) {
     super(...args);
 
@@ -33,19 +46,6 @@ class DCOSStore extends EventEmitter {
       events,
       unmountWhen: () => false,
     });
-
-    this.data = {
-      marathon: {
-        serviceTree: new ServiceTree(),
-        queue: new Map(),
-        deploymentsList: new DeploymentsList(),
-        versions: new Map(),
-        dataReceived: false,
-      },
-      mesos: new SummaryList(),
-    };
-
-    this.debouncedEvents = new Map();
   }
 
   getTotalListenerCount() {

--- a/src/js/stores/LanguageModalStore.ts
+++ b/src/js/stores/LanguageModalStore.ts
@@ -13,6 +13,8 @@ import AppDispatcher from "../events/AppDispatcher";
 import GetSetBaseStore from "./GetSetBaseStore";
 
 class LanguageModalStore extends GetSetBaseStore {
+  storeID = "languageModal";
+
   constructor() {
     super();
 
@@ -39,10 +41,6 @@ class LanguageModalStore extends GetSetBaseStore {
 
       return true;
     });
-  }
-
-  get storeID() {
-    return "languageModal";
   }
 }
 export default new LanguageModalStore();

--- a/src/js/stores/MesosSummaryFetchers.tsx
+++ b/src/js/stores/MesosSummaryFetchers.tsx
@@ -27,12 +27,10 @@ export function withNode<P extends object>(
   ComponentWithNode: React.ComponentType<P>
 ) {
   return class extends React.Component<any, WithNodeState> {
+    state = { summary: MesosSummaryStore.getLastSuccessfulSummarySnapshot() };
     constructor(props: any) {
       super(props);
       this.receiveNewSummary = this.receiveNewSummary.bind(this);
-      this.state = {
-        summary: MesosSummaryStore.getLastSuccessfulSummarySnapshot(),
-      };
     }
 
     public receiveNewSummary() {

--- a/src/js/stores/VirtualNetworksStore.ts
+++ b/src/js/stores/VirtualNetworksStore.ts
@@ -14,15 +14,12 @@ import { Overlay } from "../structs/Overlay";
 import VirtualNetworksActions from "../events/VirtualNetworksActions";
 
 class VirtualNetworksStore extends BaseStore {
-  overlays: Overlay[];
-
   storeID = "virtualNetworks";
   fetch = VirtualNetworksActions.fetch;
+  overlays: Overlay[] = [];
 
   constructor() {
     super();
-
-    this.overlays = [];
 
     PluginSDK.addStoreConfig({
       store: this,
@@ -48,8 +45,6 @@ class VirtualNetworksStore extends BaseStore {
       }
     });
   }
-
-  getOverlays = () => this.overlays;
 
   addChangeListener(eventName: string, callback: () => void) {
     super.addChangeListener(eventName, callback);

--- a/src/js/stores/__tests__/VirtualNetworksStore-test.ts
+++ b/src/js/stores/__tests__/VirtualNetworksStore-test.ts
@@ -21,14 +21,14 @@ describe("VirtualNetworksStore", () => {
     VirtualNetworksStore.removeAllListeners();
   });
 
-  describe("#getOverlays", () => {
+  describe("#overlays", () => {
     it("returns the overlays", () => {
       AppDispatcher.handleServerAction({
         type: ActionTypes.REQUEST_VIRTUAL_NETWORKS_SUCCESS,
         data: apiData(),
       });
 
-      const overlay = VirtualNetworksStore.getOverlays()[0];
+      const overlay = VirtualNetworksStore.overlays[0];
       expect(overlay).toMatchObject({ name: "foo", subnet: "bar" });
     });
   });
@@ -41,8 +41,8 @@ describe("VirtualNetworksStore", () => {
           data: apiData(),
         });
 
-        expect(VirtualNetworksStore.getOverlays()[0].name).toEqual("foo");
-        expect(VirtualNetworksStore.getOverlays()[1].name).toEqual("bar");
+        expect(VirtualNetworksStore.overlays[0].name).toEqual("foo");
+        expect(VirtualNetworksStore.overlays[1].name).toEqual("bar");
       });
 
       it("emits event after success event is dispatched", () => {

--- a/src/js/structs/CompositeState.ts
+++ b/src/js/structs/CompositeState.ts
@@ -18,11 +18,12 @@ const enrichNodeDataWithHealthData = (nodes, healthData) => {
 
 let storedNodeHealth, storedState;
 class CompositeState {
+  _refCount = 0;
+  masterInfo = null;
+  nodeHealthData = {};
+
   constructor(data = {}) {
-    this._refCount = 0;
     this.data = data;
-    this.masterInfo = null;
-    this.nodeHealthData = {};
   }
 
   /**

--- a/src/js/structs/SummaryList.ts
+++ b/src/js/structs/SummaryList.ts
@@ -2,7 +2,7 @@ import List from "./List";
 import MesosSummaryUtil from "../utils/MesosSummaryUtil";
 import StateSummary from "./StateSummary";
 
-class SummaryList extends List {
+class SummaryList extends List<StateSummary> {
   constructor(options = {}) {
     super(...arguments);
     this.maxLength = options.maxLength || null;

--- a/src/js/utils/Util.ts
+++ b/src/js/utils/Util.ts
@@ -7,7 +7,7 @@ const uniqueIDMap = {};
  * @param {string} id              Namespace for the unique ids.
  * @return {Integer}               A unique id.
  */
-export function uniqueID(id) {
+export function uniqueID(id?) {
   if (!Object.prototype.hasOwnProperty.call(uniqueIDMap, id)) {
     uniqueIDMap[id] = 0;
   }


### PR DESCRIPTION
while trying to establish type safety for volume types i realized that react
infers state-types from a class field, but not from a property set in a
constructor.

let's use that to our advantage and decrease the amount of type errors by over
10% while providing higher quality messages when something really is off.

definitely make sure to check out [our type errors snapshot](https://github.com/dcos/dcos-ui/pull/4920/files#diff-1b84a03db416cd17410db475e5120ab0)!