### PR TITLE
chore: remove recompose and symbol-observable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5479,15 +5479,6 @@
         "@types/react": "*"
       }
     },
-    "@types/recompose": {
-      "version": "0.30.7",
-      "resolved": "https://registry.npmjs.org/@types/recompose/-/recompose-0.30.7.tgz",
-      "integrity": "sha512-kEvD7XMguXgG7jJJS//cE1QTbkFj2qDtIPAg1FvXxE8D6jD1C0WabJjT7cVitC7TK0N5I3yp2955hqNFFZV0wg==",
-      "dev": true,
-      "requires": {
-        "@types/react": "*"
-      }
-    },
     "@types/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
@@ -9481,11 +9472,6 @@
           }
         }
       }
-    },
-    "change-emitter": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
-      "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
     },
     "char-regex": {
       "version": "1.0.2",
@@ -34602,19 +34588,6 @@
         }
       }
     },
-    "recompose": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
-      "integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "change-emitter": "^0.1.2",
-        "fbjs": "^0.8.1",
-        "hoist-non-react-statics": "^2.3.1",
-        "react-lifecycles-compat": "^3.0.2",
-        "symbol-observable": "^1.0.4"
-      }
-    },
     "redent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
@@ -35981,9 +35954,9 @@
           }
         },
         "hosted-git-info": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.5.tgz",
-          "integrity": "sha512-i4dpK6xj9BIpVOTboXIlKG9+8HMKggcrMX7WA24xZtKwX0TPelq/rbaS5rCKeNX8sJXZJGdSxpnEGtta+wismQ==",
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.6.tgz",
+          "integrity": "sha512-VRvqVD5T6t9HdmNDWTwbi8H/EC722MemAhOSP5QvYAXpDAY0Nhu2I/i+bXsktu4sU5LVHSh/wmXtVU8bDtjedQ==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -72,13 +72,11 @@
     "react-transition-group": "4.4.1",
     "reactjs-components": "5.0.3",
     "reactjs-mixin": "0.0.2",
-    "recompose": "0.30.0",
     "redux": "4.0.5",
     "reflect-metadata": "0.1.13",
     "rxjs": "6.6.3",
     "semver": "7.3.2",
