### PR TITLE
fix: correctly group service tasks again

### DIFF
--- a/src/js/stores/MesosStateStore.ts
+++ b/src/js/stores/MesosStateStore.ts
@@ -249,7 +249,8 @@ class MesosStateStore extends GetSetBaseStore {
     return tasks
       .filter(
         (task) =>
-          task.isStartedByMarathon && task.id.startsWith(`${taskIdPrefix}.`)
+          task.isStartedByMarathon &&
+          task.id.startsWith(`${taskIdPrefix}.instance`)
       )
       .concat(serviceTasks)
       .map((task) => MesosStateUtil.flagSDKTask(task, service));


### PR DESCRIPTION
this reverts 177e7aade8c6f4ba7a39fc9d21fec42b17bfc5aa, which has been factored to make DCOS-UI backwards compatible with DC/OS 1.12, where marathon did not yet have `.instance` suffixes on mesos-task-IDs. unfortunately with that we also broke some task-grouping that customers now rely on - see COPS-6744 for more info.

closes COPS-6744
