### PR TITLE
chore: disable flake-reporting

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,9 +89,6 @@ pipeline {
           steps { sh "npm run test -- --runInBand --testPathIgnorePatterns tslint typecheck" }
         }
         stage("Integration Test") {
-          environment {
-            JUNIT_NAME = "integration"
-          }
           steps {
             sh "npm run test:integration"
           }
@@ -99,7 +96,6 @@ pipeline {
           post {
             always {
               archiveArtifacts "cypress/**/*"
-              junit "cypress/result-${JUNIT_NAME}.xml"
             }
           }
         }
@@ -108,7 +104,6 @@ pipeline {
           environment {
             DCOS_DIR = "/tmp/.dcos-OSS-latest"
             PROXY_PORT = "4201"
-            JUNIT_NAME = "oss-master"
             TERRAFORM_DIR = "./scripts/terraform-oss-latest"
             TF_VAR_cluster_name = "ui-oss-${cluster_suffix}-${BUILD_NUMBER}"
             TF_VAR_custom_dcos_download_path = "https://downloads.dcos.io/dcos/testing/master/dcos_generate_config.sh"
@@ -132,7 +127,6 @@ pipeline {
                 sh "cd $TERRAFORM_DIR && ./down.sh"
               }
               archiveArtifacts "cypress/**/*"
-              junit "cypress/result-${JUNIT_NAME}.xml"
             }
           }
         }
@@ -140,7 +134,6 @@ pipeline {
           environment {
             DCOS_DIR = "/tmp/.dcos-EE-master"
             PROXY_PORT = "4202"
-            JUNIT_NAME = "ee-master"
             TERRAFORM_DIR = "./scripts/terraform-ee-master"
             TF_VAR_cluster_name = "ui-ee-${cluster_suffix}-${BUILD_NUMBER}"
             TF_VAR_custom_dcos_download_path = "https://downloads.mesosphere.com/dcos-enterprise/testing/master/dcos_generate_config.ee.sh"
@@ -169,7 +162,6 @@ pipeline {
                 sh "cd $TERRAFORM_DIR && ./down.sh"
               }
               archiveArtifacts "cypress/**/*"
-              junit "cypress/result-${JUNIT_NAME}.xml"
             }
           }
         }
@@ -183,7 +175,6 @@ pipeline {
           environment {
             DCOS_DIR = "/tmp/.dcos-OSS-2.1"
             PROXY_PORT = "4300"
-            JUNIT_NAME = "oss-2.1"
             TERRAFORM_DIR = "./scripts/terraform-oss-2.1"
             TF_VAR_cluster_name = "ui-21oss-${cluster_suffix}-${BUILD_NUMBER}"
             TF_VAR_custom_dcos_download_path = "https://downloads.dcos.io/dcos/stable/2.1.0/dcos_generate_config.sh"
@@ -207,7 +198,6 @@ pipeline {
                 sh "cd $TERRAFORM_DIR && ./down.sh"
               }
               archiveArtifacts "cypress/**/*"
-              junit "cypress/result-${JUNIT_NAME}.xml"
             }
           }
         }
@@ -215,7 +205,6 @@ pipeline {
           environment {
             DCOS_DIR = "/tmp/.dcos-EE-2.1"
             PROXY_PORT = "4301"
-            JUNIT_NAME = "ee-2.1"
             TERRAFORM_DIR = "./scripts/terraform-ee-2.1"
             TF_VAR_cluster_name = "ui-21ee-${cluster_suffix}-${BUILD_NUMBER}"
             TF_VAR_custom_dcos_download_path = "https://downloads.mesosphere.com/dcos-enterprise/stable/2.1.0/dcos_generate_config.ee.sh"
@@ -244,7 +233,6 @@ pipeline {
                 sh "cd $TERRAFORM_DIR && ./down.sh"
               }
               archiveArtifacts "cypress/**/*"
-              junit "cypress/result-${JUNIT_NAME}.xml"
             }
           }
         }
@@ -258,7 +246,6 @@ pipeline {
           environment {
             DCOS_DIR = "/tmp/.dcos-OSS-2.0"
             PROXY_PORT = "4400"
-            JUNIT_NAME = "oss-2.0"
             TERRAFORM_DIR = "./scripts/terraform-oss-2.0"
             TF_VAR_cluster_name = "ui-20oss-${cluster_suffix}-${BUILD_NUMBER}"
             TF_VAR_custom_dcos_download_path = "https://downloads.dcos.io/dcos/stable/2.0.4/dcos_generate_config.sh"
@@ -282,7 +269,6 @@ pipeline {
                 sh "cd $TERRAFORM_DIR && ./down.sh"
               }
               archiveArtifacts "cypress/**/*"
-              junit "cypress/result-${JUNIT_NAME}.xml"
             }
           }
         }
