### PR TITLE
COPS-6624 always keep ui-kit poppers visible

### DIFF
--- a/src/styles/hacks.less
+++ b/src/styles/hacks.less
@@ -1,0 +1,8 @@
+// COPS-6624
+// popper.js sometimes seems to think that our reference elements are outside of the viewport and marks them with this attribute.
+// ui-kit then chooses to set `visibility: hidden; pointer-events: none;`, which effectively hides the poppers for some OSX users.
+// this is a quickfix that we could try removing once we removed FullScreenModal from the code base.
+body [data-popper-reference-hidden] {
+  visibility: visible !important;
+  pointer-events: auto !important;
+}

--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -536,3 +536,6 @@
 
 @import 'views/services/variables.less';
 @import 'views/services/styles.less';
+
+// Stuff we'd love to get rid of
+@import 'hacks.less';


### PR DESCRIPTION
we have a situation in that SOME osx users don't see tooltips and the dependency
toggle on the services form.

this is a workaround that always keeps poppers visible - where they would
usually be hidden once their reference elements are scrolled out of the
viewport.

note that i can not reproduce the issue, so this is a best effort commit/PR.

closes COPS-6624