-    "svg-inline-loader": "0.8.2",
-    "symbol-observable": "1.2.0"
+    "svg-inline-loader": "0.8.2"
   },
   "devDependencies": {
     "@commitlint/cli": "11.0.0",
@@ -98,7 +96,6 @@
     "@types/prop-types": "15.7.3",
     "@types/react": "16.9.52",
     "@types/react-router": "2.0.57",
-    "@types/recompose": "0.30.7",
     "@types/semver": "7.3.4",
     "autoprefixer": "9.8.6",
     "babel-cli": "6.26.0",

--- a/src/js/__tests__/__snapshots__/typecheck-test.ts.snap
+++ b/src/js/__tests__/__snapshots__/typecheck-test.ts.snap
@@ -173,7 +173,6 @@ plugins/catalog/src/js/repositories/RepositoriesAdd.tsx: error TS2571: Object is
 plugins/catalog/src/js/repositories/RepositoriesAdd.tsx: error TS2571: Object is of type 'unknown'.
 plugins/catalog/src/js/repositories/RepositoriesAdd.tsx: error TS2571: Object is of type 'unknown'.
 plugins/catalog/src/js/repositories/RepositoriesAdd.tsx: error TS2571: Object is of type 'unknown'.
-plugins/catalog/src/js/repositories/RepositoriesAdd.tsx: error TS2339: Property 'pipe' does not exist on type 'Subscribable<unknown>'.
 plugins/catalog/src/js/repositories/RepositoriesAdd.tsx: error TS2571: Object is of type 'unknown'.
 plugins/catalog/src/js/repositories/RepositoriesAdd.tsx: error TS2322: type * is not assignable to type *.
 plugins/catalog/src/js/repositories/RepositoriesAdd.tsx: error TS2571: Object is of type 'unknown'.
@@ -188,7 +187,6 @@ plugins/catalog/src/js/repositories/RepositoriesDelete.tsx: error TS2571: Object
 plugins/catalog/src/js/repositories/RepositoriesDelete.tsx: error TS2571: Object is of type 'unknown'.
 plugins/catalog/src/js/repositories/RepositoriesDelete.tsx: error TS2571: Object is of type 'unknown'.
 plugins/catalog/src/js/repositories/RepositoriesDelete.tsx: error TS2571: Object is of type 'unknown'.
-plugins/catalog/src/js/repositories/RepositoriesDelete.tsx: error TS2339: Property 'pipe' does not exist on type 'Subscribable<unknown>'.
 plugins/catalog/src/js/repositories/RepositoriesDelete.tsx: error TS6133: 'response' is declared but its value is never read.
 plugins/catalog/src/js/repositories/RepositoriesDelete.tsx: error TS2571: Object is of type 'unknown'.
 plugins/catalog/src/js/repositories/RepositoriesDelete.tsx: error TS2698: Spread types may only be created from object types.
@@ -276,7 +274,6 @@ plugins/cluster-linking/stores/ClusterLinkingStore.ts: error TS2339: Property 'c
 plugins/external-links/SDK.ts: error TS2451: Cannot redeclare block-scoped variable 'SDK'.
 plugins/external-links/index.ts: error TS2306: File '/plugins/external-links/SDK.ts' is not a module.
 plugins/jobs/src/js/JobDetailPageContainer.tsx: error TS2571: Object is of type 'unknown'.
-plugins/jobs/src/js/JobDetailPageContainer.tsx: error TS2339: Property 'pipe' does not exist on type 'Subscribable<unknown>'.
 plugins/jobs/src/js/JobDetailPageContainer.tsx: error TS2571: Object is of type 'unknown'.
 plugins/jobs/src/js/JobDetailPageContainer.tsx: error TS2571: Object is of type 'unknown'.
 plugins/jobs/src/js/JobDetailPageContainer.tsx: error TS2769: No overload matches this call.
@@ -820,9 +817,7 @@ plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.tsx: error TS2339
 plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2339: Property 'networks' does not exist on type *.
 plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2769: No overload matches this call.
 plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2339: Property 'networks' does not exist on type 'object'.
-plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2769: No overload matches this call.
-plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2322: Type 'Observable<unknown>' is not assignable to type 'Subscribable<ReactNode>'.
-plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2345: Argument of type * is not assignable to parameter of type *.
+plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2322: type * is not assignable to type *.
 plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2556: Expected 1-2 arguments, but got 0 or more.
 plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2339: Property 'location' does not exist on type *.
 plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.tsx: error TS2339: Property 'hosts' does not exist on type *.
@@ -2586,7 +2581,6 @@ plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2322: typ
 plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2551: Property 'contextTypes' does not exist on type *. Did you mean 'contextType'?
 plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2571: Object is of type 'unknown'.
 plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'string'.
-plugins/services/src/js/containers/services/ServicesTable.tsx: error TS2493: Tuple type * of length '1' has no element at index '1'.
 plugins/services/src/js/containers/services/__tests__/ServicesContainer-test.tsx: error TS2769: No overload matches this call.
 plugins/services/src/js/containers/services/__tests__/ServicesTable-test.ts: error TS2554: Expected 5 arguments, but got 3.
 plugins/services/src/js/containers/services/__tests__/ServicesTable-test.ts: error TS2554: Expected 5 arguments, but got 3.

--- a/src/js/index.tsx
+++ b/src/js/index.tsx
@@ -7,11 +7,6 @@ import { Router, hashHistory } from "react-router";
 import { Provider } from "react-redux";
 import PluginSDK from "PluginSDK";
 
-// This polyfills Symbol.observable which is required for rxjs to recognize the object received
-// from componentFromStream as an Observable, otherwise it throws the TypeError.
-// Can be removed if recompose library usage is removed.
-import "symbol-observable";
-
 import { i18n, catalogs } from "./i18n";
 
 // Load in our CSS.


### PR DESCRIPTION
looks like we only had direct dependencies on them to express some types - which
typescript can do even better without us explicitly casting stuff.