@@ -290,7 +276,6 @@ pipeline {
           environment {
             DCOS_DIR = "/tmp/.dcos-EE-2.0"
             PROXY_PORT = "4401"
-            JUNIT_NAME = "ee-2.0"
             TERRAFORM_DIR = "./scripts/terraform-ee-2.0"
             TF_VAR_cluster_name = "ui-20ee-${cluster_suffix}-${BUILD_NUMBER}"
             TF_VAR_custom_dcos_download_path = "https://downloads.mesosphere.com/dcos-enterprise/stable/2.0.4/dcos_generate_config.ee.sh"
@@ -319,7 +304,6 @@ pipeline {
                 sh "cd $TERRAFORM_DIR && ./down.sh"
               }
               archiveArtifacts "cypress/**/*"
-              junit "cypress/result-${JUNIT_NAME}.xml"
             }
           }
         }
@@ -333,7 +317,6 @@ pipeline {
           environment {
             DCOS_DIR = "/tmp/.dcos-OSS-1.13"
             PROXY_PORT = "4500"
-            JUNIT_NAME = "oss-1.13"
             TERRAFORM_DIR = "./scripts/terraform-oss-1.13"
             TF_VAR_cluster_name = "ui-113oss-${cluster_suffix}-${BUILD_NUMBER}"
             TF_VAR_custom_dcos_download_path = "https://downloads.dcos.io/dcos/stable/1.13.7/dcos_generate_config.sh"
@@ -357,7 +340,6 @@ pipeline {
                 sh "cd $TERRAFORM_DIR && ./down.sh"
               }
               archiveArtifacts "cypress/**/*"
-              junit "cypress/result-${JUNIT_NAME}.xml"
             }
           }
         }
@@ -365,7 +347,6 @@ pipeline {
           environment {
             DCOS_DIR = "/tmp/.dcos-EE-1.13"
             PROXY_PORT = "4501"
-            JUNIT_NAME = "ee-1.13"
             TERRAFORM_DIR = "./scripts/terraform-ee-1.13"
             TF_VAR_cluster_name = "ui-113ee-${cluster_suffix}-${BUILD_NUMBER}"
             TF_VAR_custom_dcos_download_path = "https://downloads.mesosphere.com/dcos-enterprise/stable/1.13.7/dcos_generate_config.ee.sh"
@@ -394,7 +375,6 @@ pipeline {
                 sh "cd $TERRAFORM_DIR && ./down.sh"
               }
               archiveArtifacts "cypress/**/*"
-              junit "cypress/result-${JUNIT_NAME}.xml"
             }
           }
         }

--- a/cypress.json
+++ b/cypress.json
@@ -8,7 +8,7 @@
   "integrationFolder": "tests",
   "pageLoadTimeout": 600000,
   "projectId": "a209b1cd-e44f-47a4-b22c-d8f26649f43f",
-  "reporter": "junit",
+  "reporter": "spec",
   "screenshotsFolder": "cypress/screenshots",
   "supportFile": "tests/_support",
   "trashAssetsBeforeRuns": false,

--- a/scripts/utils/tests-functions
+++ b/scripts/utils/tests-functions
@@ -25,9 +25,7 @@ function executeCypress() {
     ${CYPRESS_NO_EXIT:+"--no-exit"} \
     --spec "${FILE}" \
     --config-file ${CYPRESS_CONFIG_FILE:-"cypress.json"} \
-    --config "numTestsKeptInMemory=0,video=${RECORD_VIDEO:-'false'}$ADDITIONAL_CYPRESS_CONFIG" \
-    --reporter junit \
-    --reporter-options "mochaFile=cypress/result-${JUNIT_NAME}-[hash].xml"
+    --config "numTestsKeptInMemory=0,video=${RECORD_VIDEO:-'false'}$ADDITIONAL_CYPRESS_CONFIG"
 }
 
 # runs tests for matched file
@@ -77,15 +75,6 @@ function runTestFile() {
   return $EXIT_CODE
 }
 
-function merge_junit_files() {
-  # $1 is expected to be "integration" or "system"
-  if [ "$(find "${PROJECT_ROOT}/cypress/" -type f -name result-$1-*.xml | wc -l)" -ne 0 ]; then
-    echo "==> Merging results from ./cypress/result-$1-*.xml into ./cypress/result-$1.xml…"
-    junit-merge --out "${PROJECT_ROOT}/cypress/result-$1.xml" $(find ${PROJECT_ROOT}/cypress/result-$1-*.xml -type f)
-    echo "===> done."
-  fi
-}
-
 # sets up everything
 function setup() {
   echo "=> Setup"
@@ -111,8 +100,6 @@ function teardown() {
   echo ""
   echo "=> Teardown"
   [ "$PROXY_PID" != "0" ] && kill $PROXY_PID
-  # merges results from cypress runs into one file
-  merge_junit_files $JUNIT_NAME
   echo "=> Bye."
 }
 


### PR DESCRIPTION
we currently suffer a lot from almost always having yellow builds that are
reported as failures to github.
as there seems to be no way to convince jenkins to report a success easily, we
now go for this solution and now only have "green" and "red".

as a downside you now have to look at the test bubbles if you want to find
flakes and they are not reported in the upper right corner of jenkins anymore.

but currently it seems to be well worth that change.

